### PR TITLE
feat(web): URL 変換のキャプチャ待ち中に疑似進捗を表示

### DIFF
--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -21,6 +21,15 @@ import { movieNameForFiles, movieNameForUrl } from './upload-name';
 /** data-batch-name-suffix が無いときの接尾辞（ロケール非依存で読める形）。 */
 const DEFAULT_BATCH_NAME_SUFFIX = '+{count}';
 
+/**
+ * URL 変換のキャプチャ待ち（数十秒）は進捗イベントが一切来ないため、バーが 0% で静止する。
+ * その間だけ疑似進捗をゆっくり進めて「動いている」ことを示す。実進捗を先取りしないよう
+ * 上限は低く抑え、キャプチャ完了後は実進捗（conversionProgress）へ引き継ぐ。
+ */
+const CAPTURE_PSEUDO_PROGRESS_INTERVAL_MS = 800;
+const CAPTURE_PSEUDO_PROGRESS_START = 2;
+const CAPTURE_PSEUDO_PROGRESS_MAX = 12;
+
 type Dispatch = (event: UploadEvent, runGeneration?: number) => void;
 type Navigate = (url: string) => void;
 
@@ -256,12 +265,24 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     if (state.phase === 'converting' || state.phase === 'uploading') return;
     dispatch({ type: 'selectUrl', url });
     const current = generation;
+
+    let pseudoProgress = CAPTURE_PSEUDO_PROGRESS_START - 1;
+    const pseudoTimer = window.setInterval(() => {
+      pseudoProgress += 1;
+      dispatch({ type: 'progress', value: pseudoProgress }, current);
+      if (pseudoProgress >= CAPTURE_PSEUDO_PROGRESS_MAX) window.clearInterval(pseudoTimer);
+    }, CAPTURE_PSEUDO_PROGRESS_INTERVAL_MS);
+
     void requestJson('/api/capture/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url }),
     })
       .then(asCaptureResponse)
+      // 成功・失敗のどちらでも疑似進捗を必ず止める（ここから先は実進捗が来る）。
+      .finally(() => {
+        window.clearInterval(pseudoTimer);
+      })
       .then((capture) => convertImageUrlsToMp4(capture.images, (progress) => {
         dispatch({ type: 'conversionProgress', ...progress }, current);
       }))

--- a/web/src/lib/ui/upload-flow.ts
+++ b/web/src/lib/ui/upload-flow.ts
@@ -135,11 +135,14 @@ export function reduceUpload(state: UploadState, event: UploadEvent): UploadStat
 
     case 'conversionProgress': {
       if (state.phase !== 'converting' || event.total <= 0 || event.current < 0) return state;
+      // URL 変換ではキャプチャ待ちの間だけ疑似進捗でバーを進めるため、実進捗の初回値
+      // （1/30 = 3% など）の方が小さくなりうる。バーの逆戻りを避けて大きい方を採る。
+      // converted で progress は 0 に戻るので、この下限が次のフェーズへ漏れることはない。
       return {
         ...state,
         current: Math.min(event.current, event.total),
         total: event.total,
-        progress: clampProgress((event.current / event.total) * 100),
+        progress: Math.max(state.progress, clampProgress((event.current / event.total) * 100)),
       };
     }
 

--- a/web/tests/ui/upload-flow.test.ts
+++ b/web/tests/ui/upload-flow.test.ts
@@ -156,6 +156,53 @@ describe('URL からの変換', () => {
   });
 });
 
+describe('変換ページの進捗', () => {
+  function convertingUrl(): UploadState {
+    return reduceUpload(INITIAL_UPLOAD_STATE, { type: 'selectUrl', url: 'https://example.com' });
+  }
+
+  test('現在位置と総数から進捗率を出す', () => {
+    const state = reduceUpload(select('slides.pdf'), {
+      type: 'conversionProgress',
+      current: 3,
+      total: 10,
+    });
+
+    expect(state.progress).toBe(30);
+    expect(state.current).toBe(3);
+    expect(state.total).toBe(10);
+  });
+
+  test('実進捗が疑似進捗より小さくてもバーは戻さず、現在位置と総数だけ更新する', () => {
+    const pseudo = reduceUpload(convertingUrl(), { type: 'progress', value: 12 });
+
+    const state = reduceUpload(pseudo, { type: 'conversionProgress', current: 1, total: 30 });
+
+    expect(state.progress).toBe(12);
+    expect(state.current).toBe(1);
+    expect(state.total).toBe(30);
+  });
+
+  test('実進捗が疑似進捗を追い越したら実進捗の値になる', () => {
+    let state = reduceUpload(convertingUrl(), { type: 'progress', value: 12 });
+    state = reduceUpload(state, { type: 'conversionProgress', current: 1, total: 30 });
+
+    state = reduceUpload(state, { type: 'conversionProgress', current: 5, total: 30 });
+
+    expect(state.progress).toBe(17);
+    expect(state.current).toBe(5);
+  });
+
+  test('変換中でなければ進捗イベントを無視する', () => {
+    const uploading = reduceUpload(select('slides.pdf'), { type: 'converted' });
+    expect(uploading.phase).toBe('uploading');
+
+    expect(reduceUpload(uploading, { type: 'conversionProgress', current: 1, total: 4 })).toBe(
+      uploading
+    );
+  });
+});
+
 describe('変換対象の上限', () => {
   test('複数ファイルのどれかが 50 MB を超えると変換前に拒否する', () => {
     const state = reduceUpload(INITIAL_UPLOAD_STATE, {


### PR DESCRIPTION
## なぜこの変更が必要か

URL 変換はサーバー側キャプチャ（数十秒）の間、進捗イベントが一切来ないため「変換しています 0%」+ 空バーで静止し、その後一気に進む。0% で止まっていると動いているのか分からない（ユーザー報告・スクショあり）。

## 変更内容

- キャプチャ待ちの間だけ疑似進捗を進める: 800ms ごとに 2% → +1% ずつ、上限 12% で自停止。キャプチャ完了・失敗のどちらでも `.finally` で確実に停止し、以降は実進捗（conversionProgress）へ引き継ぐ
- 実進捗の初回値（例 1/30 = 3%）が疑似進捗より小さい時にバーが逆戻りしないよう、`conversionProgress` reducer に単調増加ガード（max 採用）を追加。N/M カウントは実値のまま。`converted` の 0% リセットは維持

## テスト

- [x] bun test 229 pass（conversionProgress の reducer テスト 4 本を新設: % 計算 / 単調増加ガード / 実進捗の追い越し / converting 以外で無視）
- [x] tsc / playwright top.spec 12 pass（URL 変換テストが interval 残骸で落ちないこと）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
