### PR TITLE
refactor(web): movies API の公開型・バリデータを contracts/api.ts へ集約

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -24,12 +24,10 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `GET /api/me/` | ログイン中のユーザー情報 | 本人 | — |
 | `POST /api/uploads/presign/` | R2 へのアップロード先を払い出し、movies に `pending` 行を作る | 本人 | `PresignRequest` / `PresignResponse` |
 | `POST /api/uploads/commit/` | アップロード完了を確定し `ready` にする | 本人（当該 movie の所有者） | `CommitRequest` / `CommitResponse` |
-| `GET /api/history/` | 自分の動画一覧 | 本人 | — |
-| `POST /api/movies/{shortId}/pin/` | pin の切り替え（自動削除の対象外にする） | 本人（所有者） | — |
+| `GET /api/history/` | 自分の動画一覧 | 本人 | `HistoryResponse` |
+| `POST /api/movies/{shortId}/pin/` | pin の切り替え（自動削除の対象外にする） | 本人（所有者） | `PinResponse` |
+| `PATCH /api/movies/{shortId}/` | ファイル名の変更 | 本人（所有者） | `RenameMovieRequest` / `RenameMovieResponse` |
 | `DELETE /api/movies/{shortId}/` | 動画の削除（R2 の実体 → D1 の行の順） | 本人（所有者） | — |
-
-`GET /api/history/` / pin / delete の型は `web/src/lib/services/movies.ts` が持つ（contracts/api.ts が
-別タスクで凍結中のための暫定。解凍後に contracts へ移す）。
 
 エラーは全経路で `ErrorResponse`（`errorCode` + `message`）を返す。
 

--- a/web/src/lib/contracts/api.ts
+++ b/web/src/lib/contracts/api.ts
@@ -113,6 +113,47 @@ export interface CaptureResponse {
 }
 
 // ---------------------------------------------------------------------------
+// 動画メタデータ — GET /api/history/, POST /api/movies/{shortId}/pin/,
+//                 PATCH /api/movies/{shortId}/
+// ---------------------------------------------------------------------------
+
+/** 履歴 1 件。外部公開フィールドなので camelCase（D1 の snake_case は services/movies.ts で変換する）。 */
+export interface HistoryEntry {
+  shortId: string;
+  filename: string;
+  status: MovieStatus;
+  pinned: boolean;
+  /** ISO8601。D1 の DEFAULT datetime('now') は UTC の "YYYY-MM-DD HH:MM:SS" なので境界で正規化する。 */
+  createdAt: string;
+  /** ISO8601。pin 中は null（自動削除の対象外）。 */
+  expiresAt: string | null;
+  publicUrl: string;
+}
+
+/** `GET /api/history/` の応答。配列を直接返さず包むのは、後で件数などを足せるようにするため。 */
+export interface HistoryResponse {
+  movies: HistoryEntry[];
+}
+
+/** `POST /api/movies/{shortId}/pin/` の応答。 */
+export interface PinResponse {
+  shortId: string;
+  pinned: boolean;
+  expiresAt: string | null;
+}
+
+/** `PATCH /api/movies/{shortId}/` のリクエスト。 */
+export interface RenameMovieRequest {
+  filename: string;
+}
+
+/** ファイル名変更の応答。 */
+export interface RenameMovieResponse {
+  shortId: string;
+  filename: string;
+}
+
+// ---------------------------------------------------------------------------
 // バリデータ
 // ---------------------------------------------------------------------------
 
@@ -226,4 +267,24 @@ function isHttpUrl(value: string): boolean {
     return false;
   }
   return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
+
+/**
+ * ファイル名変更のリクエストを検証する。
+ *
+ * 前後の空白は UI 由来で混ざりやすいので落として受理し、trim 後の値を正とする
+ * （サービス層は検証済みの値をそのまま保存する）。
+ */
+export function validateRenameMovieRequest(input: unknown): ValidationResult<RenameMovieRequest> {
+  const body = asRecord(input);
+  if (!body) return invalid('リクエストボディは JSON オブジェクトである必要があります');
+
+  const { filename } = body;
+  if (typeof filename !== 'string') return invalid('filename が不正です');
+
+  // 空文字と MAX_FILENAME_LENGTH 超も isSafeFilename が弾く（空白のみは trim 後に空文字になる）。
+  const trimmed = filename.trim();
+  if (!isSafeFilename(trimmed)) return invalid('filename が不正です');
+
+  return { ok: true, value: { filename: trimmed } };
 }

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -3,48 +3,22 @@
  *
  * 履歴とプレビューページ（/{shortId}/）の両方がここを通る。SQL とビジネス規則を
  * 1 箇所に閉じ込め、エントリポイント（pages/）は HTTP との I/O 変換だけを担う。
- *
- * 型を contracts/ ではなくここに置いているのは、contracts/ が別タスクで凍結中のため。
- * 契約が解凍されたら HistoryEntry / PinResponse は contracts/api.ts へ移す。
  */
 
 import {
   ERROR_CODES,
-  isSafeFilename,
-  MAX_FILENAME_LENGTH,
   type ErrorCode,
+  type HistoryEntry,
+  type HistoryResponse,
   type MovieStatus,
+  type PinResponse,
+  type RenameMovieResponse,
 } from '../contracts/api';
 import { isShortId, movieKey } from '../contracts/r2key';
 import { MAX_PINNED_MOVIES, MOVIE_RETENTION_MS, UNPIN_GRACE_MS } from './quota';
 
 /** 履歴に返す最大件数。ドロップダウンで一覧できる範囲に抑える。 */
 export const HISTORY_LIMIT = 50;
-
-/** 履歴 1 件。外部公開フィールドなので camelCase（D1 の snake_case は本ファイルで変換する）。 */
-export interface HistoryEntry {
-  shortId: string;
-  filename: string;
-  status: MovieStatus;
-  pinned: boolean;
-  /** ISO8601。D1 の DEFAULT datetime('now') は UTC の "YYYY-MM-DD HH:MM:SS" なのでここで正規化する。 */
-  createdAt: string;
-  /** ISO8601。pin 中は null（自動削除の対象外）。 */
-  expiresAt: string | null;
-  publicUrl: string;
-}
-
-/** `GET /api/history/` の応答。配列を直接返さず包むのは、後で件数などを足せるようにするため。 */
-export interface HistoryResponse {
-  movies: HistoryEntry[];
-}
-
-/** `POST /api/movies/{shortId}/pin/` の応答。 */
-export interface PinResponse {
-  shortId: string;
-  pinned: boolean;
-  expiresAt: string | null;
-}
 
 /** プレビューページが描画に使う、公開済み（ready）の 1 件。 */
 export interface PublicMovie {
@@ -112,12 +86,6 @@ export interface MovieActionInput {
   shortId: string;
 }
 
-/** ファイル名変更の応答。 */
-export interface RenameMovieResponse {
-  shortId: string;
-  filename: string;
-}
-
 /** 自分の movies を新しい順に返す（未完了の pending も進捗確認のために含める）。 */
 export async function listHistory(input: ListHistoryInput): Promise<HistoryResponse> {
   // created_at は秒精度なので、同一秒の挿入で並びが揺れないよう short_id を第 2 キーにする。
@@ -170,30 +138,22 @@ export async function togglePin(
   return { shortId: input.shortId, pinned: nextPinned, expiresAt };
 }
 
-/** 所有者の動画の表示名を変更する。 */
+/**
+ * 所有者の動画の表示名を変更する。
+ *
+ * filename は検証済み（validateRenameMovieRequest 通過後）の値を受け取る前提。
+ * 形式の正本は contracts/api.ts なので、ここでは所有者チェックだけを行う。
+ */
 export async function renameMovie(
-  input: MovieActionInput & { filename: unknown }
+  input: MovieActionInput & { filename: string }
 ): Promise<RenameMovieResponse> {
-  if (typeof input.filename !== 'string') {
-    throw new MovieActionError(400, ERROR_CODES.invalidRequest, 'filename が不正です');
-  }
-
-  const filename = input.filename.trim();
-  if (
-    filename.length === 0 ||
-    filename.length > MAX_FILENAME_LENGTH ||
-    !isSafeFilename(filename)
-  ) {
-    throw new MovieActionError(400, ERROR_CODES.invalidRequest, 'filename が不正です');
-  }
-
   await findOwnedMovie(input.database, input.userId, input.shortId);
   await input.database
     .prepare('UPDATE movies SET filename = ? WHERE short_id = ? AND user_id = ?')
-    .bind(filename, input.shortId, input.userId)
+    .bind(input.filename, input.shortId, input.userId)
     .run();
 
-  return { shortId: input.shortId, filename };
+  return { shortId: input.shortId, filename: input.filename };
 }
 
 /**

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -6,7 +6,7 @@
  * 古い一覧のまま見せないため。
  */
 
-import type { HistoryEntry } from '../services/movies';
+import type { HistoryEntry } from '../contracts/api';
 import {
   HISTORY_ENDPOINT,
   formatRelativeTime,

--- a/web/src/lib/ui/history-view.ts
+++ b/web/src/lib/ui/history-view.ts
@@ -6,8 +6,7 @@
  * bun test で検証する。
  */
 
-import type { HistoryEntry } from '../services/movies';
-import { MOVIE_STATUSES, type MovieStatus } from '../contracts/api';
+import { MOVIE_STATUSES, type HistoryEntry, type MovieStatus } from '../contracts/api';
 
 /** trailingSlash: 'always' のためスラッシュ必須。省くと 301 を挟む。 */
 export const HISTORY_ENDPOINT = '/api/history/';

--- a/web/src/pages/api/movies/[shortId]/index.ts
+++ b/web/src/pages/api/movies/[shortId]/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 
-import { ERROR_CODES } from '../../../../lib/contracts/api';
+import { ERROR_CODES, validateRenameMovieRequest } from '../../../../lib/contracts/api';
 import { importSigningKey } from '../../../../lib/contracts/session';
 import { requireUser, type AuthDatabase } from '../../../../lib/services/auth';
 import {
@@ -42,16 +42,15 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     return invalidRequest('リクエストボディは JSON である必要があります');
   }
 
-  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
-    return invalidRequest('リクエストボディは JSON オブジェクトである必要があります');
-  }
+  const validated = validateRenameMovieRequest(body);
+  if (!validated.ok) return Response.json(validated.error, { status: 400 });
 
   try {
     const response = await renameMovie({
       database: bindings.DB,
       userId: result.user.id,
       shortId: params.shortId ?? '',
-      filename: (body as { filename?: unknown }).filename,
+      filename: validated.value.filename,
     });
     return Response.json(response);
   } catch (error) {

--- a/web/tests/contracts/api.test.ts
+++ b/web/tests/contracts/api.test.ts
@@ -140,6 +140,9 @@ describe('validateRenameMovieRequest', () => {
     ['filename が空白のみ', { filename: '   ' }],
     ['filename が 256 文字', { filename: 'a'.repeat(256) }],
     ['filename がパス区切りを含む', { filename: 'folder/file.mp4' }],
+    // isSafeFilename を通していることの確認。全パターンは validatePresignRequest 側で網羅する。
+    ['filename が親ディレクトリ参照', { filename: '..' }],
+    ['filename が RTL override を含む', { filename: 'report\u202egpj.exe' }],
     ['filename が欠落', {}],
     ['filename が数値', { filename: 42 }],
     ['ボディが配列', []],

--- a/web/tests/contracts/api.test.ts
+++ b/web/tests/contracts/api.test.ts
@@ -8,6 +8,7 @@ import {
   validateCaptureRequest,
   validateCommitRequest,
   validatePresignRequest,
+  validateRenameMovieRequest,
 } from '../../src/lib/contracts/api';
 
 const VALID_SHORT_ID = 'aB3dE5fG7hJ9';
@@ -123,5 +124,30 @@ describe('validateCaptureRequest', () => {
     ['width が小数', { url: 'https://example.com/', width: 640.5 }],
   ])('%s は拒否する', (_label, input) => {
     expect(validateCaptureRequest(input).ok).toBe(false);
+  });
+});
+
+describe('validateRenameMovieRequest', () => {
+  test('前後の空白を落として受理する', () => {
+    expect(validateRenameMovieRequest({ filename: ' renamed.mp4 ' })).toEqual({
+      ok: true,
+      value: { filename: 'renamed.mp4' },
+    });
+  });
+
+  test.each([
+    ['filename が空文字', { filename: '' }],
+    ['filename が空白のみ', { filename: '   ' }],
+    ['filename が 256 文字', { filename: 'a'.repeat(256) }],
+    ['filename がパス区切りを含む', { filename: 'folder/file.mp4' }],
+    ['filename が欠落', {}],
+    ['filename が数値', { filename: 42 }],
+    ['ボディが配列', []],
+    ['ボディが null', null],
+  ])('%s は INVALID_REQUEST で拒否する', (_label, input) => {
+    expect(validateRenameMovieRequest(input)).toMatchObject({
+      ok: false,
+      error: { errorCode: ERROR_CODES.invalidRequest },
+    });
   });
 });

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -242,27 +242,13 @@ describe('togglePin', () => {
 });
 
 describe('renameMovie', () => {
-  it('所有者のファイル名を trim して変更する', async () => {
+  it('所有者のファイル名を変更する', async () => {
     const database = new FakeMoviesDatabase([movie()]);
 
     await expect(
-      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename: ' renamed.mp4 ' })
+      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
     ).resolves.toEqual({ shortId: SHORT_ID, filename: 'renamed.mp4' });
     expect(database.movies.get(SHORT_ID)?.filename).toBe('renamed.mp4');
-  });
-
-  it.each([
-    ['', '空文字'],
-    ['   ', '空白のみ'],
-    ['a'.repeat(256), '256 文字'],
-    ['folder/file.mp4', 'パス区切り'],
-  ])('%s（%s）は 400 で拒否する', async (filename) => {
-    const database = new FakeMoviesDatabase([movie()]);
-
-    await expect(
-      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename })
-    ).rejects.toMatchObject({ status: 400, errorCode: 'INVALID_REQUEST' });
-    expect(database.movies.get(SHORT_ID)?.filename).toBe('slides.pdf');
   });
 
   it('他人の動画は 404 で拒否する', async () => {


### PR DESCRIPTION
## なぜこの変更が必要か

`web/src/lib/services/movies.ts` の冒頭には「contracts/ が別タスクで凍結中のため、型をここに置いている。解凍されたら contracts/api.ts へ移す」という TODO が残っており、`docs/api-contracts.md` にも同じ暫定措置が明記されていた。凍結は解けているのに暫定状態が残り続け、リネーム機能の PR ではさらに `RenameMovieResponse` が同じ場所に足された（レビューで指摘）。

公開 API の型は producer（Worker のハンドラ）と consumer（ブラウザ JS）をまたぐ契約で、正本が 2 箇所に分かれていると「どちらを見ればいいか」が判断できなくなる。暫定の解消がこれ以上先送りされる前に、契約の正本を `contracts/api.ts` に一本化する。

## 変更内容

- `HistoryEntry` / `HistoryResponse` / `PinResponse` / `RenameMovieResponse` を `services/movies.ts` から `contracts/api.ts` へ移設
- rename の入力検証を `validateRenameMovieRequest` として contracts に切り出し、`renameMovie` からは検証を削除（検証済みの `filename: string` を受ける形に変更）
- PATCH ハンドラの型キャスト（`(body as { filename?: unknown }).filename`）を validator 呼び出しに置き換え
- `services/movies.ts` の凍結コメントと `docs/api-contracts.md` の同旨の記述を削除。エンドポイント表の型カラムを補完し、記載漏れだった `PATCH /api/movies/{shortId}/` の行を追加
- rename バリデータのテストに、パストラバーサル（`..`）と拡張子偽装（RTL override）のケースを追加

## 意思決定

### 採用アプローチ
- 検証ロジックを contracts の `ValidationResult` 流儀（例外ではなく値で失敗を返す）に揃えた。既存の `validatePresignRequest` / `validateCommitRequest` と同じ形にすることで、ハンドラ側が `result.error` をそのまま `ErrorResponse` として返せる

### 却下した代替案
- **`services/movies.ts` に型の re-export シムを残す** → 却下: 移行が楽になる代わりに「どちらが正本か」が再び曖昧になる。本 PR の目的そのものを損なうため、参照側（`ui/history-menu.ts` / `ui/history-view.ts`）の import を直接付け替えた
- **`renameMovie` 内にも検証を残す（二重防御）** → 却下: 検証の正本を 1 箇所にするのが目的で、二重化はその逆。呼び出し元は PATCH ハンドラ 1 箇所のみで、`docs/architecture-contract.toml` の層構造（entrypoints → services）が検証を飛ばす経路を作れないようにしている

### トレードオフ
- 契約の一元化 > サービス層単体の防御力: `renameMovie` は単体では任意の文字列を保存できる関数になった。将来 caller が増える時に検証漏れが起きうるが、その時点で branded type を入れる方が、今 1 箇所のために抽象化を先回りするより安い

## テスト

- [x] `bun test`: 236 pass / 0 fail（18 ファイル、367 assertions）
- [x] `bun run typecheck`（`tsc --noEmit`）: エラーなし
- [x] `python3 ~/.claude/scripts/check-architecture.py`: exit 0（違反なし・対象 67 ファイル）
- [x] `E2E_PORT=4392 bunx playwright test`: 38 passed（ファイル名変更の 3 ケース = Enter で変更・空白のみ拒否・長すぎ拒否を含む）

挙動変更なしのリファクタなので、エラーメッセージ文字列・HTTP ステータス・400/404 の返し分け順は変更前と一致していることを重点確認した（codex レビューゲート 2 レーンでも順序維持を確認）。

Closes #26

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
