### PR TITLE
feat(web): プレビューの並びを整理し自動コピーの完了表示を 0.5 秒遅らせる

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 import { join } from 'node:path';
 
 // Playwright は Node で直接実行するため、JSON には import 属性が要る（Vite は不要）
@@ -154,6 +154,28 @@ test.describe('公開プレビュー', () => {
 });
 
 test.describe('所有者の操作', () => {
+  test('タイトル → 保管期限 → ピン留め → URL → 動画 の順に並ぶ', async ({ page, context }) => {
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.goto(`/${E2E_FIXTURES.readyShortId}/`);
+
+    const top = async (locator: Locator): Promise<number> => {
+      const box = await locator.boundingBox();
+      if (box === null) throw new Error('要素が表示されていない');
+      return box.y;
+    };
+
+    // VRChat に貼る URL を動画本体より先に見せ、期限とピン留めは同じ話なので隣接させる
+    const positions = [
+      await top(page.getByRole('heading', { level: 1 })),
+      await top(page.getByText(ja.preview.expiry)),
+      await top(page.getByRole('button', { name: ja.preview.pin })),
+      await top(page.locator('[data-preview-url]')),
+      await top(page.locator('[data-preview-video]')),
+    ];
+
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
   test('ファイル名を Enter で変更し、再読み込み後も保持する', async ({ page, context }) => {
     const filename = 'renamed-slides.mp4';
     await signIn(context, E2E_FIXTURES.ownerId);

--- a/web/src/components/MoviePreview.astro
+++ b/web/src/components/MoviePreview.astro
@@ -134,16 +134,26 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
       )
     }
 
-    <video
-      data-preview-video
-      src={publicUrl}
-      controls
-      playsinline
-      preload="metadata"
-      class="mt-6 aspect-video w-full rounded-xl bg-slate-900"
-    ></video>
+    {
+      isOwner && (
+        <div class="mt-4 flex flex-col gap-3">
+          <div class="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              data-pin-button
+              class="inline-flex items-center gap-2 rounded-md border border-brand-500 px-4 py-2 text-base font-semibold text-brand-700 hover:bg-brand-50"
+            >
+              <i class="fa-solid fa-thumbtack" aria-hidden="true" />
+              <span>{pinned ? t.preview.unpin : t.preview.pin}</span>
+            </button>
+            <span class="text-base text-slate-600">{pinHint}</span>
+          </div>
+          <p data-pin-failed hidden role="alert" class="text-base text-red-700" />
+        </div>
+      )
+    }
 
-    <label for="preview-url" class="mt-6 block text-base font-semibold text-slate-700">
+    <label for="preview-url" class="mt-8 block text-base font-semibold text-slate-700">
       {t.preview.urlLabel}
     </label>
     <div class="mt-2 flex flex-col gap-3 sm:flex-row">
@@ -172,24 +182,14 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
     </div>
     <p class="mt-2 text-base text-slate-600">{t.preview.playbackHint}</p>
 
-    {
-      isOwner && (
-        <div class="mt-8 flex flex-col gap-4 border-t border-slate-200 pt-6">
-          <div class="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              data-pin-button
-              class="inline-flex items-center gap-2 rounded-md border border-brand-500 px-4 py-2 text-base font-semibold text-brand-700 hover:bg-brand-50"
-            >
-              <i class="fa-solid fa-thumbtack" aria-hidden="true" />
-              <span>{pinned ? t.preview.unpin : t.preview.pin}</span>
-            </button>
-            <span class="text-base text-slate-600">{pinHint}</span>
-          </div>
-          <p data-pin-failed hidden role="alert" class="text-base text-red-700" />
-        </div>
-      )
-    }
+    <video
+      data-preview-video
+      src={publicUrl}
+      controls
+      playsinline
+      preload="metadata"
+      class="mt-8 aspect-video w-full rounded-xl bg-slate-900"
+    ></video>
   </div>
 
   <div data-when-preview="deleted" class="py-10 text-center">

--- a/web/src/lib/ui/auto-copy.ts
+++ b/web/src/lib/ui/auto-copy.ts
@@ -1,24 +1,33 @@
 const AUTO_COPY_KEY = 'webscreen:auto-copy';
 
-type SessionStorage = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
+/**
+ * 自動コピーの完了表示を遅らせる時間。
+ *
+ * 遷移直後に「コピーしました」まで出すとボタンが最初からその状態で描画され、
+ * 自動で押されたことに気づけない。遅らせるのは表示だけで、コピー自体は即時に行う
+ * （離脱でコピーを取りこぼしたり、直後の貼り付けが古い内容になったりするため）。
+ */
+export const AUTO_COPY_FEEDBACK_DELAY_MS = 500;
+
+export type SessionStorage = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
 
 /** 次に開く同じプレビューで動画 URL をコピーする one-shot フラグを保存する。 */
-export function markAutoCopy(shortId: string, storage: SessionStorage = sessionStorage): void {
+export function markAutoCopy(shortId: string, storage?: SessionStorage): void {
   try {
-    storage.setItem(AUTO_COPY_KEY, shortId);
+    // sessionStorage 自体が無い環境でも落ちないよう、参照を try の中に置く。
+    (storage ?? sessionStorage).setItem(AUTO_COPY_KEY, shortId);
   } catch {
     // ストレージが無効でも、変換完了後のプレビュー遷移は妨げない。
   }
 }
 
 /** このプレビューへの one-shot 自動コピー要求を消費し、一致時だけ true を返す。 */
-export function consumeAutoCopy(
-  shortId: string,
-  storage: SessionStorage = sessionStorage
-): boolean {
+export function consumeAutoCopy(shortId: string, storage?: SessionStorage): boolean {
   try {
-    const markedShortId = storage.getItem(AUTO_COPY_KEY);
-    storage.removeItem(AUTO_COPY_KEY);
+    // sessionStorage 自体が無い環境でも落ちないよう、参照を try の中に置く。
+    const store = storage ?? sessionStorage;
+    const markedShortId = store.getItem(AUTO_COPY_KEY);
+    store.removeItem(AUTO_COPY_KEY);
     return markedShortId === shortId;
   } catch {
     return false;

--- a/web/src/lib/ui/preview-actions.ts
+++ b/web/src/lib/ui/preview-actions.ts
@@ -7,7 +7,7 @@
 
 import { MAX_FILENAME_LENGTH } from '../contracts/api';
 import { copyToClipboard } from './clipboard';
-import { consumeAutoCopy } from './auto-copy';
+import { AUTO_COPY_FEEDBACK_DELAY_MS, consumeAutoCopy, type SessionStorage } from './auto-copy';
 import { movieEndpoint, pinEndpoint } from './history-view';
 
 // 遷移直後の自動コピーでも見逃しにくい長さ（2000ms は短すぎるとの報告で延長）
@@ -21,6 +21,8 @@ export interface PreviewActionsOptions {
   schedule?: Schedule;
   /** pin 成功後の再読み込み。保管期限の表示はサーバーが持つので画面を作り直す。 */
   reload?: () => void;
+  /** 自動コピー要求の保存先（既定は sessionStorage）。 */
+  storage?: SessionStorage;
 }
 
 function find<T extends HTMLElement>(root: HTMLElement, selector: string): T | null {
@@ -257,9 +259,10 @@ export function mountPreviewActions(
   wireCopy(root, schedule);
   const shortId = root.dataset['shortId'] ?? '';
   const input = find<HTMLInputElement>(root, '[data-preview-url]');
-  if (consumeAutoCopy(shortId) && input) {
+  if (consumeAutoCopy(shortId, options.storage) && input) {
     void copyToClipboard(input.value, input).then((copied) => {
-      if (copied) showCopied(root, schedule);
+      // コピーは即時（離脱で取りこぼさないため）。表示だけ遅らせて、ボタンが変わる瞬間を見せる。
+      if (copied) schedule(() => showCopied(root, schedule), AUTO_COPY_FEEDBACK_DELAY_MS);
     });
   }
   wirePin(root, fetchImpl, reload);

--- a/web/tests/ui/preview-actions.test.ts
+++ b/web/tests/ui/preview-actions.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { markAutoCopy } from '../../src/lib/ui/auto-copy';
+import { mountPreviewActions } from '../../src/lib/ui/preview-actions';
+
+const SHORT_ID = 'Ab12Cd34Ef56';
+const PUBLIC_URL = 'https://public.example/movies/Ab12Cd34Ef56.mp4';
+
+class FakeStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+/** URL 入力欄と shortId だけを持つ最小のプレビュー（pin / rename / 削除は所有者だけの要素）。 */
+class FakePreview {
+  readonly dataset: Record<string, string> = { shortId: SHORT_ID };
+  readonly input = { value: PUBLIC_URL, select(): void {} };
+
+  querySelector(selector: string): unknown {
+    return selector === '[data-preview-url]' ? this.input : null;
+  }
+}
+
+interface ScheduledCall {
+  callback: () => void;
+  delayMs: number;
+}
+
+function mount(storage: FakeStorage): { preview: FakePreview; scheduled: ScheduledCall[] } {
+  const preview = new FakePreview();
+  const scheduled: ScheduledCall[] = [];
+  mountPreviewActions(preview as unknown as HTMLElement, {
+    storage,
+    schedule: (callback, delayMs) => {
+      scheduled.push({ callback, delayMs });
+    },
+  });
+  return { preview, scheduled };
+}
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+/** navigator.clipboard を差し替えて writeText の呼び出しを記録する。 */
+function stubClipboard(): { writes: string[] } {
+  const writes: string[] = [];
+  Object.defineProperty(globalThis, 'navigator', {
+    value: {
+      clipboard: {
+        writeText(value: string): Promise<void> {
+          writes.push(value);
+          return Promise.resolve();
+        },
+      },
+    },
+    configurable: true,
+    writable: true,
+  });
+  return { writes };
+}
+
+afterEach(() => {
+  if (originalNavigator) Object.defineProperty(globalThis, 'navigator', originalNavigator);
+  else Reflect.deleteProperty(globalThis, 'navigator');
+});
+
+describe('プレビューの自動コピー', () => {
+  test('コピーは即時、「コピーしました」の表示だけ 0.5 秒遅らせる', async () => {
+    const clipboard = stubClipboard();
+    const storage = new FakeStorage();
+    markAutoCopy(SHORT_ID, storage);
+
+    const { preview, scheduled } = mount(storage);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // コピーを遅らせると離脱で取りこぼす。遅らせるのは表示だけ
+    expect(clipboard.writes).toEqual([PUBLIC_URL]);
+    expect(preview.dataset['copied']).toBeUndefined();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]?.delayMs).toBe(500);
+
+    scheduled[0]?.callback();
+
+    expect(preview.dataset['copied']).toBe('true');
+  });
+
+  test('自動コピー要求が無ければコピーしない', () => {
+    const clipboard = stubClipboard();
+    const { scheduled } = mount(new FakeStorage());
+
+    expect(scheduled).toEqual([]);
+    expect(clipboard.writes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## なぜこの変更が必要か

変換後のプレビュー画面（例: https://web-screen.net/mrDfkAl2T2nS/ ）で 2 つの使いにくさがあった。

1. 並びが「動画 → URL → ピン留め」で、実際に使う情報（VRChat に貼る URL）が動画の下に埋もれ、保管期限とピン留めという同じ「いつまで残るか」の話が離れていた
2. 変換直後の自動コピーが即時すぎて、ページを開いた時点でボタンが「コピーしました」で描画される。勝手にコピーされたことに気づけず、コピー済みだと分からない

## 変更内容

- プレビューを タイトル → 保管期限 → ピン留め → 動画の URL → 動画 の順に並べ替え
- 自動コピーの完了表示（ボタンが「コピーしました」に変わる）を 500ms 遅延
- 並び順の E2E 回帰テストと、自動コピーのユニットテストを追加
- `markAutoCopy` / `consumeAutoCopy` のストレージ参照を try の中へ移動（sessionStorage が無い環境で ReferenceError を出さない）

## 意思決定

### 採用アプローチ
- 遅らせるのは**表示だけ**でコピー自体は即時。ボタンが変わる瞬間を見せつつ、コピーの確実性を落とさない

### 却下した代替案
- コピー処理自体を 500ms 遅らせる → 却下: 遅延中にページを離れるとフラグは消費済みなのにコピーされず取りこぼす。500ms 以内の貼り付けが古いクリップボード内容になる（codex レビュー指摘）

### トレードオフ
- 「コピー済み」の視認性 > 表示の即時性: 0.5 秒の遅れよりも、自動でコピーされたと気づけることを優先

## テスト

- [x] `bun test` 268 pass
- [x] `bun run typecheck`（tsc --noEmit）pass
- [x] `bunx playwright test e2e/preview.spec.ts` 23 pass（並び順の回帰テストを含む）
- [x] 所有者ビューのスクリーンショットで並び順を目視確認

## Screenshot

| Before | After |
|--------|-------|
| ![preview-order-before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/bccba1d330d7-preview-order-before.avif) | ![preview-order-after](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/f38c67791863-preview-order-after.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
