### PR TITLE
feat(web): リネームの長すぎエラーに理由と文字数を表示

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -186,6 +186,30 @@ test.describe('所有者の操作', () => {
     await expect(input).toBeHidden();
   });
 
+  test('長すぎるファイル名は保存せず、文字数入りの理由を表示する', async ({ page, context }) => {
+    let patchRequested = false;
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.goto(`/${E2E_FIXTURES.pinnedShortId}/`);
+    page.on('request', (request) => {
+      if (request.method() === 'PATCH' && request.url().includes('/api/movies/')) {
+        patchRequested = true;
+      }
+    });
+
+    await page.getByRole('button', { name: ja.preview.rename }).click();
+    const input = page.locator('[data-filename-input]');
+    const longName = `${'あ'.repeat(256)}.mp4`;
+    await input.fill(longName);
+    await input.press('Enter');
+
+    const expected = ja.preview.renameTooLong
+      .replace('{count}', String(longName.length))
+      .replace('{max}', '255');
+    await expect(page.locator('[data-rename-failed]')).toHaveText(expected);
+    await expect(input).toBeVisible();
+    expect(patchRequested).toBe(false);
+  });
+
   test('編集中に Escape を押すと元の名前へ戻し保存しない', async ({ page, context }) => {
     let patchRequested = false;
     await signIn(context, E2E_FIXTURES.ownerId);

--- a/web/src/components/MoviePreview.astro
+++ b/web/src/components/MoviePreview.astro
@@ -1,5 +1,6 @@
 ---
 import { useTranslations, type Locale } from '../i18n';
+import { MAX_FILENAME_LENGTH } from '../lib/contracts/api';
 import { MAX_PINNED_MOVIES } from '../lib/services/quota';
 import { remainingDays } from '../lib/ui/history-view';
 
@@ -38,6 +39,7 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
   data-msg-pin-limit={pinLimitMessage}
   data-msg-pin-failed={t.preview.pinFailed}
   data-msg-rename-failed={t.preview.renameFailed}
+  data-msg-rename-too-long={t.preview.renameTooLong.replace('{max}', String(MAX_FILENAME_LENGTH))}
   data-label-rename={t.preview.rename}
   data-label-rename-save={t.preview.renameSave}
   data-label-rename-saved={t.preview.renameSaved}

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -71,6 +71,7 @@
     "renameSave": "Save",
     "renameSaved": "Saved",
     "renameFailed": "Could not rename the file",
+    "renameTooLong": "File name is too long ({count} / max {max} characters)",
     "notFoundHeading": "Video not found",
     "notFoundLead": "The URL may be wrong, or the video may have been removed after its retention period.",
     "backHome": "Back to the home page",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -71,6 +71,7 @@
     "renameSave": "保存",
     "renameSaved": "保存済み",
     "renameFailed": "ファイル名を変更できませんでした",
+    "renameTooLong": "ファイル名が長すぎます（{count} / 上限 {max} 文字）",
     "notFoundHeading": "動画が見つかりません",
     "notFoundLead": "URL が間違っているか、保管期限が過ぎて削除された可能性があります。",
     "backHome": "トップへ戻る",

--- a/web/src/lib/ui/preview-actions.ts
+++ b/web/src/lib/ui/preview-actions.ts
@@ -5,6 +5,7 @@
  * 文言は HTML に埋め込まれた辞書の値を読むだけで、ここに日本語 / 英語を書かない。
  */
 
+import { MAX_FILENAME_LENGTH } from '../contracts/api';
 import { copyToClipboard } from './clipboard';
 import { consumeAutoCopy } from './auto-copy';
 import { movieEndpoint, pinEndpoint } from './history-view';
@@ -115,6 +116,19 @@ function wireRename(root: HTMLElement, fetchImpl: typeof fetch, schedule: Schedu
     const filename = input.value.trim();
     if (filename.length === 0 || filename === originalFilename) {
       cancel();
+      return;
+    }
+
+    // 長すぎは送信前に弾き、理由と現在の文字数を出す（サーバー 400 は防御層として残る）。
+    if (filename.length > MAX_FILENAME_LENGTH) {
+      if (failure) {
+        failure.textContent = (root.dataset['msgRenameTooLong'] ?? '').replace(
+          '{count}',
+          String(filename.length)
+        );
+        failure.hidden = false;
+      }
+      input.focus();
       return;
     }
 


### PR DESCRIPTION
## なぜこの変更が必要か

リネームで長すぎるファイル名を入れた時に汎用の「変更できませんでした」しか出ず、原因と直し方が分からない（ユーザー報告）。

## 変更内容

- 保存前にクライアントで長さを検証し、「ファイル名が長すぎます（{count} / 上限 255 文字）」を表示（現在の文字数入り。編集状態を維持して直せる）。サーバー側 400 は防御層として維持
- i18n `preview.renameTooLong` を ja/en に追加

## 確認事項（ユーザー質問への回答）

「ファイル名が長いものがアップロードされた時にエラーが出ないこと」→ **担保済み**。自動命名は生成時に上限へ切り詰めて `validatePresignRequest` を必ず通る設計（PR #28）で、`tests/ui/upload-name.test.ts` の 250 文字 base + 複数枚ケースが常時検証している。

## テスト

- [x] bun test 225 pass / tsc / playwright 38 pass（256 文字入力 → 件数入りメッセージ表示 + PATCH 不送信の e2e 追加）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
