### PR TITLE
feat(web): ヘッダーロゴを2枚に分割してテキストを左に表示

### DIFF
--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -22,18 +22,21 @@ const LOGOUT_URL = '/api/auth/logout/';
 <header class="border-b border-slate-200 bg-white">
   <div class="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-4 py-3">
     <div class="flex items-center gap-3">
-      <a href={`/${lang}/`} class="flex items-center gap-3 no-underline">
-        <picture>
-          <source media="(max-width: 767px)" srcset={`${BANNER_BASE_URL}header-7.png`} />
-          <img
-            src={`${BANNER_BASE_URL}header-2000.png`}
-            alt={t.nav.bannerAlt}
-            width="1000"
-            height="100"
-            class="h-9 w-auto"
-          />
-        </picture>
-        <span class="text-xl font-bold tracking-tight text-slate-900 lg:hidden">WebScreen</span>
+      <a href={`/${lang}/`} class="flex items-center gap-2 no-underline">
+        <img
+          src={`${BANNER_BASE_URL}logo-text.png`}
+          alt={t.nav.bannerAlt}
+          width="860"
+          height="200"
+          class="h-9 w-auto"
+        />
+        <img
+          src={`${BANNER_BASE_URL}logo-characters.png`}
+          alt=""
+          width="620"
+          height="200"
+          class="h-9 w-auto"
+        />
         <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
           β
         </span>


### PR DESCRIPTION
## なぜこの変更が必要か

ヘッダーロゴが「キャラクター2人 + WEB SCREEN テキスト」の1枚画像で、並び順（キャラ左・テキスト右）を変えられなかった。テキストを左・キャラクターをその右に表示するというユーザー要望に合わせ、画像を2枚に分割して並び替える。

## 変更内容

- 元画像 header-2000.png（2000x200）を ffmpeg で crop し、GCS に `logo-text.png`（テキスト部）と `logo-characters.png`（キャラクター部）を追加（既存ファイルは無変更）
- SiteHeader.astro: `<picture>`（デスクトップ/モバイル出し分け）を廃止し、テキスト画像 → キャラクター画像 → β バッジの順に表示
- テキストがロゴ画像として常時読めるようになったため、モバイル用の重複した "WebScreen" テキスト span を削除

## テスト

- [x] astro dev で 1280px / 375px を Playwright スクリーンショット確認

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/a28cf156e82e-after-desktop-20260826-101021.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/9e0e2d3669ec-logo-split-desktop-20260826-112039.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
