### PR TITLE
feat: URL 変換の接続先を Cloud Run の web-capture に切り替える

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -20,7 +20,7 @@
     "R2_ACCOUNT_ID": "65850b2bd0055921bdcfbe42383c794a",
     "R2_BUCKET_NAME": "webscreen-beta",
     "R2_PUBLIC_BASE_URL": "https://pub-ebb48e6efc2f4128b606cf381851cae5.r2.dev",
-    "WEBCAPTURE_URL": "http://localhost:8090"
+    "WEBCAPTURE_URL": "https://web-capture-345811595113.asia-northeast1.run.app"
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## なぜこの変更が必要か

β の URL 変換は `WEBCAPTURE_URL` がローカル開発既定（`http://localhost:8090`）のままで、
Worker からは到達できず実質使えない状態だった。web-capture を Cloud Run へ配置し、
β から実際に使えるようにする。

## 変更内容

- `web/wrangler.jsonc` の `WEBCAPTURE_URL` を Cloud Run の web-capture URL に変更

インフラ側（リポ外）の作業:

- web-capture を Cloud Run (asia-northeast1) にデプロイ（メモリ2Gi / CPU2 / timeout 300s / 同時実行4 / 最大3インスタンス）
- イメージは Artifact Registry（`asia-northeast1-docker.pkg.dev/noricha/web-capture`）へ amd64 でビルド・push
- 共有トークンと R2 認証情報を Secret Manager で管理（`WEBCAPTURE_TOKEN` / `WEBCAPTURE_R2_ACCESS_KEY_ID` / `WEBCAPTURE_R2_SECRET_ACCESS_KEY`）

## 意思決定

### 採用アプローチ

- **シークレットは Secret Manager 経由**（`--set-env-vars` での平文渡しは却下）。値がコマンド履歴と
  Cloud Run コンソールに残るため。投入は `secret-set.sh` を使い、末尾改行除去と読み戻し sha256 照合まで実施
- **secretAccessor は secret 単位で付与**（プロジェクト全体への付与は却下）。実行 SA が読めるのは
  この3つだけに限定する。既定 SA が持つ `roles/editor` には Secret Manager の値読み取りが含まれないため付与が必要だった

### トレードオフ

- **同時実行4・最大3インスタンス** > スループット: Selenium + Chrome はメモリを食うため、
  まず保守的な上限で運用して実測から調整する

## テスト

- [x] Cloud Run `GET /health` 200
- [x] 無認証 `POST /capture` → 401
- [x] **β のブラウザから実測**: Wikipedia の VRChat ページを変換 → Cloud Run が13枚撮影 →
      FFmpeg.wasm で mp4 化 → R2 公開 URL 取得
- [x] 生成物を ffprobe で検証: h264 / Constrained Baseline / yuv420p / bf=0 / faststart / 1920x1080 / 13フレーム13秒
- [x] フレーム 0 / 6 / 12 を抽出し、ページ冒頭 → 中盤 → 末尾と進む**スクロール動画**であることを確認

## Screenshot

変換完了画面（動画 URL とプレビュー導線）は PR #14 に掲載済みのため省略。本 PR の差分は設定値1行。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
