### PR TITLE
feat: PDF→動画変換をWASM化してクライアントサイドで処理

### DIFF
--- a/router/main.py
+++ b/router/main.py
@@ -19,9 +19,57 @@ ROOT_DIR = Path(os.path.dirname(__file__)).parent
 STATIC_DIR = ROOT_DIR / "static"
 MOVIE_DIR = ROOT_DIR / "movie"
 
-app = FastAPI(debug=DEBUG)
-app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
-app.mount("/movie", StaticFiles(directory=MOVIE_DIR), name="movie")
+
+class COOPCOEPMiddleware:
+    """
+    SharedArrayBuffer を有効化するための COOP/COEP ヘッダーを追加する純粋な ASGI ミドルウェア
+
+    FFmpeg.wasm が SharedArrayBuffer を必要とするため、以下のヘッダーが必要:
+    - Cross-Origin-Embedder-Policy: require-corp
+    - Cross-Origin-Opener-Policy: same-origin
+
+    ただし、これらのヘッダーは外部リソース（GCS, CDN等）の読み込みをブロックするため、
+    PDFページと関連リソース（/static/js/, /api/save-movie/）のみに適用する。
+    """
+
+    # COOP/COEPヘッダーを適用するパスのパターン
+    ENABLED_PATHS = (
+        '/ja/pdf/',
+        '/en/pdf/',
+        '/static/js/',
+        '/api/save-movie/',
+    )
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        should_add_headers = any(path.startswith(p) for p in self.ENABLED_PATHS)
+
+        if not should_add_headers:
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message):
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.append((b"cross-origin-embedder-policy", b"credentialless"))
+                headers.append((b"cross-origin-opener-policy", b"same-origin"))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
+
+
+# FastAPI アプリケーションを作成
+_fastapi_app = FastAPI(debug=DEBUG)
+_fastapi_app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+_fastapi_app.mount("/movie", StaticFiles(directory=MOVIE_DIR), name="movie")
 
 origins = [
     os.environ.get("ALLOW_HOST", None)
@@ -29,7 +77,7 @@ origins = [
 
 logger.info(f"origins: {origins}")
 
-app.add_middleware(
+_fastapi_app.add_middleware(
     CORSMiddleware,
     allow_origins=[origins],
     allow_credentials=True,
@@ -37,72 +85,72 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(api.router, prefix="/api")
+_fastapi_app.include_router(api.router, prefix="/api")
 
 
 # Redirects
-@app.get("/", response_class=HTMLResponse)
+@_fastapi_app.get("/", response_class=HTMLResponse)
 async def home(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/", status_code=301)
 
 
-@app.get("/web/", response_class=HTMLResponse)
+@_fastapi_app.get("/web/", response_class=HTMLResponse)
 async def web(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/web/", status_code=301)
 
 
-@app.get("/image/")
+@_fastapi_app.get("/image/")
 async def image(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/image/", status_code=301)
 
 
-@app.get("/pdf/")
+@_fastapi_app.get("/pdf/")
 async def pdf(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/pdf/", status_code=301)
 
 
-@app.get("/recording/")
+@_fastapi_app.get("/recording/")
 def recording_desktop(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/recording/", status_code=301)
 
 
-@app.get("/record-screen/")
-def recording_desktop(request: Request) -> RedirectResponse:
+@_fastapi_app.get("/record-screen/")
+def recording_desktop_alias(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/recording/", status_code=301)
 
 
-@app.get("/streaming/")
+@_fastapi_app.get("/streaming/")
 async def read_index(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/streaming/", status_code=301)
 
 
-@app.get("/history/", response_class=HTMLResponse)
+@_fastapi_app.get("/history/", response_class=HTMLResponse)
 async def history(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/history/", status_code=301)
 
 
-@app.get("/github/")
+@_fastapi_app.get("/github/")
 async def github(request: Request) -> RedirectResponse:
     return RedirectResponse(url=f"/{get_lang(request)}/github/", status_code=301)
 
 
-@app.get("/robots.txt/")
+@_fastapi_app.get("/robots.txt/")
 async def robots_txt():
     return FileResponse("static/robots.txt")
 
 
-@app.get("/sitemap.xml")
+@_fastapi_app.get("/sitemap.xml")
 async def sitemap():
     return FileResponse("static/sitemap.xml")
 
 
-@app.get("/favicon.ico")
+@_fastapi_app.get("/favicon.ico")
 async def favicon() -> FileResponse:
     return FileResponse((STATIC_DIR / 'favicon.ico'))
 
 
 # Streaming file from GCS
-@app.get("/stream/{uuid}/{file_name}")
+@_fastapi_app.get("/stream/{uuid}/{file_name}")
 async def get_stream(uuid: str, file_name: str):
     """
     Get m3u8 file.
@@ -125,7 +173,7 @@ async def get_stream(uuid: str, file_name: str):
         return FileResponse(movie_path)
 
 
-@app.get("/cache/{file_path:path}")
+@_fastapi_app.get("/cache/{file_path:path}")
 async def read_static_file(file_path: str):
     try:
         file_path = STATIC_DIR / file_path
@@ -136,7 +184,11 @@ async def read_static_file(file_path: str):
         raise HTTPException(status_code=404, detail="File not found")
 
 
-app.include_router(main_page.router)  # main page needs to load after all routes. It routes all paths to `/{lang}/`
+# main page needs to load after all routes. It routes all paths to `/{lang}/`
+_fastapi_app.include_router(main_page.router)
+
+# COOP/COEPミドルウェアでラップしたASGIアプリケーションをエクスポート
+app = COOPCOEPMiddleware(_fastapi_app)
 
 if __name__ == '__main__':
     # reload = True

--- a/static/js/ffmpeg/const.js
+++ b/static/js/ffmpeg/const.js
@@ -1,0 +1,22 @@
+export const MIME_TYPE_JAVASCRIPT = "text/javascript";
+export const MIME_TYPE_WASM = "application/wasm";
+export const CORE_VERSION = "0.12.6";
+export const CORE_URL = `https://unpkg.com/@ffmpeg/core@${CORE_VERSION}/dist/umd/ffmpeg-core.js`;
+export var FFMessageType;
+(function (FFMessageType) {
+    FFMessageType["LOAD"] = "LOAD";
+    FFMessageType["EXEC"] = "EXEC";
+    FFMessageType["WRITE_FILE"] = "WRITE_FILE";
+    FFMessageType["READ_FILE"] = "READ_FILE";
+    FFMessageType["DELETE_FILE"] = "DELETE_FILE";
+    FFMessageType["RENAME"] = "RENAME";
+    FFMessageType["CREATE_DIR"] = "CREATE_DIR";
+    FFMessageType["LIST_DIR"] = "LIST_DIR";
+    FFMessageType["DELETE_DIR"] = "DELETE_DIR";
+    FFMessageType["ERROR"] = "ERROR";
+    FFMessageType["DOWNLOAD"] = "DOWNLOAD";
+    FFMessageType["PROGRESS"] = "PROGRESS";
+    FFMessageType["LOG"] = "LOG";
+    FFMessageType["MOUNT"] = "MOUNT";
+    FFMessageType["UNMOUNT"] = "UNMOUNT";
+})(FFMessageType || (FFMessageType = {}));

--- a/static/js/ffmpeg/errors.js
+++ b/static/js/ffmpeg/errors.js
@@ -1,0 +1,4 @@
+export const ERROR_UNKNOWN_MESSAGE_TYPE = new Error("unknown message type");
+export const ERROR_NOT_LOADED = new Error("ffmpeg is not loaded, call `await ffmpeg.load()` first");
+export const ERROR_TERMINATED = new Error("called FFmpeg.terminate()");
+export const ERROR_IMPORT_FAILURE = new Error("failed to import ffmpeg-core.js");

--- a/static/js/ffmpeg/worker.js
+++ b/static/js/ffmpeg/worker.js
@@ -1,0 +1,151 @@
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+import { CORE_URL, FFMessageType } from "./const.js";
+import { ERROR_UNKNOWN_MESSAGE_TYPE, ERROR_NOT_LOADED, ERROR_IMPORT_FAILURE, } from "./errors.js";
+let ffmpeg;
+const load = async ({ coreURL: _coreURL, wasmURL: _wasmURL, workerURL: _workerURL, }) => {
+    const first = !ffmpeg;
+    try {
+        if (!_coreURL)
+            _coreURL = CORE_URL;
+        // when web worker type is `classic`.
+        importScripts(_coreURL);
+    }
+    catch {
+        if (!_coreURL)
+            _coreURL = CORE_URL.replace('/umd/', '/esm/');
+        // when web worker type is `module`.
+        self.createFFmpegCore = (await import(
+        /* webpackIgnore: true */ /* @vite-ignore */ _coreURL)).default;
+        if (!self.createFFmpegCore) {
+            throw ERROR_IMPORT_FAILURE;
+        }
+    }
+    const coreURL = _coreURL;
+    const wasmURL = _wasmURL ? _wasmURL : _coreURL.replace(/.js$/g, ".wasm");
+    const workerURL = _workerURL
+        ? _workerURL
+        : _coreURL.replace(/.js$/g, ".worker.js");
+    ffmpeg = await self.createFFmpegCore({
+        // Fix `Overload resolution failed.` when using multi-threaded ffmpeg-core.
+        // Encoded wasmURL and workerURL in the URL as a hack to fix locateFile issue.
+        mainScriptUrlOrBlob: `${coreURL}#${btoa(JSON.stringify({ wasmURL, workerURL }))}`,
+    });
+    ffmpeg.setLogger((data) => self.postMessage({ type: FFMessageType.LOG, data }));
+    ffmpeg.setProgress((data) => self.postMessage({
+        type: FFMessageType.PROGRESS,
+        data,
+    }));
+    return first;
+};
+const exec = ({ args, timeout = -1 }) => {
+    ffmpeg.setTimeout(timeout);
+    ffmpeg.exec(...args);
+    const ret = ffmpeg.ret;
+    ffmpeg.reset();
+    return ret;
+};
+const writeFile = ({ path, data }) => {
+    ffmpeg.FS.writeFile(path, data);
+    return true;
+};
+const readFile = ({ path, encoding }) => ffmpeg.FS.readFile(path, { encoding });
+// TODO: check if deletion works.
+const deleteFile = ({ path }) => {
+    ffmpeg.FS.unlink(path);
+    return true;
+};
+const rename = ({ oldPath, newPath }) => {
+    ffmpeg.FS.rename(oldPath, newPath);
+    return true;
+};
+// TODO: check if creation works.
+const createDir = ({ path }) => {
+    ffmpeg.FS.mkdir(path);
+    return true;
+};
+const listDir = ({ path }) => {
+    const names = ffmpeg.FS.readdir(path);
+    const nodes = [];
+    for (const name of names) {
+        const stat = ffmpeg.FS.stat(`${path}/${name}`);
+        const isDir = ffmpeg.FS.isDir(stat.mode);
+        nodes.push({ name, isDir });
+    }
+    return nodes;
+};
+// TODO: check if deletion works.
+const deleteDir = ({ path }) => {
+    ffmpeg.FS.rmdir(path);
+    return true;
+};
+const mount = ({ fsType, options, mountPoint }) => {
+    const str = fsType;
+    const fs = ffmpeg.FS.filesystems[str];
+    if (!fs)
+        return false;
+    ffmpeg.FS.mount(fs, options, mountPoint);
+    return true;
+};
+const unmount = ({ mountPoint }) => {
+    ffmpeg.FS.unmount(mountPoint);
+    return true;
+};
+self.onmessage = async ({ data: { id, type, data: _data }, }) => {
+    const trans = [];
+    let data;
+    try {
+        if (type !== FFMessageType.LOAD && !ffmpeg)
+            throw ERROR_NOT_LOADED; // eslint-disable-line
+        switch (type) {
+            case FFMessageType.LOAD:
+                data = await load(_data);
+                break;
+            case FFMessageType.EXEC:
+                data = exec(_data);
+                break;
+            case FFMessageType.WRITE_FILE:
+                data = writeFile(_data);
+                break;
+            case FFMessageType.READ_FILE:
+                data = readFile(_data);
+                break;
+            case FFMessageType.DELETE_FILE:
+                data = deleteFile(_data);
+                break;
+            case FFMessageType.RENAME:
+                data = rename(_data);
+                break;
+            case FFMessageType.CREATE_DIR:
+                data = createDir(_data);
+                break;
+            case FFMessageType.LIST_DIR:
+                data = listDir(_data);
+                break;
+            case FFMessageType.DELETE_DIR:
+                data = deleteDir(_data);
+                break;
+            case FFMessageType.MOUNT:
+                data = mount(_data);
+                break;
+            case FFMessageType.UNMOUNT:
+                data = unmount(_data);
+                break;
+            default:
+                throw ERROR_UNKNOWN_MESSAGE_TYPE;
+        }
+    }
+    catch (e) {
+        self.postMessage({
+            id,
+            type: FFMessageType.ERROR,
+            data: e.toString(),
+        });
+        return;
+    }
+    if (data instanceof Uint8Array) {
+        trans.push(data.buffer);
+    }
+    self.postMessage({ id, type, data }, trans);
+};

--- a/static/js/pdf.js
+++ b/static/js/pdf.js
@@ -1,35 +1,85 @@
-'use static';
+'use strict';
 
-async function fetchMovieUrl() {
-    const fileInput = document.getElementById('files');
-    const file = fileInput.files?.[0];
-    fileSizeValidation(file, 'This file is too large. File size should be smaller than 32MB.')
+import { convertPdfToMp4 } from './pdfWasmConverter.js';
 
-    let request_url = `/api/pdf-to-movie/`;
-    console.log(`Requesting ${request_url}`);
-    let frame_sec = parseInt((document.querySelector('input[name="frame_sec"]:checked')).value);
-    let formData = new FormData();
-    formData.append('pdf', file);
-    formData.append('frame_sec', frame_sec.toString());
+// 進捗表示要素
+const progressText = document.createElement('div');
+progressText.id = 'progress-text';
+progressText.className = 'text-center mt-2';
+progressText.style.display = 'none';
 
-    return await fetch(request_url, {
+/**
+ * 進捗を更新
+ * @param {string} message - 進捗メッセージ
+ */
+function updateProgress(message) {
+    progressText.textContent = message;
+    progressText.style.display = 'block';
+    console.log(message);
+}
+
+/**
+ * MP4をサーバーにアップロードしてURLを取得
+ * @param {Blob} mp4Blob - MP4動画のBlob
+ * @returns {Promise<Object>} アップロード結果
+ */
+async function uploadMp4(mp4Blob) {
+    const formData = new FormData();
+    formData.append('file', mp4Blob, 'converted.mp4');
+
+    const response = await fetch('/api/save-movie/', {
         method: 'POST',
         body: formData
     });
-}
 
-
-function fileSizeValidation(file, message) {
-    const maxFileSize = 32 * 1024 * 1024; // 32MB in bytes
-    if (file && file.size > maxFileSize) {
-        alert(message);
-        window.location.reload()
+    if (!response.ok) {
+        throw new Error(`Upload failed: ${response.status}`);
     }
+
+    return response.json();
 }
 
+/**
+ * PDF変換処理（WASMベース）
+ * @returns {Promise<Object>} レスポンスオブジェクト風のオブジェクト
+ */
+async function fetchMovieUrl() {
+    const fileInput = document.getElementById('files');
+    const file = fileInput.files?.[0];
 
+    if (!file) {
+        throw new Error('No file selected');
+    }
+
+    const frameSec = parseInt(document.querySelector('input[name="frame_sec"]:checked').value);
+
+    // WASMでPDF -> MP4変換
+    const mp4Blob = await convertPdfToMp4(file, frameSec, updateProgress);
+
+    // サーバーにアップロード
+    updateProgress('Uploading video...');
+    const result = await uploadMp4(mp4Blob);
+
+    return {
+        ok: true,
+        json: async () => result
+    };
+}
+
+/**
+ * イベントリスナーを設定
+ */
 function addEventListeners() {
+    // 進捗テキスト要素を追加
+    const progressBar = document.getElementById('progress_bar');
+    if (progressBar?.parentNode) {
+        progressBar.parentNode.after(progressText);
+    }
+
     submitButton.addEventListener('click', submit);
 }
+
+// baseFunctions.js の fetchMovieUrl を上書き
+window.fetchMovieUrl = fetchMovieUrl;
 
 addEventListeners();

--- a/static/js/pdfWasmConverter.js
+++ b/static/js/pdfWasmConverter.js
@@ -1,0 +1,190 @@
+/**
+ * PDF to Movie WASM Converter
+ * PDF.js と FFmpeg.wasm を使用してブラウザ内で PDF → MP4 変換を行う
+ */
+
+// CDN URLs (jsdelivr has proper CORS headers)
+const PDFJS_CDN = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.min.mjs';
+const PDFJS_WORKER_CDN = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.worker.min.mjs';
+const FFMPEG_CDN = 'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.10/dist/esm/index.js';
+const FFMPEG_UTIL_CDN = 'https://cdn.jsdelivr.net/npm/@ffmpeg/util@0.12.1/dist/esm/index.js';
+const FFMPEG_CORE_CDN = 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.js';
+const FFMPEG_CORE_WASM_CDN = 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.wasm';
+// Worker URL (ローカルにホストしてクロスオリジン制約を回避 - 絶対URLで指定)
+const FFMPEG_WORKER_URL = new URL('/static/js/ffmpeg/worker.js', window.location.origin).href;
+
+let pdfjsLib = null;
+let FFmpeg = null;
+let fetchFile = null;
+
+/**
+ * ライブラリを動的にロード
+ * @param {function} onProgress - 進捗コールバック
+ */
+async function loadLibraries(onProgress) {
+    onProgress?.('Loading PDF.js...');
+
+    // PDF.js をロード
+    const pdfjs = await import(PDFJS_CDN);
+    pdfjsLib = pdfjs;
+    pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_CDN;
+
+    onProgress?.('Loading FFmpeg.wasm...');
+
+    // FFmpeg.wasm をロード
+    const ffmpegModule = await import(FFMPEG_CDN);
+    FFmpeg = ffmpegModule.FFmpeg;
+
+    const utilModule = await import(FFMPEG_UTIL_CDN);
+    fetchFile = utilModule.fetchFile;
+
+    onProgress?.('Libraries loaded');
+}
+
+/**
+ * PDFファイルをPNG画像配列に変換
+ * @param {File} pdfFile - PDFファイル
+ * @param {function} onProgress - 進捗コールバック
+ * @returns {Promise<Uint8Array[]>} PNG画像データの配列
+ */
+async function pdfToImages(pdfFile, onProgress) {
+    const arrayBuffer = await pdfFile.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    const numPages = pdf.numPages;
+    const images = [];
+
+    for (let i = 1; i <= numPages; i++) {
+        onProgress?.(`Rendering page ${i}/${numPages}...`);
+
+        const page = await pdf.getPage(i);
+        const viewport = page.getViewport({ scale: 1 });
+
+        // 1920px幅に合わせてスケールを計算
+        const TARGET_WIDTH = 1920;
+        const scale = TARGET_WIDTH / viewport.width;
+        const scaledViewport = page.getViewport({ scale });
+
+        // Canvas作成
+        const canvas = document.createElement('canvas');
+        canvas.width = scaledViewport.width;
+        canvas.height = scaledViewport.height;
+        const ctx = canvas.getContext('2d');
+
+        // 背景を白で塗りつぶし
+        ctx.fillStyle = 'white';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        // PDFをレンダリング
+        await page.render({
+            canvasContext: ctx,
+            viewport: scaledViewport
+        }).promise;
+
+        // PNGに変換
+        const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+        const pngData = new Uint8Array(await blob.arrayBuffer());
+        images.push(pngData);
+
+        // メモリ解放
+        canvas.width = 0;
+        canvas.height = 0;
+    }
+
+    return images;
+}
+
+/**
+ * PNG画像配列をMP4動画に変換
+ * @param {Uint8Array[]} images - PNG画像データの配列
+ * @param {number} frameSec - 1ページあたりの表示秒数
+ * @param {function} onProgress - 進捗コールバック
+ * @returns {Promise<Blob>} MP4動画のBlob
+ */
+async function imagesToMp4(images, frameSec, onProgress) {
+    onProgress?.('Initializing FFmpeg...');
+
+    const ffmpeg = new FFmpeg();
+
+    // FFmpegの進捗イベントを設定
+    ffmpeg.on('progress', ({ progress }) => {
+        const percent = Math.round(progress * 100);
+        onProgress?.(`Encoding video... ${percent}%`);
+    });
+
+    // FFmpeg Core をロード（classWorkerURLをローカルに指定してクロスオリジン制約を回避）
+    await ffmpeg.load({
+        coreURL: FFMPEG_CORE_CDN,
+        wasmURL: FFMPEG_CORE_WASM_CDN,
+        classWorkerURL: FFMPEG_WORKER_URL
+    });
+
+    onProgress?.('Writing frames...');
+
+    // frame_secに応じてフレームを複製（6fpsで1秒 = 6フレーム）
+    const FRAMES_PER_SECOND = 6;
+    const framesPerPage = frameSec * FRAMES_PER_SECOND;
+    let frameIndex = 0;
+
+    for (let i = 0; i < images.length; i++) {
+        const image = images[i];
+        // 同じ画像を framesPerPage 回書き込む（各回でコピーを作成してdetached対策）
+        for (let j = 0; j < framesPerPage; j++) {
+            const frameName = `frame${String(frameIndex).padStart(4, '0')}.png`;
+            // Uint8Arrayをコピーして渡す（FFmpegがArrayBufferを転送してしまうため）
+            await ffmpeg.writeFile(frameName, new Uint8Array(image));
+            frameIndex++;
+        }
+        onProgress?.(`Writing frames... ${i + 1}/${images.length} pages`);
+    }
+
+    onProgress?.('Encoding video...');
+
+    // ffmpegで動画生成（現在のバックエンドと同じ設定）
+    await ffmpeg.exec([
+        '-framerate', '6',
+        '-i', 'frame%04d.png',
+        '-vf', "scale='min(1280,iw)':-2",
+        '-c:v', 'libx264',
+        '-pix_fmt', 'yuv420p',
+        '-preset', 'slow',
+        '-profile:v', 'baseline',
+        '-bf', '0',
+        '-g', '1',
+        '-tune', 'stillimage',
+        '-y', 'output.mp4'
+    ]);
+
+    onProgress?.('Reading output...');
+
+    // 出力ファイルを読み取り
+    const data = await ffmpeg.readFile('output.mp4');
+
+    // クリーンアップ
+    ffmpeg.terminate();
+
+    return new Blob([data.buffer], { type: 'video/mp4' });
+}
+
+/**
+ * PDFファイルをMP4動画に変換
+ * @param {File} pdfFile - PDFファイル
+ * @param {number} frameSec - 1ページあたりの表示秒数
+ * @param {function} onProgress - 進捗コールバック
+ * @returns {Promise<Blob>} MP4動画のBlob
+ */
+export async function convertPdfToMp4(pdfFile, frameSec, onProgress) {
+    // ライブラリをロード
+    if (!pdfjsLib || !FFmpeg) {
+        await loadLibraries(onProgress);
+    }
+
+    // PDFを画像に変換
+    const images = await pdfToImages(pdfFile, onProgress);
+
+    // 画像を動画に変換
+    const mp4Blob = await imagesToMp4(images, frameSec, onProgress);
+
+    onProgress?.('Conversion complete!');
+
+    return mp4Blob;
+}

--- a/templates/pdf.html
+++ b/templates/pdf.html
@@ -27,7 +27,6 @@
                 <input type="file" accept="application/pdf" multiple class="form-control border border-dark" id="files"
                     name="files" placeholder="https://">
                 <div class="mt-3">
-                    <div>※ {{ _("最大ファイルサイズ32MB") }}</div>
                     <div>{{ _("1ページの表示時間") }}:</div>
                     <div class="form-check-inline">
                         <input class="form-check-input" type="radio" name="frame_sec" id="1" value="1" checked>
@@ -66,5 +65,5 @@
 {% block script %}
 <script src="/static/js/util.js"></script>
 <script src="/static/js/baseFunctions.js"></script>
-<script src="/static/js/pdf.js"></script>
+<script type="module" src="/static/js/pdf.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Why

PDF→動画変換をバックエンドからフロントエンドに移行することで:
- サーバー負荷を軽減（ffmpeg処理をクライアントで実行）
- 32MBのファイルサイズ制限を撤廃
- 大容量PDFも変換可能に

## What

- PDF.js + FFmpeg.wasm でクライアントサイド変換を実装
- COOP/COEPヘッダーを追加（SharedArrayBuffer有効化）
- FFmpeg workerファイルをローカルにホスト（クロスオリジン制約回避）

## Test

- [ ] 3ページPDFで変換→アップロード完了を確認
- [ ] 1秒/2秒の表示時間オプションが正しく動作
- [ ] Chrome/Edgeで動作確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)