### PR TITLE
feat(web): ヘッダー並び替えと履歴ドロップダウンの外側クリック閉じ（別セッション分の取り込み）

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -276,6 +276,23 @@ test.describe('履歴ドロップダウン', () => {
     await expect(menu.getByText(ja.history.empty)).toBeVisible();
   });
 
+  test('外側のクリックで閉じ、内側のクリックでは閉じない', async ({ page }) => {
+    await stubHistory(page, [historyMovie()]);
+    await page.goto('/ja/');
+
+    const menu = page.locator('[data-history-menu]');
+    await menu.locator('summary').click();
+    await expect(menu.locator('[data-history-row]')).toHaveCount(1);
+
+    // exact 指定は「変換した動画はまだありません」（空表示）との二重マッチを避けるため
+    await menu.getByText(ja.history.heading, { exact: true }).click();
+    await expect(menu).toHaveJSProperty('open', true);
+
+    // メニューから離れた位置を直接クリックする（間に何が描かれていても外側だと分かる座標）
+    await page.mouse.click(20, 500);
+    await expect(menu).toHaveJSProperty('open', false);
+  });
+
   test('行の削除は確認してから実行し、一覧から消える', async ({ page }) => {
     await stubHistory(page, [historyMovie(), historyMovie({ shortId: 'E2EOther0002' })]);
     await page.route('**/api/movies/*/', (route) =>
@@ -291,6 +308,8 @@ test.describe('履歴ドロップダウン', () => {
     await rows.first().getByRole('button', { name: ja.actions.deleteYes }).click();
 
     await expect(rows).toHaveCount(1);
+    // 削除は行を DOM から外すので、外側クリック判定が誤発火して閉じないこと
+    await expect(menu).toHaveJSProperty('open', true);
   });
 
   test('取得に失敗したらエラーを出す', async ({ page }) => {

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -55,8 +55,20 @@ const LOGOUT_URL = '/api/auth/logout/';
       <div data-auth-only="member" class="flex items-center gap-2">
         <HistoryDropdown lang={lang} />
 
+        <form method="post" action={LOGOUT_URL}>
+          <input type="hidden" name="lang" value={lang} />
+          <button
+            type="submit"
+            class="inline-flex items-center gap-2 whitespace-nowrap rounded-md border border-slate-300 px-3 py-2 text-base font-semibold text-slate-800 hover:bg-slate-100"
+          >
+            <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
+            <span>{t.nav.logout}</span>
+          </button>
+        </form>
+
         {/* アバターは本人確認の目印なので表示のみ。操作はログアウトの 1 つだけなので */}
         {/* ドロップダウンに畳まず、履歴と並べて常時見えるボタンにしている。 */}
+        {/* 並びの右端に置くのは、操作ボタン（履歴・ログアウト）と役割が違うため。 */}
         <span class="flex items-center">
           <span
             data-viewer-initial
@@ -74,17 +86,6 @@ const LOGOUT_URL = '/api/auth/logout/';
           {/* 名前は表示しないが、支援技術向けに残す（JS が実名で上書きする）。 */}
           <span data-viewer-name class="sr-only">{t.nav.account}</span>
         </span>
-
-        <form method="post" action={LOGOUT_URL}>
-          <input type="hidden" name="lang" value={lang} />
-          <button
-            type="submit"
-            class="inline-flex items-center gap-2 whitespace-nowrap rounded-md border border-slate-300 px-3 py-2 text-base font-semibold text-slate-800 hover:bg-slate-100"
-          >
-            <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
-            <span>{t.nav.logout}</span>
-          </button>
-        </form>
       </div>
     </div>
   </div>

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -133,4 +133,15 @@ export function mountHistoryMenu(root: HTMLDetailsElement, fetchImpl: typeof fet
   root.addEventListener('toggle', () => {
     if (root.open) void load(root, fetchImpl);
   });
+
+  // details はネイティブでは外側クリックで閉じないので document 側で拾う。
+  // contains() ではなく composedPath() を見るのは、行の削除が先に row.remove() を
+  // 走らせた場合にクリック対象が DOM から外れ、内側のクリックが「外側」と誤判定される
+  // ため（composedPath は dispatch 時点の経路を保持する）。
+  // note: 解除口は設けていない。MPA なのでページ遷移ごとに 1 回しか mount されない
+  document.addEventListener('click', (event) => {
+    if (!root.open) return;
+    if (event.composedPath().includes(root)) return;
+    root.open = false;
+  });
 }


### PR DESCRIPTION
## なぜこの変更が必要か

別セッションで実装済み・未 push だった UI 改善 2 件をユーザー指示により本番へ届ける（ローカル main に滞留していたコミットを cherry-pick で PR フローに載せたもの。実装内容は変更していない）。

## 変更内容

- ヘッダー（ログイン後）の並びを [履歴][ログアウト][アバター] に変更（操作ボタンを左にまとめ、状態表示のアバターを右端へ）
- 履歴ドロップダウンを開いたままウィンドウの外側をクリックすると閉じるように（composedPath 判定で行削除時の誤判定を回避、e2e 付き）

## テスト

- [x] bun test 225 pass / tsc / E2E_PORT=4342 playwright 37 pass（外側クリックで閉じる e2e 含む）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
