### PR TITLE
feat(web): アカウント UI を簡素化しログアウトを機能させる (#17)

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -20,7 +20,7 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `GET /api/health/` | 疎通確認 | 不要 | — |
 | `GET /api/auth/login/` | Discord OAuth 開始（state Cookie を発行してリダイレクト） | 不要 | `session.ts` |
 | `GET /api/auth/callback/` | OAuth コールバック（state 検証 → users upsert → セッション Cookie 発行） | 不要 | `session.ts` |
-| `POST /api/auth/logout/` | セッション Cookie の破棄 | 本人 | — |
+| `POST /api/auth/logout/` | セッション Cookie の破棄（form の `lang` のトップへ 303 リダイレクト。不正・欠落は `ja`） | 本人 | — |
 | `GET /api/me/` | ログイン中のユーザー情報 | 本人 | — |
 | `POST /api/uploads/presign/` | R2 へのアップロード先を払い出し、movies に `pending` 行を作る | 本人 | `PresignRequest` / `PresignResponse` |
 | `POST /api/uploads/commit/` | アップロード完了を確定し `ready` にする | 本人（当該 movie の所有者） | `CommitRequest` / `CommitResponse` |

--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -1,16 +1,11 @@
-import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { join } from 'node:path';
 
 // Playwright は Node で直接実行するため、JSON には import 属性が要る（Vite は不要）
 import en from '../src/i18n/en.json' with { type: 'json' };
 import ja from '../src/i18n/ja.json' with { type: 'json' };
-import {
-  createSessionPayload,
-  importSigningKey,
-  signSession,
-  SESSION_COOKIE_NAME,
-} from '../src/lib/contracts/session';
-import { E2E_FIXTURES, E2E_SESSION_SIGNING_KEY } from '../playwright.config';
+import { E2E_FIXTURES } from '../playwright.config';
+import { signIn } from './session';
 
 // 公開プレビュー /{shortId}/ と履歴ドロップダウンの画面確認。
 // D1 のフィクスチャは playwright.config.ts の webServer が seed.sql で流し込む。
@@ -24,16 +19,6 @@ const SCREENSHOT_DIR = join(process.cwd(), '..', 'docs', 'tmp', 'screenshots');
 function screenshotPath(name: string): string {
   const stamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 15);
   return join(SCREENSHOT_DIR, `${name}-${stamp}.png`);
-}
-
-/** 本人のセッション Cookie を作る（Worker と同じ鍵・同じ署名形式）。 */
-async function signIn(context: BrowserContext, userId: number): Promise<void> {
-  const key = await importSigningKey(E2E_SESSION_SIGNING_KEY);
-  const value = await signSession(createSessionPayload(userId), key);
-
-  await context.addCookies([
-    { name: SESSION_COOKIE_NAME, value, domain: 'localhost', path: '/' },
-  ]);
 }
 
 /** 履歴 API を差し替える（実データではなく一覧の描画と削除操作を見るため）。 */

--- a/web/e2e/session.ts
+++ b/web/e2e/session.ts
@@ -1,0 +1,22 @@
+import type { BrowserContext } from '@playwright/test';
+
+import {
+  createSessionPayload,
+  importSigningKey,
+  signSession,
+  SESSION_COOKIE_NAME,
+} from '../src/lib/contracts/session';
+import { E2E_SESSION_SIGNING_KEY } from '../playwright.config';
+
+/**
+ * 本人のセッション Cookie を作る（Worker と同じ鍵・同じ署名形式）。
+ *
+ * `*.spec.ts` に置くと testMatch に拾われてテストが二重登録されるため、
+ * 共有ヘルパーは spec ではないファイル名にしている。
+ */
+export async function signIn(context: BrowserContext, userId: number): Promise<void> {
+  const key = await importSigningKey(E2E_SESSION_SIGNING_KEY);
+  const value = await signSession(createSessionPayload(userId), key);
+
+  await context.addCookies([{ name: SESSION_COOKIE_NAME, value, domain: 'localhost', path: '/' }]);
+}

--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -6,6 +6,8 @@ import { expect, test, type Page } from '@playwright/test';
 import en from '../src/i18n/en.json' with { type: 'json' };
 import ja from '../src/i18n/ja.json' with { type: 'json' };
 import { E2E_FIXTURES } from '../playwright.config';
+import { signIn as signInWithSessionCookie } from './session';
+import { SESSION_COOKIE_NAME } from '../src/lib/contracts/session';
 
 const fixture = (name: string): Buffer =>
   readFileSync(fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url)));
@@ -113,9 +115,40 @@ test.describe('ログイン済み', () => {
     await page.goto('/ja/');
 
     await expect(page.locator('[data-history-menu] summary', { hasText: ja.nav.history })).toBeVisible();
-    await expect(page.getByText('noricha')).toBeVisible();
+    // 名前は sr-only なので、見えるアカウント表示はアバター（頭文字バッジ）とログアウトの 2 つ
+    await expect(page.locator('header [data-viewer-initial]')).toBeVisible();
+    await expect(page.getByRole('button', { name: ja.nav.logout })).toBeVisible();
     await expect(page.getByRole('link', { name: ja.hero.cta })).toBeHidden();
     await expect(page.getByText(ja.convert.dropzoneTitle)).toBeVisible();
+  });
+
+  // ログアウトが 204 を返していた頃はブラウザが遷移せず、押しても何も起きなかった。
+  // 実セッション Cookie で入る（/api/me/ をモックするとログアウト後も member を返してしまう）。
+  test('ログアウトすると未ログイン表示に戻り、セッション Cookie が消える', async ({
+    page,
+    context,
+  }) => {
+    await signInWithSessionCookie(context, E2E_FIXTURES.ownerId);
+    await page.goto('/ja/');
+
+    const header = page.locator('header');
+    const logout = header.getByRole('button', { name: ja.nav.logout });
+    await expect(logout).toBeVisible();
+
+    const logoutResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith('/api/auth/logout/') && response.request().method() === 'POST'
+    );
+    await logout.click();
+    expect((await logoutResponse).status()).toBe(303);
+
+    await expect(header.getByRole('link', { name: ja.nav.login })).toBeVisible();
+    await expect(logout).toBeHidden();
+
+    const session = (await context.cookies()).find(
+      (cookie) => cookie.name === SESSION_COOKIE_NAME
+    );
+    expect(session).toBeUndefined();
   });
 
   test('小さな画像2枚を MP4 に変換し、プレビューで動画 URL を自動コピーする', async ({ page, context }) => {

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -55,41 +55,36 @@ const LOGOUT_URL = '/api/auth/logout/';
       <div data-auth-only="member" class="flex items-center gap-2">
         <HistoryDropdown lang={lang} />
 
-        <details class="relative">
-          <summary
-            class="flex cursor-pointer list-none items-center gap-2 rounded-md border border-slate-300 px-2 py-1.5 text-base text-slate-800 hover:bg-slate-100"
+        {/* アバターは本人確認の目印なので表示のみ。操作はログアウトの 1 つだけなので */}
+        {/* ドロップダウンに畳まず、履歴と並べて常時見えるボタンにしている。 */}
+        <span class="flex items-center">
+          <span
+            data-viewer-initial
+            class="flex h-7 w-7 items-center justify-center rounded-full bg-brand-100 font-semibold text-brand-700"
+            >W</span
           >
-            <span
-              data-viewer-initial
-              class="flex h-7 w-7 items-center justify-center rounded-full bg-brand-100 font-semibold text-brand-700"
-              >W</span
-            >
-            <img
-              data-viewer-avatar
-              hidden
-              alt={t.nav.avatarAlt}
-              width="28"
-              height="28"
-              class="h-7 w-7 rounded-full"
-            />
-            <span data-viewer-name>{t.nav.account}</span>
-            <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
-          </summary>
+          <img
+            data-viewer-avatar
+            hidden
+            alt={t.nav.avatarAlt}
+            width="28"
+            height="28"
+            class="h-7 w-7 rounded-full"
+          />
+          {/* 名前は表示しないが、支援技術向けに残す（JS が実名で上書きする）。 */}
+          <span data-viewer-name class="sr-only">{t.nav.account}</span>
+        </span>
 
-          <div
-            class="absolute right-0 z-10 mt-2 w-72 rounded-md border border-slate-200 bg-white p-4 shadow-lg"
+        <form method="post" action={LOGOUT_URL}>
+          <input type="hidden" name="lang" value={lang} />
+          <button
+            type="submit"
+            class="inline-flex items-center gap-2 whitespace-nowrap rounded-md border border-slate-300 px-3 py-2 text-base font-semibold text-slate-800 hover:bg-slate-100"
           >
-            <form method="post" action={LOGOUT_URL}>
-              <button
-                type="submit"
-                class="inline-flex items-center gap-2 text-base font-semibold text-slate-700 hover:text-brand-700"
-              >
-                <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
-                <span>{t.nav.logout}</span>
-              </button>
-            </form>
-          </div>
-        </details>
+            <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
+            <span>{t.nav.logout}</span>
+          </button>
+        </form>
       </div>
     </div>
   </div>

--- a/web/src/pages/api/auth/logout.ts
+++ b/web/src/pages/api/auth/logout.ts
@@ -1,11 +1,24 @@
 import type { APIRoute } from 'astro';
 
+import { DEFAULT_LOCALE, isLocale } from '../../../i18n';
 import { SESSION_COOKIE_NAME } from '../../../lib/contracts/session';
 
 export const prerender = false;
 
-/** ログインセッション Cookie を破棄する。 */
-export const POST: APIRoute = ({ cookies }) => {
+/**
+ * ログインセッション Cookie を破棄し、元いた言語のトップへ戻す。
+ *
+ * ヘッダーの form 送信から呼ばれるため、204 ではなくリダイレクトを返す
+ * （204 だとブラウザが遷移せず、画面上はログアウトが効かないように見える）。
+ * 303 なのは POST の再送を避けて GET で遷移させるため。
+ */
+export const POST: APIRoute = async ({ cookies, redirect, request }) => {
   cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
-  return new Response(null, { status: 204 });
+
+  // lang は外部入力なので辞書にあるロケールだけを通す（オープンリダイレクト防止）。
+  const form = await request.formData().catch(() => null);
+  const requested = form?.get('lang');
+  const lang = typeof requested === 'string' && isLocale(requested) ? requested : DEFAULT_LOCALE;
+
+  return redirect(`/${lang}/`, 303);
 };

--- a/web/tests/api/logout.test.ts
+++ b/web/tests/api/logout.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { POST } from '../../src/pages/api/auth/logout';
+
+/** ログアウトハンドラを最小のモック context で直接叩く。 */
+async function callLogout(body: string | null): Promise<{
+  status: number;
+  location: string | null;
+  deletedCookies: string[];
+}> {
+  const deletedCookies: string[] = [];
+  const request = new Request('http://localhost/api/auth/logout/', {
+    method: 'POST',
+    headers: body === null ? {} : { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  const context = {
+    request,
+    cookies: {
+      delete: (name: string) => {
+        deletedCookies.push(name);
+      },
+    },
+    redirect: (location: string, status: number) =>
+      new Response(null, { status, headers: { location } }),
+  };
+
+  const response = await POST(context as unknown as Parameters<typeof POST>[0]);
+  return { status: response.status, location: response.headers.get('location'), deletedCookies };
+}
+
+describe('POST /api/auth/logout/', () => {
+  test('lang=ja なら /ja/ へ 303 リダイレクトし Cookie を破棄する', async () => {
+    const result = await callLogout('lang=ja');
+    expect(result.status).toBe(303);
+    expect(result.location).toBe('/ja/');
+    expect(result.deletedCookies).toEqual(['ws_session']);
+  });
+
+  test('lang=en なら /en/ へ 303 リダイレクトする', async () => {
+    const result = await callLogout('lang=en');
+    expect(result.status).toBe(303);
+    expect(result.location).toBe('/en/');
+  });
+
+  test('lang が不正値なら既定の /ja/ にフォールバックする', async () => {
+    const result = await callLogout('lang=https%3A%2F%2Fevil.example');
+    expect(result.status).toBe(303);
+    expect(result.location).toBe('/ja/');
+  });
+
+  test('form body が無くても /ja/ に 303 で戻り Cookie は破棄される', async () => {
+    const result = await callLogout(null);
+    expect(result.status).toBe(303);
+    expect(result.location).toBe('/ja/');
+    expect(result.deletedCookies).toEqual(['ws_session']);
+  });
+});


### PR DESCRIPTION
## なぜこの変更が必要か

ログイン後ヘッダーのアカウントドロップダウンは中身が「ログアウト」1つだけで、開く手間に見合わなかった。ユーザーと協議し「アバターのみ表示 + ログアウト常時表示」に簡素化する。あわせて、ログアウトを見える場所に出す前提として、押しても画面が変わらない既知バグ（#17: 204 応答で form 遷移しない）を修正する。

## 変更内容

- ヘッダー右側を `[履歴] (アバター) [ログアウト]` に変更。ドロップダウン廃止、アバターは表示のみ（名前は sr-only で支援技術向けに維持）
- `POST /api/auth/logout/` を 204 → **303 リダイレクト**（`/{lang}/`）に変更。lang は form の hidden input から `isLocale` で検証し不正値は ja へフォールバック（オープンリダイレクト防止）
- e2e: 実セッション Cookie でのログアウト再発防止テストを追加（Cookie 発行ヘルパーを `e2e/session.ts` に共通化）。ヘッダー表示のアサーションを新 UI に追従
- 単体テスト: logout ハンドラの lang フォールバック分岐（ja/en/不正値/body なし）を追加

## レビュー

codex sol 2レーン（通常 + セキュリティ）実施。ブロッキングなし。
- fix: lang フォールバックの単体テスト追加（両レーン共通指摘）
- 対応不要と確認: CSRF は Astro `security.checkOrigin`（既定有効・ビルド manifest で確認）が外部 Origin の form POST を遮断 / オープンリダイレクトは isLocale 完全一致で防止
- defer: Cookie 削除側の path 直書きの属性共通化（現状は発行・削除とも一致しており実害なし）

## テスト

- [x] bun test 190 pass / tsc / playwright 33 pass（ログアウト e2e は 204 に戻すと fail する red 確認済み）

## Screenshot

![member-header](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/a47b5a15d4c1-05-header-member-ja.avif)

Closes #17

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
