### PR TITLE
feat(web): web-screen.net を Worker の Custom Domain に接続する

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -50,5 +50,19 @@
       "binding": "SESSION",
       "id": "8318e211fb8c4caebb81bc04745b438b"
     }
+  ],
+  // 本番ドメイン。custom_domain: true にすると wrangler が DNS レコードと証明書まで
+  // 面倒を見る（ゾーンが同一 Cloudflare アカウントにあることが前提）。
+  //
+  // デプロイした瞬間に web-screen.net の配信先が旧 FastAPI 版（Cloud Run）から
+  // この Worker へ切り替わる。ロールバックは Cloudflare の DNS で web-screen.net の
+  // A / AAAA を旧 Cloud Run へ戻す（切替前の値は Issue #44 の DNS スナップショット）。
+  //
+  // workers.dev の URL は残す（切替後も β として検証に使うため）。
+  "routes": [
+    {
+      "pattern": "web-screen.net",
+      "custom_domain": true
+    }
   ]
 }


### PR DESCRIPTION
## なぜこの変更が必要か

マイルストーン「web-screen.net を Cloudflare 版へ切替」の最終ゲート。前提はすべて完了している。

| 前提 | Issue | 状態 |
|---|---|---|
| ネームサーバーを Cloudflare へ | #40 | 完了（DoH で NS / SOA とも正常を確認） |
| 動画配信を `cdn.web-screen.net` へ | #41 | 完了（デプロイ済み） |
| 旧 URL の 301 転送 | #42 | 完了（デプロイ済み） |
| GA4 の移植 | #45 | 完了（デプロイ済み） |
| robots / sitemap / favicon | #48 | 完了（デプロイ済み） |

## 変更内容

- `web/wrangler.jsonc` に `routes` を追加し、`web-screen.net` を Custom Domain として Worker に接続する

## 意思決定

### 採用アプローチ
- **ダッシュボードではなく `wrangler.jsonc` に書く**: 本番ドメインの向き先という最重要の設定をコードから追えるようにする。`custom_domain: true` は wrangler が DNS レコードと証明書まで作成する

### 却下した代替案
- **Cloudflare ダッシュボードで Custom Domain を追加** → 却下: 設定がリポジトリから見えなくなる。同じ理由で R2 の Custom Domain はダッシュボード管理になってしまったので、`docs/r2-delivery.md` に正本を書いて補っている

### トレードオフ
- デプロイ即切替になる（段階的なトラフィック移行ができない） > 設定の追跡可能性: Workers の Custom Domain に重み付けルーティングは無く、いずれにせよ一斉切替になるため

## デプロイ前に必須の確認

**Discord Developer Portal に `https://web-screen.net/api/auth/callback/` を登録しておくこと。** リダイレクト URI は `${url.origin}` から動的生成されるため（`web/src/pages/api/auth/login.ts:29`）、未登録のまま切り替えるとログインが `invalid_redirect_uri` で失敗する。

## テスト

- [x] `bun test`: 266 pass / 0 fail
- [x] `bun run typecheck`: エラーなし
- [x] ビルド生成物 `dist/server/wrangler.json` に `routes` が反映されることを確認
- [x] デプロイ済みの `workers.dev` で全機能を実測（`/api/health/` 200・旧 URL の 301・robots/sitemap/favicon 200・GA4 タグ出力）

切替後の検証は Issue #44 のコメントに用意したスクリプトで行う。

## ロールバック

Cloudflare の DNS で `web-screen.net` の A / AAAA を旧 Cloud Run へ戻す。

```
A    216.239.32.21 / 216.239.34.21 / 216.239.36.21 / 216.239.38.21
AAAA 2001:4860:4802:32::15 / :34::15 / :36::15 / :38::15
```

TTL は 300 秒なので数分で復帰する。旧 Cloud Run は稼働したまま残してある（停止は切替から約 1 ヶ月後の予定）。

Closes #44

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)