### PR TITLE
fix(web): 履歴ドロップダウンを外側クリックで閉じ、ヘッダーの並びを整理

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -276,6 +276,23 @@ test.describe('履歴ドロップダウン', () => {
     await expect(menu.getByText(ja.history.empty)).toBeVisible();
   });
 
+  test('外側のクリックで閉じ、内側のクリックでは閉じない', async ({ page }) => {
+    await stubHistory(page, [historyMovie()]);
+    await page.goto('/ja/');
+
+    const menu = page.locator('[data-history-menu]');
+    await menu.locator('summary').click();
+    await expect(menu.locator('[data-history-row]')).toHaveCount(1);
+
+    // exact 指定は「変換した動画はまだありません」（空表示）との二重マッチを避けるため
+    await menu.getByText(ja.history.heading, { exact: true }).click();
+    await expect(menu).toHaveJSProperty('open', true);
+
+    // メニューから離れた位置を直接クリックする（間に何が描かれていても外側だと分かる座標）
+    await page.mouse.click(20, 500);
+    await expect(menu).toHaveJSProperty('open', false);
+  });
+
   test('行の削除は確認してから実行し、一覧から消える', async ({ page }) => {
     await stubHistory(page, [historyMovie(), historyMovie({ shortId: 'E2EOther0002' })]);
     await page.route('**/api/movies/*/', (route) =>
@@ -291,6 +308,8 @@ test.describe('履歴ドロップダウン', () => {
     await rows.first().getByRole('button', { name: ja.actions.deleteYes }).click();
 
     await expect(rows).toHaveCount(1);
+    // 削除は行を DOM から外すので、外側クリック判定が誤発火して閉じないこと
+    await expect(menu).toHaveJSProperty('open', true);
   });
 
   test('取得に失敗したらエラーを出す', async ({ page }) => {

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -55,8 +55,20 @@ const LOGOUT_URL = '/api/auth/logout/';
       <div data-auth-only="member" class="flex items-center gap-2">
         <HistoryDropdown lang={lang} />
 
+        <form method="post" action={LOGOUT_URL}>
+          <input type="hidden" name="lang" value={lang} />
+          <button
+            type="submit"
+            class="inline-flex items-center gap-2 whitespace-nowrap rounded-md border border-slate-300 px-3 py-2 text-base font-semibold text-slate-800 hover:bg-slate-100"
+          >
+            <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
+            <span>{t.nav.logout}</span>
+          </button>
+        </form>
+
         {/* アバターは本人確認の目印なので表示のみ。操作はログアウトの 1 つだけなので */}
         {/* ドロップダウンに畳まず、履歴と並べて常時見えるボタンにしている。 */}
+        {/* 並びの右端に置くのは、操作ボタン（履歴・ログアウト）と役割が違うため。 */}
         <span class="flex items-center">
           <span
             data-viewer-initial
@@ -74,17 +86,6 @@ const LOGOUT_URL = '/api/auth/logout/';
           {/* 名前は表示しないが、支援技術向けに残す（JS が実名で上書きする）。 */}
           <span data-viewer-name class="sr-only">{t.nav.account}</span>
         </span>
-
-        <form method="post" action={LOGOUT_URL}>
-          <input type="hidden" name="lang" value={lang} />
-          <button
-            type="submit"
-            class="inline-flex items-center gap-2 whitespace-nowrap rounded-md border border-slate-300 px-3 py-2 text-base font-semibold text-slate-800 hover:bg-slate-100"
-          >
-            <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
-            <span>{t.nav.logout}</span>
-          </button>
-        </form>
       </div>
     </div>
   </div>

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -133,4 +133,15 @@ export function mountHistoryMenu(root: HTMLDetailsElement, fetchImpl: typeof fet
   root.addEventListener('toggle', () => {
     if (root.open) void load(root, fetchImpl);
   });
+
+  // details はネイティブでは外側クリックで閉じないので document 側で拾う。
+  // contains() ではなく composedPath() を見るのは、行の削除が先に row.remove() を
+  // 走らせた場合にクリック対象が DOM から外れ、内側のクリックが「外側」と誤判定される
+  // ため（composedPath は dispatch 時点の経路を保持する）。
+  // note: 解除口は設けていない。MPA なのでページ遷移ごとに 1 回しか mount されない
+  document.addEventListener('click', (event) => {
+    if (!root.open) return;
+    if (event.composedPath().includes(root)) return;
+    root.open = false;
+  });
 }


### PR DESCRIPTION
## なぜこの変更が必要か

履歴ドロップダウンを開いた後、閉じる手段が「履歴ボタンをもう一度押す」しかなかった。ドロップダウンは外側を押せば閉じるのが一般的な挙動で、別の場所を押しても開いたままだと下のコンテンツが隠れ続ける。

あわせてヘッダー右上の並びを整理した。操作ボタン（履歴・ログアウト）と、状態表示でしかないアバターが交互に並んでいたため、役割ごとにまとまる順序にした。

## 変更内容

- 履歴ドロップダウン（`<details data-history-menu>`）を外側クリックで閉じるようにした
- ヘッダーの並びを `[履歴] [アバター] [ログアウト]` から `[履歴] [ログアウト] [アバター]` に変更した
- E2E に「外側で閉じる / 内側では閉じない」を追加し、既存の削除テストにも「削除後に閉じない」assert を足した

## 意思決定

### 採用アプローチ

- 開いている間だけ `document` の click を見て `root.open = false` にする。`<details>` のネイティブ挙動には外側クリックでの close がないため
- 内外判定に `event.composedPath().includes(root)` を使う。理由: 行削除は `row.remove()` を先に走らせるため、`root.contains(target)` だと DOM から外れたノードが「外側」と誤判定され、削除のたびにメニューが閉じてしまう

### 却下した代替案

- `blur` / `focusout` で閉じる → 却下: 削除確認ボタンへフォーカスが移った時にも閉じてしまう
- リスナーの解除口（unmount API）を用意する → 却下: MPA ではページ遷移ごとに 1 回しか mount されず蓄積しない。使われない API を増やさない

### トレードオフ

- `document` レベルのリスナー 1 つ > 完全な teardown: 上記のとおり蓄積しないため、解除口のコストに見合わない（意図的に省いた旨をコード内に note で残した）

## テスト

- [x] `bun test` — 225 passed / 0 failed
- [x] `tsc --noEmit` — エラーなし
- [x] `playwright e2e/preview.spec.ts -g 履歴ドロップダウン` — 5 passed（外側で閉じる / 内側で閉じない / 削除後も閉じない）
- [x] `playwright e2e/top.spec.ts` — 12 passed（ヘッダー並び替えによる回帰なし）

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/536d376f441c-before-header.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/b24ff0584025-03-history-ja-20260826140459-.avif) |

Before はデプロイ済み環境、After は E2E のローカル環境で撮影したもの。ヘッダー右上の並びが `[履歴] [ログアウト] [アバター]` に変わっている。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
