### PR TITLE
feat(web): ヘッダーロゴの拡大・β 位置変更・アップロードボタン削除

### DIFF
--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -112,7 +112,7 @@ test.describe('ログイン済み', () => {
     await signIn(page);
     await page.goto('/ja/');
 
-    await expect(page.getByRole('link', { name: ja.nav.upload })).toBeVisible();
+    await expect(page.locator('[data-history-menu] summary', { hasText: ja.nav.history })).toBeVisible();
     await expect(page.getByText('noricha')).toBeVisible();
     await expect(page.getByRole('link', { name: ja.hero.cta })).toBeHidden();
     await expect(page.getByText(ja.convert.dropzoneTitle)).toBeVisible();

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -19,7 +19,7 @@ const LOGOUT_URL = '/api/auth/logout/';
 ---
 
 <header class="border-b border-slate-200 bg-white">
-  <div class="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-4 py-3">
+  <div class="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-4 py-0">
     <div class="flex items-center gap-3">
       <a href={`/${lang}/`} class="flex items-center gap-2 no-underline">
         <img
@@ -27,18 +27,18 @@ const LOGOUT_URL = '/api/auth/logout/';
           alt={t.nav.bannerAlt}
           width="860"
           height="200"
-          class="h-9 w-auto"
+          class="h-11 w-auto sm:h-14"
         />
+        <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
+          β
+        </span>
         <img
           src={`${BANNER_BASE_URL}logo-characters.png`}
           alt=""
           width="620"
           height="200"
-          class="h-9 w-auto"
+          class="h-11 w-auto sm:h-14"
         />
-        <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
-          β
-        </span>
       </a>
     </div>
 

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -53,14 +53,6 @@ const LOGOUT_URL = '/api/auth/logout/';
       </a>
 
       <div data-auth-only="member" class="flex items-center gap-2">
-        <a
-          href={`/${lang}/#convert`}
-          class="inline-flex items-center gap-2 whitespace-nowrap rounded-md border border-brand-500 px-3 py-2 text-base font-semibold text-brand-700 hover:bg-brand-50"
-        >
-          <i class="fa-solid fa-arrow-up-from-bracket" aria-hidden="true"></i>
-          <span>{t.nav.upload}</span>
-        </a>
-
         <HistoryDropdown lang={lang} />
 
         <details class="relative">

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -7,7 +7,6 @@
   "nav": {
     "home": "Home",
     "login": "Sign in with Discord",
-    "upload": "Upload",
     "account": "Account",
     "history": "History",
     "logout": "Sign out",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -7,7 +7,6 @@
   "nav": {
     "home": "ホーム",
     "login": "Discord でログイン",
-    "upload": "アップロード",
     "account": "アカウント",
     "history": "履歴",
     "logout": "ログアウト",


### PR DESCRIPTION
## なぜこの変更が必要か

ヘッダーの調整2件（ユーザー指示）。(1) ロゴ帯の存在感が弱いので上下余白をなくして画像を拡大し、β バッジをロゴとキャラクターの間へ。(2) ログイン後のアップロードボタンは変換パネルがトップに常時表示されるため冗長で削除。

## 変更内容

- ロゴ帯: `py-3` → `py-0`、ロゴ・キャラクター画像を h-9 → h-11（sm 以上 h-14）に拡大、並びを [WEB SCREEN][β][キャラクター] に変更
- グローバルメニューからアップロードボタンを削除（`nav.upload` キーも ja/en から削除、e2e アサーション更新）

## テスト

- [x] bun test 186 pass / tsc / playwright top.spec 11 pass
- [x] 未ログイン（1280px/375px）・ログイン済みのスクショ確認

## Screenshot

| ヘッダー（未ログイン） | ログイン済み（アップロードなし） |
|--------|-------|
| ![header](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/1ca22f70b4f4-header-big-desktop-20260826-160808.avif) | ![member](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/add6761fa5aa-header-member-no-upload.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
