### PR TITLE
feat(web): 言語切替をヘッダーからフッターへ移動

### DIFF
--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -50,7 +50,7 @@ test.describe('未ログイン', () => {
 
   test('言語切替リンクで同じページの別ロケールへ移動する', async ({ page }) => {
     await page.goto('/ja/privacy/');
-    await page.getByRole('link', { name: ja.nav.langSwitch }).click();
+    await page.locator('footer').getByRole('link', { name: ja.footer.langSwitch }).click();
 
     await expect(page).toHaveURL(/\/en\/privacy\/$/);
     await expect(page.getByRole('heading', { level: 1, name: en.privacy.heading })).toBeVisible();

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -1,5 +1,5 @@
 ---
-import { useTranslations, type Locale } from '../i18n';
+import { alternateLocale, switchLocalePath, useTranslations, type Locale } from '../i18n';
 
 interface Props {
   lang: Locale;
@@ -7,6 +7,7 @@ interface Props {
 
 const { lang } = Astro.props;
 const t = useTranslations(lang);
+const other = alternateLocale(lang);
 
 const REPOSITORY_URL = 'https://github.com/noricha-vr/WebScreen';
 ---
@@ -33,6 +34,14 @@ const REPOSITORY_URL = 'https://github.com/noricha-vr/WebScreen';
       >
         <i class="fa-solid fa-shield-halved" aria-hidden="true"></i>
         <span>{t.footer.privacy}</span>
+      </a>
+      <a
+        href={switchLocalePath(Astro.url.pathname, other)}
+        hreflang={other}
+        class="inline-flex items-center gap-2 text-slate-700 underline hover:text-brand-700"
+      >
+        <i class="fa-solid fa-language" aria-hidden="true"></i>
+        <span>{t.footer.langSwitch}</span>
       </a>
     </nav>
   </div>

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -1,6 +1,6 @@
 ---
 import HistoryDropdown from './HistoryDropdown.astro';
-import { alternateLocale, switchLocalePath, useTranslations, type Locale } from '../i18n';
+import { useTranslations, type Locale } from '../i18n';
 
 interface Props {
   lang: Locale;
@@ -8,7 +8,6 @@ interface Props {
 
 const { lang } = Astro.props;
 const t = useTranslations(lang);
-const other = alternateLocale(lang);
 
 // 画像は既存サイトの GCS 配信をそのまま使う（リポジトリの .gitignore が *.png を
 // 一括で無視するため、web/public/ にバイナリを置かない方針）。
@@ -40,15 +39,6 @@ const LOGOUT_URL = '/api/auth/logout/';
         <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
           β
         </span>
-      </a>
-
-      <a
-        href={switchLocalePath(Astro.url.pathname, other)}
-        hreflang={other}
-        class="rounded-md px-2 py-1 text-base text-slate-700 hover:bg-slate-100"
-      >
-        <i class="fa-solid fa-language" aria-hidden="true"></i>
-        <span class="ml-1">{t.nav.langSwitch}</span>
       </a>
     </div>
 

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -11,7 +11,6 @@
     "account": "Account",
     "history": "History",
     "logout": "Sign out",
-    "langSwitch": "日本語",
     "bannerAlt": "WebScreen logo",
     "avatarAlt": "Account avatar"
   },
@@ -86,6 +85,7 @@
   "footer": {
     "github": "GitHub",
     "privacy": "Cookies and privacy",
+    "langSwitch": "日本語",
     "note": "WebScreen β — an early release of the Cloudflare edition"
   },
   "privacy": {

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -11,7 +11,6 @@
     "account": "アカウント",
     "history": "履歴",
     "logout": "ログアウト",
-    "langSwitch": "English",
     "bannerAlt": "WebScreen のロゴ",
     "avatarAlt": "アカウントのアバター"
   },
@@ -86,6 +85,7 @@
   "footer": {
     "github": "GitHub",
     "privacy": "Cookie とプライバシー",
+    "langSwitch": "English",
     "note": "WebScreen β — Cloudflare 版の先行公開です"
   },
   "privacy": {


### PR DESCRIPTION
## なぜこの変更が必要か

ヘッダーはロゴ・β・認証系に絞りたいというユーザー要望。言語切替は利用頻度が低いため、フッターのナビ（GitHub・プライバシーの並び）へ移動する。

## 変更内容

- SiteHeader.astro から言語切替リンクを削除（不要になった import も掃除）
- SiteFooter.astro の nav 末尾に言語切替リンクを追加（既存リンクと同スタイル、`switchLocalePath` + `hreflang` は踏襲）
- i18n キーを `nav.langSwitch` → `footer.langSwitch` へ移動（ja/en 両方）
- e2e の言語切替テストをフッター内クリックに更新

## テスト

- [x] bun test 186 pass / tsc / playwright top.spec 11 pass
- [x] /ja/ と /ja/privacy/ のスクショでヘッダーから消えフッターに表示されることを確認

## Screenshot

![footer-lang-switch](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/bb0b5eedbf2d-01-footer-lang-switch-ja-20260826-031900.avif)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
