### PR TITLE
feat(web): ヘッダーの言語切替を左揃えグループへ移動

### DIFF
--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -21,24 +21,24 @@ const LOGOUT_URL = '/api/auth/logout/';
 
 <header class="border-b border-slate-200 bg-white">
   <div class="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-4 py-3">
-    <a href={`/${lang}/`} class="flex items-center gap-3 no-underline">
-      <picture>
-        <source media="(max-width: 767px)" srcset={`${BANNER_BASE_URL}header-7.png`} />
-        <img
-          src={`${BANNER_BASE_URL}header-2000.png`}
-          alt={t.nav.bannerAlt}
-          width="1000"
-          height="100"
-          class="h-9 w-auto"
-        />
-      </picture>
-      <span class="text-xl font-bold tracking-tight text-slate-900 lg:hidden">WebScreen</span>
-      <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
-        β
-      </span>
-    </a>
-
     <div class="flex items-center gap-3">
+      <a href={`/${lang}/`} class="flex items-center gap-3 no-underline">
+        <picture>
+          <source media="(max-width: 767px)" srcset={`${BANNER_BASE_URL}header-7.png`} />
+          <img
+            src={`${BANNER_BASE_URL}header-2000.png`}
+            alt={t.nav.bannerAlt}
+            width="1000"
+            height="100"
+            class="h-9 w-auto"
+          />
+        </picture>
+        <span class="text-xl font-bold tracking-tight text-slate-900 lg:hidden">WebScreen</span>
+        <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
+          β
+        </span>
+      </a>
+
       <a
         href={switchLocalePath(Astro.url.pathname, other)}
         hreflang={other}
@@ -47,7 +47,9 @@ const LOGOUT_URL = '/api/auth/logout/';
         <i class="fa-solid fa-language" aria-hidden="true"></i>
         <span class="ml-1">{t.nav.langSwitch}</span>
       </a>
+    </div>
 
+    <div class="flex items-center gap-3">
       <a
         data-auth-only="guest"
         href={LOGIN_URL}


### PR DESCRIPTION
## なぜこの変更が必要か

ヘッダーで言語切替（English / 日本語）がログインボタンと同じ右側グループにあり、ブランド要素（キャラクターバナー・WebScreen β）と操作系が混在していた。「WebScreen (β)・キャラクター・言語設定までを左揃えに」というユーザー要望に合わせ、左＝ブランド+言語、右＝認証系（ログイン / アカウント）に整理する。

## 変更内容

- SiteHeader.astro: 言語切替リンクをロゴ（キャラクターバナー + β バッジ）と同じ左揃えグループへ移動
- 右側グループはログインボタン / アカウントメニューのみに変更

## テスト

- [x] astro dev でデスクトップ 1280px / モバイル 375px を Playwright スクリーンショット確認
- [x] bun run build 成功

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/e0911469aa03-before-desktop-20260826-101212.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/a28cf156e82e-after-desktop-20260826-101021.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
