### PR TITLE
fix(web): routes 指定で外れた workers.dev のルートを復旧する

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -59,10 +59,7 @@
   // A / AAAA を旧 Cloud Run へ戻す（切替前の値は Issue #44 の DNS スナップショット）。
   //
   // workers.dev の URL は残す（切替後も β として検証に使うため）。
-  "routes": [
-    {
-      "pattern": "web-screen.net",
-      "custom_domain": true
-    }
-  ]
+  // routes で custom_domain を指定すると workers.dev のルートが外れる（実測 2026-08-27）。
+  // 本番ドメインを繋ぐ時も β 検証用に workers.dev を残すため、明示的に true にする。
+  "workers_dev": true
 }


### PR DESCRIPTION
## なぜこの変更が必要か

#53（`web-screen.net` を Worker の Custom Domain に接続）をデプロイしたところ、切替は失敗したうえ **β 環境（workers.dev）が 404 になった**。緊急復旧としてデプロイ済みの内容を、リポジトリへ正式に反映する。

## 何が起きたか

```
✘ [ERROR] Trigger configuration for "webscreen-beta" was only partially updated:
    Custom domains:
      - Hostname 'web-screen.net' already has externally managed DNS records (A, CNAME, etc).
        Delete them first or try a different hostname. [code: 100117]
  Successful trigger changes were not rolled back.
```

1. **Custom Domain の設定は失敗した** — Custom Domain は Cloudflare が DNS レコードを管理する仕組みで、旧 Cloud Run を指す A/AAAA と共存できない
2. **workers.dev のルートだけ外れた** — `routes` を明示すると `workers_dev` が既定 false になる。エラーメッセージのとおり trigger の一部だけが適用され、`https://webscreen-beta.teranori.workers.dev` が 404 になった

**本番の `web-screen.net` は旧サイトを配信したままで無傷だった**（DNS が Cloudflare 経由で旧 Cloud Run を指す状態が保たれた）。

## 変更内容

- `routes` を削除し、`workers_dev: true` を明示（既定値に頼らず、意図をコードに残す）

## 意思決定

### 採用アプローチ
- **`workers_dev: true` を明示的に書く**: 既定値は `routes` の有無で変わるため、暗黙に頼ると同じ事故が再発する

### 却下した代替案
- **`routes` を残したまま `workers_dev: true` を足す** → 却下: A/AAAA が残る限り Custom Domain の設定は失敗し続け、デプロイのたびにエラーになる。切替は DNS レコードを整理してから改めて行う

## テスト

デプロイ後に実測（緊急復旧のため先にデプロイ済み）:

| 確認 | 結果 |
|---|---|
| workers.dev `/api/health/` | 200 |
| workers.dev `/ja/` | 200 |
| workers.dev `/ja/web/` | 301 |
| workers.dev `/robots.txt` | 200 |
| 本番 `web-screen.net/ja/` | 200（`server: Google Frontend` = 旧サイト・無傷） |

## 切替をやり直す手順

Issue #44 に記録した。要点は「Cloudflare の DNS から `web-screen.net` の A/AAAA を削除してから Custom Domain を設定する」。削除と設定の間はドメインが解決しない時間が生じるため、ダッシュボードから Custom Domain を追加する方式（Cloudflare が既存レコードの置換を扱う）も併せて検討する。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)