### PR TITLE
feat(web): 本番ドメインを Route 方式で接続する（発火は Proxied 化）

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -59,7 +59,20 @@
   // A / AAAA を旧 Cloud Run へ戻す（切替前の値は Issue #44 の DNS スナップショット）。
   //
   // workers.dev の URL は残す（切替後も β として検証に使うため）。
-  // routes で custom_domain を指定すると workers.dev のルートが外れる（実測 2026-08-27）。
+  // routes を書くと workers.dev のルートが外れる（実測 2026-08-27）。
   // 本番ドメインを繋ぐ時も β 検証用に workers.dev を残すため、明示的に true にする。
-  "workers_dev": true
+  "workers_dev": true,
+  // 本番ドメイン。custom_domain ではなく Route 方式を使う。
+  // Custom Domain は Cloudflare が DNS レコードを管理する仕組みで、旧 Cloud Run を指す
+  // A/AAAA の削除が要る（削除〜設定の間ドメインが解決しない）。Route なら既存レコードを
+  // Proxied にするだけでよく、ロールバックもこの routes を外して再デプロイするだけで済む。
+  //
+  // 効くのは A/AAAA が Proxied（オレンジ雲）の時だけ。DNS only の間はここに書いても
+  // トラフィックが Cloudflare を通らないため何も起きない（切替は雲の切り替えで発火する）。
+  "routes": [
+    {
+      "pattern": "web-screen.net/*",
+      "zone_name": "web-screen.net"
+    }
+  ]
 }


### PR DESCRIPTION
## なぜこの変更が必要か

#53 の Custom Domain 方式は Cloudflare に拒否された。

```
Hostname 'web-screen.net' already has externally managed DNS records (A, CNAME, etc).
Delete them first or try a different hostname. [code: 100117]
```

Custom Domain は Cloudflare が DNS レコードを管理する仕組みで、旧 Cloud Run を指す A/AAAA と共存できない。削除すると設定までの間ドメインが解決しなくなる。

**Route 方式なら既存レコードを Proxied にするだけでよく、ダウンタイムがない。**

> All domains and subdomains must have a DNS record to be proxied on Cloudflare and used to invoke a Worker.
> — [Workers Routes](https://developers.cloudflare.com/workers/configuration/routing/routes/)（参照日 2026-08-27）

## 変更内容

- `web/wrangler.jsonc` に `routes`（`pattern` + `zone_name`）を追加

## この PR だけでは切り替わらない

A/AAAA が **DNS only** の間はトラフィックが Cloudflare を通らないため、Route を書いても発火しない。デプロイ後の実測:

| 確認 | 結果 |
|---|---|
| trigger 登録 | `workers.dev` と `web-screen.net/*` の 2 件 |
| 本番 `GET /ja/` | 200・`server: Google Frontend`（**旧サイトのまま**） |
| 本番 `/api/health/` | 404（旧サイトに存在しないパス） |
| β `workers.dev` | 200 |

**切替は Cloudflare ダッシュボードで apex の A/AAAA を Proxied（オレンジ雲）にした時点で発火する。**

## 意思決定

### 採用アプローチ
- **Route 方式**: DNS レコードを削除しないため、切替とロールバックの両方が無停止。ロールバックは `routes` を外して再デプロイするだけで、DNS の伝播を待たない

### 却下した代替案
- **Custom Domain**（#53） → 却下: Cloudflare が拒否。A/AAAA の削除が前提で、削除〜設定の間ドメインが解決しない
- **ダッシュボードから Route を設定** → 却下: 本番ドメインの向き先という最重要の設定をコードから追えなくする

### トレードオフ
- 切替の発火がコード外（雲の切り替え）になる > ダウンタイムゼロ: 発火条件をコメントに明記して補う

## テスト

- [x] `bun test`: 266 pass（前回デプロイ時から変更なし）
- [x] デプロイ後に trigger 2 件の登録を実測
- [x] 本番・β とも無傷であることを実測

## ロールバック

`routes` を外して再デプロイする。DNS は Proxied のまま旧 Cloud Run を指しているので即座に戻る。さらに Cloudflare を完全に迂回したい場合は雲をグレーに戻す。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)