### PR TITLE
fix(web): R2 の CORS に本番オリジンを追加し設定をリポジトリで管理する

### DIFF
--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -18,14 +18,30 @@ r2.dev は Cloudflare が開発専用と明記しているエンドポイント�
 
 WebScreen では VRChat のワールド内で複数人が同時に同じ動画を取得するため、レート制限がそのまま「再生できない」というユーザー影響になる。キャッシュが効かない点も配信コストと再生開始の遅さに直結する。
 
-## Cloudflare 側の設定（コード外の正本）
+## Cloudflare 側の設定
 
-ダッシュボードでのみ管理される。変更したらこの表も更新すること。
+| 設定 | 管理場所 | 内容 |
+|---|---|---|
+| R2 Custom Domain | ダッシュボード | バケット `webscreen-beta` に `cdn.web-screen.net` を接続（Active） |
+| Transform Rule `cdn: noindex for media` | ダッシュボード | `http.host eq "cdn.web-screen.net"` のとき `X-Robots-Tag: noindex` を付与 |
+| **R2 の CORS** | **`web/r2-cors.json`** | 下記「CORS」節 |
 
-| 設定 | 内容 |
-|---|---|
-| R2 Custom Domain | バケット `webscreen-beta` に `cdn.web-screen.net` を接続（Active） |
-| Transform Rule `cdn: noindex for media` | `http.host eq "cdn.web-screen.net"` のとき `X-Robots-Tag: noindex` を付与 |
+ダッシュボード管理のものは変更したらこの表も更新すること。
+
+### CORS（アップロード経路）
+
+アップロードはブラウザから **R2 の S3 エンドポイントへ直接 PUT** する（`web/src/lib/infra/r2presign.ts` が署名 URL を払い出す）。配信ドメインではなく `https://{accountId}.r2.cloudflarestorage.com` が相手なので、**サイトのオリジンを R2 のバケット CORS に登録しないと preflight が 403 になり変換できない**。
+
+設定の正本は `web/r2-cors.json`。反映はこのコマンド:
+
+```bash
+cd web && bunx wrangler r2 bucket cors set webscreen-beta --file r2-cors.json
+bunx wrangler r2 bucket cors list webscreen-beta   # 確認
+```
+
+**サイトのオリジンが増減したら必ずここも直す。** 2026-08-27 の本番ドメイン切替では、`https://web-screen.net` の登録漏れで変換が全滅した（`presign` は 200 を返すのに R2 への PUT だけが CORS エラーになるため、原因が分かりにくい）。
+
+`AllowedMethods` に `PUT` が要るのはアップロードのため、`GET` / `HEAD` は動画再生のため。`ExposeHeaders` の `ETag` はアップロード完了の検証に使う。
 
 `X-Robots-Tag` は、プレビューページの `noindex` メタタグだけでは防げない「動画ファイル本体がクローラに直接収集される」経路を塞ぐためのもの（HTML の noindex はその HTML を検索結果から外すだけで、`<video src>` の先には効かない）。
 

--- a/web/r2-cors.json
+++ b/web/r2-cors.json
@@ -1,0 +1,19 @@
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://web-screen.net",
+          "https://webscreen-beta.teranori.workers.dev",
+          "http://localhost:4321",
+          "http://localhost:8787",
+          "http://127.0.0.1:8787"
+        ],
+        "methods": ["GET", "PUT", "HEAD"],
+        "headers": ["Content-Type"]
+      },
+      "exposeHeaders": ["ETag"],
+      "maxAgeSeconds": 3600
+    }
+  ]
+}


### PR DESCRIPTION
## なぜこの変更が必要か

本番ドメイン切替後、**変換が全滅していた**。`presign` は 200 を返すのに R2 への直接 PUT だけが失敗する状態で、DevTools には preflight 403 と CORS エラーが出ていた。

```
presign/                              200
EC81aMzJS4Mc.mp4?X-Amz-...  preflight 403
EC81aMzJS4Mc.mp4?X-Amz-...  fetch     CORS エラー
```

原因は R2 バケット `webscreen-beta` の CORS 許可オリジンに `https://web-screen.net` が無かったこと。

```
allowed_origins: https://webscreen-beta.teranori.workers.dev, http://localhost:4321,
                 http://localhost:8787, http://127.0.0.1:8787
```

アップロードは**ブラウザから R2 の S3 エンドポイントへ直接 PUT** する設計（`web/src/lib/infra/r2presign.ts`）なので、サイトのオリジンが変わればバケット側の登録も要る。切替時の想定漏れだった。

## 変更内容

- `web/r2-cors.json` を追加（CORS 設定の正本）。既存オリジンは 1 つも落とさず `https://web-screen.net` を追加
- `docs/r2-delivery.md` に CORS 節を追加。反映コマンドと「サイトのオリジンが増減したら直す」注意を明記

## 意思決定

### 採用アプローチ
- **設定ファイルをリポジトリに置く**: これまで Cloudflare のダッシュボードにしか無く、コードから追えなかった。同じ事故を繰り返さないため、`wrangler r2 bucket cors set --file` で反映できる形にした

### 却下した代替案
- **ダッシュボードで直接編集して終わり** → 却下: 設定が追えないまま残り、次にオリジンが変わった時にまた同じ障害になる
- **アップロードを Worker 経由のプロキシに変える**（CORS 不要になる） → 却下: 50MB の動画が Worker を通ることになり、設計の変更が大きい。今回の障害はオリジン 1 行の登録漏れが原因で、設計の問題ではない

## テスト

適用後に実測:

| 確認 | 結果 |
|---|---|
| `https://web-screen.net` からの preflight | **204** / `Access-Control-Allow-Origin: https://web-screen.net` |
| `https://webscreen-beta.teranori.workers.dev` からの preflight | 204（既存オリジンが維持されている） |
| 本番ブラウザでの画像変換 | **成功**（640×360 PNG → `https://cdn.web-screen.net/movies/CA1KxQ4myonP.mp4`） |
| 動画の配信 | 200 / `content-type: video/mp4` / `accept-ranges: bytes` / Range 206 |
| エンコード契約 | h264 / Constrained Baseline / yuv420p / `has_b_frames=0` / 全フレーム I / moov 先頭 |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)