### PR TITLE
feat(web): コピー完了フィードバックをボタン切替方式に変更

### DIFF
--- a/web/src/components/MoviePreview.astro
+++ b/web/src/components/MoviePreview.astro
@@ -158,14 +158,16 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
         data-copy-button
         class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-brand-500 px-4 py-2 text-base font-semibold text-white hover:bg-brand-700"
       >
-        <i class="fa-solid fa-copy" aria-hidden="true"></i>
-        <span>{t.preview.copy}</span>
+        <span data-when-copied="idle" class="inline-flex items-center gap-2">
+          <i class="fa-solid fa-copy" aria-hidden="true"></i>
+          <span>{t.preview.copy}</span>
+        </span>
+        <span data-when-copied="copied" role="status" class="inline-flex items-center gap-2">
+          <i class="fa-solid fa-check" aria-hidden="true"></i>
+          <span>{t.preview.copied}</span>
+        </span>
       </button>
     </div>
-    <p data-copied-label class="mt-2 flex items-center gap-2 text-base text-brand-700" role="status">
-      <i class="fa-solid fa-check" aria-hidden="true"></i>
-      <span>{t.preview.copied}</span>
-    </p>
     <p class="mt-2 text-base text-slate-600">{t.preview.playbackHint}</p>
 
     {

--- a/web/src/lib/ui/preview-actions.ts
+++ b/web/src/lib/ui/preview-actions.ts
@@ -9,7 +9,8 @@ import { copyToClipboard } from './clipboard';
 import { consumeAutoCopy } from './auto-copy';
 import { movieEndpoint, pinEndpoint } from './history-view';
 
-const COPIED_FEEDBACK_MS = 2000;
+// 遷移直後の自動コピーでも見逃しにくい長さ（2000ms は短すぎるとの報告で延長）
+const COPIED_FEEDBACK_MS = 4000;
 const RENAME_SAVED_FEEDBACK_MS = 2000;
 
 type Schedule = (callback: () => void, delayMs: number) => void;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -52,9 +52,15 @@
   display: none;
 }
 
-/* コピー完了のフィードバック（2 秒で data-copied が外れる）。 */
-[data-preview]:not([data-copied]) [data-copied-label] {
+/* コピー完了のフィードバック: ボタン自体が「コピーしました」（緑）に切り替わる。
+   自動コピーと手動コピーが同じ data-copied を使うため、見える場所も1つに統一している。 */
+[data-preview]:not([data-copied]) [data-when-copied='copied'],
+[data-preview][data-copied] [data-when-copied='idle'] {
   display: none;
+}
+[data-preview][data-copied] [data-copy-button],
+[data-preview][data-copied] [data-copy-button]:hover {
+  background-color: var(--color-emerald-600, #059669);
 }
 
 /* 履歴ドロップダウンの状態別表示（読み込み中 / 一覧 / 空 / 失敗）。 */


### PR DESCRIPTION
## なぜこの変更が必要か

変換完了 → プレビュー自動遷移時にクリップボードへ自動コピーされるが、完了表示が URL 行下の小さいテキスト 2 秒のみで、コピーされたことに気づきにくい（ユーザー報告）。提示 3 案から「ボタン切替」を採用: ユーザーの視線が向くコピーボタンそのものが変わるため見る場所を探す必要がなく、自動・手動コピーで同じ場所に同じフィードバックが出る。

## 変更内容

- 「URL をコピー」ボタン自体が、コピー成功時に「コピーしました」（チェックアイコン + 緑背景）へ **4 秒間**切り替わる（自動コピー・手動コピー共通）
- 冗長になった別行の「コピーしました」テキストを撤去（表示を 1 箇所に統一）
- 表示時間を 2 秒 → 4 秒に延長（遷移直後でも見逃しにくく）

## テスト

- [x] bun test 225 pass / tsc / playwright 36 pass（自動コピーで copied 表示・reload で再表示しない・手動コピーの各 e2e が新 UI で通過）

## Screenshot

コピー済み状態（緑ボタン）は表示が 4 秒で戻るため静止画は e2e アサーションで代替（`ja.preview.copied` がボタン内に表示されることを検証済み）。通常状態:

![preview](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/63ca169d3481-01-preview-ja-20260826140536-.avif)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
