### PR TITLE
feat(web): 変換結果の自動命名を元コンテンツ由来に改善

### DIFF
--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -160,10 +160,16 @@ test.describe('ログイン済み', () => {
 
     const panel = page.locator('[data-convert-panel]');
     const uploadRequest = page.waitForRequest('https://upload.test/r2-upload');
+    const presignRequest = page.waitForRequest('**/api/uploads/presign/');
     await panel.locator('[data-file-input]').setInputFiles([
       { name: 'first.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG },
       { name: 'second.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG },
     ]);
+
+    // 複数枚は「先頭ファイル名 + 残り枚数」で保存される（/ja/ なので日本語の接尾辞）
+    expect((await presignRequest).postDataJSON().filename).toBe(
+      `first ${ja.convert.batchNameSuffix.replace('{count}', '1')}.mp4`
+    );
 
     const request = await uploadRequest;
     expect(request.headers()['content-type']).toBe('video/mp4');
@@ -241,8 +247,12 @@ test.describe('ログイン済み', () => {
 
     const panel = page.locator('[data-convert-panel]');
     const uploadRequest = page.waitForRequest('https://upload.test/r2-upload');
+    const presignRequest = page.waitForRequest('**/api/uploads/presign/');
     await panel.locator('[data-url-input]').fill('https://example.com/');
     await panel.locator('[data-url-form] button[type="submit"]').click();
+
+    // 変換元の URL から名前を作る（ルート直下なのでホスト名だけ）
+    expect((await presignRequest).postDataJSON().filename).toBe('example.com.mp4');
 
     const request = await uploadRequest;
     expect(request.headers()['content-type']).toBe('video/mp4');

--- a/web/src/components/ConvertPanel.astro
+++ b/web/src/components/ConvertPanel.astro
@@ -21,6 +21,7 @@ const t = useTranslations(lang);
   data-msg-failed={t.convert.errorFailed}
   data-label-converting={t.convert.converting}
   data-label-uploading={t.convert.uploading}
+  data-batch-name-suffix={t.convert.batchNameSuffix}
   class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
 >
   <h2 class="text-2xl font-bold tracking-tight text-slate-900">{t.convert.heading}</h2>

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -42,7 +42,8 @@
     "errorTooLarge": "This file is larger than the 50 MB limit",
     "errorUnsupported": "This file type is not supported",
     "errorTooManyPages": "PDF files must have 200 pages or fewer",
-    "errorFailed": "Conversion failed. Please try again in a moment"
+    "errorFailed": "Conversion failed. Please try again in a moment",
+    "batchNameSuffix": "+{count}"
   },
   "history": {
     "heading": "Your videos",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -42,7 +42,8 @@
     "errorTooLarge": "ファイルサイズが上限の 50 MB を超えています",
     "errorUnsupported": "対応していないファイル形式です",
     "errorTooManyPages": "PDF は 200 ページ以下にしてください",
-    "errorFailed": "変換に失敗しました。時間をおいて再度お試しください"
+    "errorFailed": "変換に失敗しました。時間をおいて再度お試しください",
+    "batchNameSuffix": "他{count}枚"
   },
   "history": {
     "heading": "変換した動画",

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -16,6 +16,10 @@ import {
   type UploadState,
 } from './upload-flow';
 import { markAutoCopy } from './auto-copy';
+import { movieNameForFiles, movieNameForUrl } from './upload-name';
+
+/** data-batch-name-suffix が無いときの接尾辞（ロケール非依存で読める形）。 */
+const DEFAULT_BATCH_NAME_SUFFIX = '+{count}';
 
 type Dispatch = (event: UploadEvent, runGeneration?: number) => void;
 type Navigate = (url: string) => void;
@@ -116,11 +120,6 @@ function asCaptureResponse(value: unknown): CaptureResponse {
   return { images: value.images as string[] };
 }
 
-function mp4Filename(source: string): string {
-  const extension = source.lastIndexOf('.');
-  return `${extension > 0 ? source.slice(0, extension) : source}.mp4`;
-}
-
 async function uploadMp4(
   mp4: Blob,
   filename: string,
@@ -206,7 +205,18 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     void convertFilesToMp4(files, kind, (progress) => {
       dispatch({ type: 'conversionProgress', ...progress }, current);
     })
-      .then((mp4) => uploadMp4(mp4, mp4Filename(files[0]!.name), kind, dispatch, current))
+      .then((mp4) =>
+        uploadMp4(
+          mp4,
+          movieNameForFiles(
+            files.map((file) => file.name),
+            panel.dataset['batchNameSuffix'] ?? DEFAULT_BATCH_NAME_SUFFIX
+          ),
+          kind,
+          dispatch,
+          current
+        )
+      )
       .catch((error: unknown) => {
         console.error('conversion failed', error);
         dispatch({ type: 'failed', errorCode: conversionErrorCode(error) }, current);
@@ -255,7 +265,7 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
       .then((capture) => convertImageUrlsToMp4(capture.images, (progress) => {
         dispatch({ type: 'conversionProgress', ...progress }, current);
       }))
-      .then((mp4) => uploadMp4(mp4, 'capture.mp4', 'web', dispatch, current))
+      .then((mp4) => uploadMp4(mp4, movieNameForUrl(url), 'web', dispatch, current))
       .catch((error: unknown) => {
         console.error('conversion failed', error);
         dispatch({ type: 'failed', errorCode: conversionErrorCode(error) }, current);

--- a/web/src/lib/ui/upload-name.ts
+++ b/web/src/lib/ui/upload-name.ts
@@ -1,0 +1,107 @@
+/**
+ * アップロードする mp4 のファイル名を決める純粋関数。
+ *
+ * 変換結果はダウンロード名・履歴の表示名としてそのまま残るため、
+ * 「元が何だったか」が分かる名前を作るのがここの責務。DOM には触らない。
+ *
+ * 生成した名前は presign の filename としてサーバーへ送られ、
+ * contracts/api.ts の isSafeFilename で検証される。パス区切り・制御文字を
+ * 含めないこと、長すぎないことはこちら側で保証する。
+ */
+
+/** 拡張子込みの上限。UI・ダウンロード名として読める長さに抑える（サーバー上限 255 より厳しい）。 */
+const MAX_NAME_LENGTH = 80;
+
+const MP4_EXTENSION = '.mp4';
+
+/** URL から名前を作れなかったときの名前（従来の固定値と同じ）。 */
+const FALLBACK_NAME = `capture${MP4_EXTENSION}`;
+
+/** `index.html` のような「そのディレクトリを指すだけ」のセグメント。名前に使っても情報がない。 */
+const INDEX_SEGMENT = /^index\.[^.]+$/i;
+
+/** 制御文字の境界。isSafeFilename が弾く範囲と合わせる。 */
+const CONTROL_CHAR_MAX = 0x1f;
+const DELETE_CHAR = 0x7f;
+
+/** 拡張子を落とす。先頭ドット（`.gitignore` 等）は拡張子ではなく名前として残す。 */
+function baseName(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  return dot > 0 ? filename.slice(0, dot) : filename;
+}
+
+/** isSafeFilename が弾く文字（パス区切りと制御文字）かどうか。 */
+function isUnsafeChar(char: string): boolean {
+  if (char === '/' || char === '\\') return true;
+  const code = char.codePointAt(0) ?? 0;
+  return code <= CONTROL_CHAR_MAX || code === DELETE_CHAR;
+}
+
+function sanitize(value: string): string {
+  return [...value].map((char) => (isUnsafeChar(char) ? '-' : char)).join('');
+}
+
+/** コードポイント単位で切る（slice はサロゲートペアを割って壊れた文字を残す）。 */
+function truncate(value: string, limit: number): string {
+  const chars = [...value];
+  return chars.length <= limit ? value : chars.slice(0, limit).join('');
+}
+
+/**
+ * ファイル選択・ドロップから作る名前。
+ *
+ * 1 件なら元のファイル名の拡張子を mp4 に替えるだけ。複数件は先頭ファイル名に
+ * 残り件数を添える（`batchSuffixTemplate` の `{count}` を先頭以外の件数で置換）。
+ */
+export function movieNameForFiles(names: readonly string[], batchSuffixTemplate: string): string {
+  const first = names[0];
+  if (first === undefined) return FALLBACK_NAME;
+
+  const base = baseName(first);
+  if (names.length === 1) return `${base}${MP4_EXTENSION}`;
+
+  const suffix = batchSuffixTemplate.replaceAll('{count}', String(names.length - 1));
+  return `${base} ${suffix}${MP4_EXTENSION}`;
+}
+
+/**
+ * URL 変換から作る名前。`{ホスト名}-{末尾の意味のあるパスセグメント}.mp4` にする。
+ *
+ * 例: https://zenn.dev/noricha/articles/abc123 → `zenn.dev-abc123.mp4`
+ * パスが実質無ければホスト名だけ、URL として読めなければ `capture.mp4`。
+ */
+export function movieNameForUrl(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return FALLBACK_NAME;
+  }
+  if (url.hostname.length === 0) return FALLBACK_NAME;
+
+  const segment = meaningfulSegment(url.pathname);
+  const base = segment === null ? url.hostname : `${url.hostname}-${segment}`;
+
+  // decode で `%2F` が `/` に戻りうるため、sanitize は decode の後でなければならない。
+  return `${truncate(sanitize(base), MAX_NAME_LENGTH - MP4_EXTENSION.length)}${MP4_EXTENSION}`;
+}
+
+/** 末尾から遡って、名前に使える最初のセグメントを返す（無ければ null）。 */
+function meaningfulSegment(pathname: string): string | null {
+  const segments = pathname.split('/').filter((segment) => segment.length > 0);
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index]!;
+    if (INDEX_SEGMENT.test(segment)) continue;
+    return decodeSegment(segment);
+  }
+  return null;
+}
+
+/** パーセントエンコードを戻して読める名前にする（不正なエンコードはそのまま使う）。 */
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/web/src/lib/ui/upload-name.ts
+++ b/web/src/lib/ui/upload-name.ts
@@ -9,8 +9,13 @@
  * 含めないこと、長すぎないことはこちら側で保証する。
  */
 
-/** 拡張子込みの上限。UI・ダウンロード名として読める長さに抑える（サーバー上限 255 より厳しい）。 */
-const MAX_NAME_LENGTH = 80;
+import { MAX_FILENAME_LENGTH } from '../contracts/api';
+
+/**
+ * URL 由来の名前の上限（拡張子込み）。パスは任意長になりうるので、
+ * サーバー上限（MAX_FILENAME_LENGTH）より手前で「読める長さ」に切る。
+ */
+const URL_MAX_NAME_LENGTH = 80;
 
 const MP4_EXTENSION = '.mp4';
 
@@ -41,10 +46,35 @@ function sanitize(value: string): string {
   return [...value].map((char) => (isUnsafeChar(char) ? '-' : char)).join('');
 }
 
-/** コードポイント単位で切る（slice はサロゲートペアを割って壊れた文字を残す）。 */
+/**
+ * 長さ上限まで切り詰める。
+ *
+ * 上限は isSafeFilename と同じ UTF-16 コード単位で数えるが、切る位置はコードポイント境界に
+ * 揃える（`slice` はサロゲートペアを割って壊れた文字を残す）。
+ */
 function truncate(value: string, limit: number): string {
-  const chars = [...value];
-  return chars.length <= limit ? value : chars.slice(0, limit).join('');
+  if (value.length <= limit) return value;
+
+  let result = '';
+  for (const char of value) {
+    if (result.length + char.length > limit) break;
+    result += char;
+  }
+  return result;
+}
+
+/**
+ * `{base}{suffix}.mp4` を上限内に収めて組み立てる。
+ *
+ * 削るのは base から。suffix（枚数表示）は情報量が高いので優先して残すが、
+ * suffix だけで上限を食い潰す異常な辞書値でも上限は必ず守る。
+ */
+function composeName(base: string, suffix: string, limit: number): string {
+  const tail = `${suffix}${MP4_EXTENSION}`;
+  if (tail.length >= limit) {
+    return `${truncate(suffix, limit - MP4_EXTENSION.length)}${MP4_EXTENSION}`;
+  }
+  return `${truncate(base, limit - tail.length)}${tail}`;
 }
 
 /**
@@ -52,16 +82,21 @@ function truncate(value: string, limit: number): string {
  *
  * 1 件なら元のファイル名の拡張子を mp4 に替えるだけ。複数件は先頭ファイル名に
  * 残り件数を添える（`batchSuffixTemplate` の `{count}` を先頭以外の件数で置換）。
+ *
+ * ファイル名は OS 由来で長さ・文字種を選べないため、URL 由来と同じく sanitize と
+ * 切り詰めを通す。上限直前のファイル名に接尾辞を足すと presign が 400 で落ちるため、
+ * 接尾辞と拡張子の分を先に確保してから base を詰める。
  */
 export function movieNameForFiles(names: readonly string[], batchSuffixTemplate: string): string {
   const first = names[0];
   if (first === undefined) return FALLBACK_NAME;
 
-  const base = baseName(first);
-  if (names.length === 1) return `${base}${MP4_EXTENSION}`;
+  const suffix =
+    names.length === 1
+      ? ''
+      : ` ${batchSuffixTemplate.replaceAll('{count}', String(names.length - 1))}`;
 
-  const suffix = batchSuffixTemplate.replaceAll('{count}', String(names.length - 1));
-  return `${base} ${suffix}${MP4_EXTENSION}`;
+  return composeName(sanitize(baseName(first)), sanitize(suffix), MAX_FILENAME_LENGTH);
 }
 
 /**
@@ -83,7 +118,7 @@ export function movieNameForUrl(rawUrl: string): string {
   const base = segment === null ? url.hostname : `${url.hostname}-${segment}`;
 
   // decode で `%2F` が `/` に戻りうるため、sanitize は decode の後でなければならない。
-  return `${truncate(sanitize(base), MAX_NAME_LENGTH - MP4_EXTENSION.length)}${MP4_EXTENSION}`;
+  return composeName(sanitize(base), '', URL_MAX_NAME_LENGTH);
 }
 
 /** 末尾から遡って、名前に使える最初のセグメントを返す（無ければ null）。 */

--- a/web/tests/ui/upload-name.test.ts
+++ b/web/tests/ui/upload-name.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+
+import { MAX_FILENAME_LENGTH } from '../../src/lib/contracts/api';
+import { movieNameForFiles, movieNameForUrl } from '../../src/lib/ui/upload-name';
+
+/** contracts/api.ts の isSafeFilename と同じ判定（presign に渡せる名前かの確認用）。 */
+function isSafeFilename(value: string): boolean {
+  if (value.length === 0 || value.length > MAX_FILENAME_LENGTH) return false;
+  if (value.includes('/') || value.includes('\\')) return false;
+  if (value === '.' || value === '..') return false;
+  return ![...value].some((char) => {
+    const code = char.codePointAt(0) ?? 0;
+    return code <= 0x1f || code === 0x7f;
+  });
+}
+
+const JA_SUFFIX = '他{count}枚';
+const EN_SUFFIX = '+{count}';
+
+describe('movieNameForFiles', () => {
+  test('1 件なら拡張子だけ mp4 に替える', () => {
+    expect(movieNameForFiles(['slides.pdf'], JA_SUFFIX)).toBe('slides.mp4');
+  });
+
+  test('拡張子が無いファイルはそのまま mp4 を足す', () => {
+    expect(movieNameForFiles(['README'], JA_SUFFIX)).toBe('README.mp4');
+  });
+
+  test('複数件は先頭ファイル名に「先頭以外の枚数」を添える（日本語）', () => {
+    const names = ['IMG_1234.jpg', 'IMG_1235.jpg', 'IMG_1236.jpg', 'IMG_1237.jpg'];
+    expect(movieNameForFiles(names, JA_SUFFIX)).toBe('IMG_1234 他3枚.mp4');
+  });
+
+  test('複数件の接尾辞はテンプレートで切り替わる（英語）', () => {
+    const names = ['IMG_1234.jpg', 'IMG_1235.jpg', 'IMG_1236.jpg', 'IMG_1237.jpg'];
+    expect(movieNameForFiles(names, EN_SUFFIX)).toBe('IMG_1234 +3.mp4');
+  });
+
+  test('2 件のときの枚数は 1', () => {
+    expect(movieNameForFiles(['first.png', 'second.png'], JA_SUFFIX)).toBe('first 他1枚.mp4');
+  });
+
+  test('ファイルが無ければ既定名にする', () => {
+    expect(movieNameForFiles([], JA_SUFFIX)).toBe('capture.mp4');
+  });
+});
+
+describe('movieNameForUrl', () => {
+  test.each([
+    ['ルート直下はホスト名だけ', 'https://example.com/', 'example.com.mp4'],
+    ['パスが無い URL もホスト名だけ', 'https://example.com', 'example.com.mp4'],
+    ['深いパスは末尾セグメントを使う', 'https://zenn.dev/noricha/articles/abc123', 'zenn.dev-abc123.mp4'],
+    ['末尾スラッシュは無視する', 'https://zenn.dev/noricha/articles/abc123/', 'zenn.dev-abc123.mp4'],
+    ['index.html はスキップして 1 つ手前を使う', 'https://example.com/docs/guide/index.html', 'example.com-guide.mp4'],
+    ['index.* だけのパスはホスト名だけ', 'https://example.com/index.php', 'example.com.mp4'],
+    ['クエリとハッシュは無視する', 'https://example.com/blog/post-1?utm=x&a=b#section', 'example.com-post-1.mp4'],
+    ['ポート番号付きでもホスト名だけを使う', 'http://localhost:4322/ja/privacy/', 'localhost-privacy.mp4'],
+  ])('%s', (_label, url, expected) => {
+    expect(movieNameForUrl(url as string)).toBe(expected as string);
+  });
+
+  test('日本語のパスはデコードして読める名前にする', () => {
+    expect(movieNameForUrl('https://example.com/記事/動画変換')).toBe('example.com-動画変換.mp4');
+  });
+
+  test('パス区切りにデコードされる文字は - に置き換える', () => {
+    expect(movieNameForUrl('https://example.com/a%2Fb')).toBe('example.com-a-b.mp4');
+  });
+
+  test('長すぎる URL は拡張子込み 80 文字に収める', () => {
+    const name = movieNameForUrl(`https://example.com/${'a'.repeat(200)}`);
+
+    expect(name.length).toBe(80);
+    expect(name.endsWith('.mp4')).toBe(true);
+    expect(name.startsWith('example.com-aaa')).toBe(true);
+  });
+
+  test('URL として読めない入力は既定名にフォールバックする', () => {
+    expect(movieNameForUrl('not a url')).toBe('capture.mp4');
+    expect(movieNameForUrl('')).toBe('capture.mp4');
+    expect(movieNameForUrl('file:///etc/passwd')).toBe('capture.mp4');
+  });
+
+  test('生成した名前はどれも presign に渡せる', () => {
+    const urls = [
+      'https://example.com/',
+      'https://zenn.dev/noricha/articles/abc123',
+      'https://example.com/a%2Fb',
+      'https://example.com/記事/動画変換',
+      `https://example.com/${'a'.repeat(200)}`,
+      'not a url',
+    ];
+
+    for (const url of urls) {
+      expect(isSafeFilename(movieNameForUrl(url))).toBe(true);
+    }
+  });
+});

--- a/web/tests/ui/upload-name.test.ts
+++ b/web/tests/ui/upload-name.test.ts
@@ -1,21 +1,21 @@
 import { describe, expect, test } from 'bun:test';
 
-import { MAX_FILENAME_LENGTH } from '../../src/lib/contracts/api';
+import { validatePresignRequest } from '../../src/lib/contracts/api';
 import { movieNameForFiles, movieNameForUrl } from '../../src/lib/ui/upload-name';
 
-/** contracts/api.ts の isSafeFilename と同じ判定（presign に渡せる名前かの確認用）。 */
-function isSafeFilename(value: string): boolean {
-  if (value.length === 0 || value.length > MAX_FILENAME_LENGTH) return false;
-  if (value.includes('/') || value.includes('\\')) return false;
-  if (value === '.' || value === '..') return false;
-  return ![...value].some((char) => {
-    const code = char.codePointAt(0) ?? 0;
-    return code <= 0x1f || code === 0x7f;
-  });
+/**
+ * 生成した名前を実際の presign バリデータに掛ける。
+ * 判定ロジックをテスト側に写すと契約がドリフトするため、正本をそのまま呼ぶ。
+ */
+function presignAccepts(filename: string): boolean {
+  return validatePresignRequest({ filename, sizeBytes: 1024, kind: 'image' }).ok;
 }
 
 const JA_SUFFIX = '他{count}枚';
 const EN_SUFFIX = '+{count}';
+
+/** 制御文字はソースに直接書くとファイルごと壊れるので、コードポイントから組み立てる。 */
+const CONTROL_CHAR = String.fromCharCode(1);
 
 describe('movieNameForFiles', () => {
   test('1 件なら拡張子だけ mp4 に替える', () => {
@@ -42,6 +42,57 @@ describe('movieNameForFiles', () => {
 
   test('ファイルが無ければ既定名にする', () => {
     expect(movieNameForFiles([], JA_SUFFIX)).toBe('capture.mp4');
+  });
+
+  test('パス区切り・制御文字を含むファイル名は - に置き換える', () => {
+    const name = movieNameForFiles([`a/b\\c${CONTROL_CHAR}d.png`], JA_SUFFIX);
+
+    expect(name).toBe('a-b-c-d.mp4');
+    expect(presignAccepts(name)).toBe(true);
+  });
+
+  test('上限ぎりぎりの長いファイル名に接尾辞を足しても presign を通る', () => {
+    // 250 文字 base + 「 他3枚」+ .mp4 は素直に繋ぐと 255 文字を超える
+    const long = `${'a'.repeat(250)}.jpg`;
+    const name = movieNameForFiles([long, 'b.jpg', 'c.jpg', 'd.jpg'], JA_SUFFIX);
+
+    expect(name.endsWith(' 他3枚.mp4')).toBe(true);
+    expect(name.length).toBeLessThanOrEqual(255);
+    expect(presignAccepts(name)).toBe(true);
+  });
+
+  test('長いファイル名は 1 件のときも presign を通る長さに収める', () => {
+    const name = movieNameForFiles([`${'あ'.repeat(300)}.png`], JA_SUFFIX);
+
+    expect(name.length).toBeLessThanOrEqual(255);
+    expect(presignAccepts(name)).toBe(true);
+  });
+
+  test('上限内のファイル名は切り詰めずそのまま使う', () => {
+    const base = 'a'.repeat(240);
+
+    expect(movieNameForFiles([`${base}.jpg`], JA_SUFFIX)).toBe(`${base}.mp4`);
+  });
+
+  test('接尾辞が異常に長い辞書値でも上限を超えない', () => {
+    const name = movieNameForFiles(['photo.jpg', 'b.jpg'], 'x'.repeat(400));
+
+    expect(name.length).toBeLessThanOrEqual(255);
+    expect(presignAccepts(name)).toBe(true);
+  });
+
+  test('絵文字入りの長いファイル名でも壊れた文字を残さない', () => {
+    const name = movieNameForFiles([`${'🎬'.repeat(200)}.png`, 'b.png'], JA_SUFFIX);
+
+    // サロゲートペアの片割れ（孤立サロゲート）が残っていないこと
+    const hasLoneSurrogate = [...name].some((char) => {
+      const code = char.charCodeAt(0);
+      return char.length === 1 && code >= 0xd800 && code <= 0xdfff;
+    });
+
+    expect(name.length).toBeLessThanOrEqual(255);
+    expect(hasLoneSurrogate).toBe(false);
+    expect(presignAccepts(name)).toBe(true);
   });
 });
 
@@ -92,7 +143,7 @@ describe('movieNameForUrl', () => {
     ];
 
     for (const url of urls) {
-      expect(isSafeFilename(movieNameForUrl(url))).toBe(true);
+      expect(presignAccepts(movieNameForUrl(url))).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## なぜこの変更が必要か

変換結果の自動命名が弱く、URL 変換は全部 `capture.mp4`、複数画像は先頭ファイル名のみで、履歴やプレビューで見分けられなかった（ユーザー指摘）。

## 変更内容

- 新規 `upload-name.ts`（純関数）: URL 変換 = `{hostname}-{末尾の意味のあるパス}.mp4`（例 `zenn.dev-abc123.mp4`、`index.*` スキップ・クエリ除去・sanitize・80 文字切詰め・パース不能は `capture.mp4`）/ 複数画像 = `{先頭名} 他N枚.mp4`（en: `+N`、i18n テンプレート `convert.batchNameSuffix`）
- 生成名は常に `validatePresignRequest` を通ることを保証（suffix と `.mp4` の長さを確保して base を sanitize + UTF-16 単位で切詰め。従来は 255 文字超で presign 400 → 変換結果破棄だったのが成功に変わる）

## レビュー

codex sol 実施。ブロッキング1件 fix（長いファイル名 + suffix で 255 超 → presign 400 になるケース。250 文字 base で実再現→修正を実証）、改善1件 fix（テストの isSafeFilename 複製を validatePresignRequest 直呼びに変更し契約ドリフトを防止）。

## テスト

- [x] bun test 215 pass（upload-name 25本: 深いパス・クエリ・日本語 URL・長尺・絵文字・パース不能）
- [x] tsc / E2E_PORT=4332 playwright top.spec 12 pass（presign に渡る filename をリクエスト body で検証、期待値を誤らせると落ちる mutation check 済み）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
