### PR TITLE
feat(web): ピン留めを保管期限の右のアイコンボタンにまとめる

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import en from '../src/i18n/en.json' with { type: 'json' };
 import ja from '../src/i18n/ja.json' with { type: 'json' };
 import { E2E_FIXTURES } from '../playwright.config';
+import { MAX_PINNED_MOVIES } from '../src/lib/services/quota';
 import { signIn } from './session';
 
 // 公開プレビュー /{shortId}/ と履歴ドロップダウンの画面確認。
@@ -33,6 +34,15 @@ async function stubHistory(page: Page, movies: unknown[]): Promise<void> {
       body: JSON.stringify({ movies }),
     })
   );
+}
+
+/** 画面上の位置を比べるための矩形（見えない要素は取れないので失敗させる）。 */
+async function boxOf(
+  locator: Locator
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  const box = await locator.boundingBox();
+  if (box === null) throw new Error('要素が表示されていない');
+  return box;
 }
 
 function historyMovie(overrides: Record<string, unknown> = {}) {
@@ -154,26 +164,85 @@ test.describe('公開プレビュー', () => {
 });
 
 test.describe('所有者の操作', () => {
-  test('タイトル → 保管期限 → ピン留め → URL → 動画 の順に並ぶ', async ({ page, context }) => {
+  test('タイトル → 保管期限 → URL → 動画 の順に並ぶ', async ({ page, context }) => {
     await signIn(context, E2E_FIXTURES.ownerId);
     await page.goto(`/${E2E_FIXTURES.readyShortId}/`);
 
-    const top = async (locator: Locator): Promise<number> => {
-      const box = await locator.boundingBox();
-      if (box === null) throw new Error('要素が表示されていない');
-      return box.y;
-    };
-
-    // VRChat に貼る URL を動画本体より先に見せ、期限とピン留めは同じ話なので隣接させる
+    // VRChat に貼る URL を動画本体より先に見せる
     const positions = [
-      await top(page.getByRole('heading', { level: 1 })),
-      await top(page.getByText(ja.preview.expiry)),
-      await top(page.getByRole('button', { name: ja.preview.pin })),
-      await top(page.locator('[data-preview-url]')),
-      await top(page.locator('[data-preview-video]')),
-    ];
+      await boxOf(page.getByRole('heading', { level: 1 })),
+      await boxOf(page.getByText(ja.preview.expiry)),
+      await boxOf(page.locator('[data-preview-url]')),
+      await boxOf(page.locator('[data-preview-video]')),
+    ].map((box) => box.y);
 
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  test('ピン留めボタンは保管期限の右にあり、ホバーで保管の説明を出す', async ({ page, context }) => {
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.goto(`/${E2E_FIXTURES.readyShortId}/`);
+
+    const expiry = await boxOf(page.getByText(ja.preview.expiry));
+    const pinButton = page.getByRole('button', { name: ja.preview.pin });
+    const pin = await boxOf(pinButton);
+
+    // 同じ行の右側（期限テキストとの上下差はボタンのパディング分に収まる）
+    expect(pin.x).toBeGreaterThan(expiry.x);
+    expect(Math.abs(pin.y + pin.height / 2 - (expiry.y + expiry.height / 2))).toBeLessThan(8);
+
+    // 説明文は常時表示せず、ホバーした時だけ出す
+    const hint = page.locator('[data-preview] [data-tooltip]');
+    await expect(hint).toBeHidden();
+    await pinButton.hover();
+    await expect(hint).toBeVisible();
+    await expect(hint).toHaveText(
+      ja.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES))
+    );
+
+    // フェード途中で撮らないようトランジションを終端まで進める
+    await page.screenshot({ path: screenshotPath('05-preview-pin-tooltip'), animations: 'disabled' });
+  });
+
+  test('狭い画面でもツールチップが画面内に収まる', async ({ page, context }) => {
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.setViewportSize({ width: 320, height: 720 });
+    await page.goto(`/${E2E_FIXTURES.pinnedShortId}/`);
+
+    const scrollWidth = (): Promise<number> =>
+      page.evaluate(() => document.documentElement.scrollWidth);
+    const before = await scrollWidth();
+
+    await page.getByRole('button', { name: ja.preview.unpin }).hover();
+    const hint = await boxOf(page.locator('[data-preview] [data-tooltip]'));
+
+    expect(hint.x).toBeGreaterThanOrEqual(0);
+    expect(hint.x + hint.width).toBeLessThanOrEqual(320);
+    // ツールチップが新たな横スクロールを作らないこと
+    expect(await scrollWidth()).toBe(before);
+  });
+
+  test('キーボードでフォーカスしてもツールチップが出る', async ({ page, context }) => {
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.goto(`/${E2E_FIXTURES.readyShortId}/`);
+
+    const hint = page.locator('[data-preview] [data-tooltip]');
+    await page.getByRole('button', { name: ja.preview.pin }).focus();
+    await expect(hint).toBeVisible();
+
+    // 上のコンテンツを覆ったままにしない（WCAG 1.4.13 Dismissible）
+    await page.keyboard.press('Escape');
+    await expect(hint).toBeHidden();
+  });
+
+  test('ピン留め中はボタンが解除の操作に変わる', async ({ page, context }) => {
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.goto(`/${E2E_FIXTURES.pinnedShortId}/`);
+
+    await expect(page.getByRole('button', { name: ja.preview.unpin })).toBeVisible();
+    await expect(page.getByRole('button', { name: ja.preview.pin })).toHaveCount(0);
+
+    await page.screenshot({ path: screenshotPath('06-preview-pinned') });
   });
 
   test('ファイル名を Enter で変更し、再読み込み後も保持する', async ({ page, context }) => {

--- a/web/src/components/MoviePreview.astro
+++ b/web/src/components/MoviePreview.astro
@@ -83,13 +83,41 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
       )
     }
 
-    <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
-      <p class="flex items-center gap-2 text-base text-slate-700">
-        <i
-          class={pinned ? 'fa-solid fa-thumbtack text-brand-500' : 'fa-regular fa-clock text-slate-500'}
-          aria-hidden="true"></i>
+    <!-- ツールチップは行の左端を基準に出す（ボタン基準だと狭い画面で左右にはみ出す） -->
+    <div class="relative mt-3 flex flex-wrap items-center justify-between gap-3">
+      <p class="flex flex-wrap items-center gap-2 text-base text-slate-700">
+        <i class="fa-regular fa-clock text-slate-500" aria-hidden="true"></i>
         <span class="text-slate-600">{t.preview.expiry}</span>
         <span class="font-semibold text-slate-900">{expiryLabel}</span>
+        {
+          isOwner && (
+            <span data-tooltip-scope class="inline-flex">
+              {/* ラベル自体が状態の裏返し（ピン留め中なら「解除」）なので aria-pressed は重ねない */}
+              <button
+                type="button"
+                data-pin-button
+                aria-label={pinned ? t.preview.unpin : t.preview.pin}
+                aria-describedby="pin-hint"
+                class={`inline-flex h-9 w-9 items-center justify-center rounded-md border text-base ${
+                  pinned
+                    ? 'border-brand-500 bg-brand-500 text-white hover:bg-brand-700'
+                    : 'border-slate-300 text-slate-500 hover:bg-brand-50 hover:text-brand-700'
+                }`}
+              >
+                <i class="fa-solid fa-thumbtack" aria-hidden="true" />
+              </button>
+              {/* 常時表示のヒント文を畳んで画面を軽くする（説明はホバー・フォーカス時だけ） */}
+              <span
+                id="pin-hint"
+                data-tooltip
+                role="tooltip"
+                class="absolute bottom-full left-0 z-10 mb-2 w-max max-w-[min(18rem,100%)] rounded-md bg-slate-900 px-3 py-2 text-sm leading-snug text-white shadow-lg"
+              >
+                {pinHint}
+              </span>
+            </span>
+          )
+        }
       </p>
 
       {
@@ -128,28 +156,12 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
     </div>
     {
       isOwner && (
-        <p data-delete-failed hidden role="alert" class="mt-2 text-base text-red-700">
-          {t.actions.deleteFailed}
-        </p>
-      )
-    }
-
-    {
-      isOwner && (
-        <div class="mt-4 flex flex-col gap-3">
-          <div class="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              data-pin-button
-              class="inline-flex items-center gap-2 rounded-md border border-brand-500 px-4 py-2 text-base font-semibold text-brand-700 hover:bg-brand-50"
-            >
-              <i class="fa-solid fa-thumbtack" aria-hidden="true" />
-              <span>{pinned ? t.preview.unpin : t.preview.pin}</span>
-            </button>
-            <span class="text-base text-slate-600">{pinHint}</span>
-          </div>
-          <p data-pin-failed hidden role="alert" class="text-base text-red-700" />
-        </div>
+        <>
+          <p data-pin-failed hidden role="alert" class="mt-2 text-base text-red-700" />
+          <p data-delete-failed hidden role="alert" class="mt-2 text-base text-red-700">
+            {t.actions.deleteFailed}
+          </p>
+        </>
       )
     }
 

--- a/web/src/lib/ui/preview-actions.ts
+++ b/web/src/lib/ui/preview-actions.ts
@@ -16,6 +16,11 @@ const RENAME_SAVED_FEEDBACK_MS = 2000;
 
 type Schedule = (callback: () => void, delayMs: number) => void;
 
+/** Escape を拾うためだけの document。テストから差し替えられるよう最小限に絞る。 */
+interface DocumentEventTarget {
+  addEventListener(type: string, listener: (event: Event) => void): void;
+}
+
 export interface PreviewActionsOptions {
   fetchImpl?: typeof fetch;
   schedule?: Schedule;
@@ -23,6 +28,8 @@ export interface PreviewActionsOptions {
   reload?: () => void;
   /** 自動コピー要求の保存先（既定は sessionStorage）。 */
   storage?: SessionStorage;
+  /** ツールチップを閉じる Escape の取得先（既定は document）。 */
+  document?: DocumentEventTarget;
 }
 
 function find<T extends HTMLElement>(root: HTMLElement, selector: string): T | null {
@@ -43,6 +50,30 @@ function wireCopy(root: HTMLElement, schedule: Schedule): void {
       if (copied) showCopied(root, schedule);
     });
   });
+}
+
+/**
+ * ホバー / フォーカスで出る補足を Escape で閉じられるようにする（WCAG 1.4.13 Dismissible）。
+ *
+ * ポインタでホバーしている間はフォーカスが別の場所にあるため、キー入力は document で拾う。
+ * 閉じたことを示すフラグは、その要素から離れた時に外す（次のホバーでまた出す）。
+ */
+function wireTooltips(root: HTMLElement, doc: DocumentEventTarget): void {
+  const scopes = [...root.querySelectorAll<HTMLElement>('[data-tooltip-scope]')];
+  if (scopes.length === 0) return;
+
+  doc.addEventListener('keydown', (event) => {
+    if ((event as KeyboardEvent).key !== 'Escape') return;
+    for (const scope of scopes) scope.dataset['tooltipDismissed'] = 'true';
+  });
+
+  for (const scope of scopes) {
+    const restore = (): void => {
+      delete scope.dataset['tooltipDismissed'];
+    };
+    scope.addEventListener('mouseleave', restore);
+    scope.addEventListener('focusout', restore);
+  }
 }
 
 function wirePin(root: HTMLElement, fetchImpl: typeof fetch, reload: () => void): void {
@@ -257,6 +288,7 @@ export function mountPreviewActions(
   const reload = options.reload ?? (() => window.location.reload());
 
   wireCopy(root, schedule);
+  wireTooltips(root, options.document ?? document);
   const shortId = root.dataset['shortId'] ?? '';
   const input = find<HTMLInputElement>(root, '[data-preview-url]');
   if (consumeAutoCopy(shortId, options.storage) && input) {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -94,6 +94,30 @@
 }
 
 /*
+ * ホバー・フォーカスで上に出る補足（OS のヘルプテキスト相当）。
+ * 常時表示のヒント文を畳んで画面の密度を下げるために使う。
+ * display ではなく visibility を切り替えるのは、テストとスクリーンリーダーから
+ * 「隠れている要素」として扱えるようにするため。
+ */
+[data-tooltip] {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+
+[data-tooltip-scope]:hover [data-tooltip],
+[data-tooltip-scope]:focus-within [data-tooltip] {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Escape で閉じた間は出さない（WCAG 1.4.13 Dismissible）。フラグは離れると外れる。 */
+[data-tooltip-scope][data-tooltip-dismissed] [data-tooltip] {
+  visibility: hidden;
+  opacity: 0;
+}
+
+/*
  * 削除のインライン確認。confirm() を使わず、確認 UI を同じ場所に出し分ける。
  * 履歴の各行とプレビューページの両方で同じ規則を使う。
  */

--- a/web/tests/ui/preview-actions.test.ts
+++ b/web/tests/ui/preview-actions.test.ts
@@ -30,6 +30,10 @@ class FakePreview {
   querySelector(selector: string): unknown {
     return selector === '[data-preview-url]' ? this.input : null;
   }
+
+  querySelectorAll(): unknown[] {
+    return [];
+  }
 }
 
 interface ScheduledCall {
@@ -42,6 +46,7 @@ function mount(storage: FakeStorage): { preview: FakePreview; scheduled: Schedul
   const scheduled: ScheduledCall[] = [];
   mountPreviewActions(preview as unknown as HTMLElement, {
     storage,
+    document: { addEventListener: () => {} },
     schedule: (callback, delayMs) => {
       scheduled.push({ callback, delayMs });
     },


### PR DESCRIPTION
## なぜこの変更が必要か

プレビュー画面のピン留めが「大きなボタン + 常時表示の説明文」で1行を占有し、画面が重かった。
ピン留めは保管期限の話なのに、期限表示から離れた場所にあって関連も分かりにくい。

## 変更内容

- 保管期限の右にピンのアイコンボタンを配置（押すとピン留めのオン / オフ）
- 状態を見た目に反映: ピン留め中は紫の塗り + 期限表示が「無期限（ピン留め中）」、ラベルは「ピン留めを解除」
- 説明文（期限なしで保管・10 件まで）は常時表示をやめ、ホバー / フォーカスで上に出るツールチップへ
- ツールチップは Escape で閉じられる（WCAG 1.4.13 Dismissible）
- 配置・ホバー表示・キーボードフォーカス・Escape・狭い画面（320px）の E2E を追加

## 意思決定

### 採用アプローチ
- ツールチップの位置基準はボタンではなく保管期限の行。狭い画面でボタンが行内のどこに来ても、行幅を超えない
- 状態は色だけでなくラベル（ピン留めする / ピン留めを解除）でも伝える

### 却下した代替案
- ボタン基準の `left-0` / `right-0` 配置 → 却下: 320px 幅でツールチップが画面外へ出るのを実測（右へ 524px / 左へ -236px）
- `aria-pressed` の併用 → 却下: ラベル自体が状態の裏返しなので、支援技術で二重に読み上げられる

### トレードオフ
- 画面のすっきりさ > タッチ環境での発見性: タッチではホバーできず、最初のタップでピン留めが実行される。ピン留めは再度タップで戻せる可逆操作で、期限表示も即座に変わるため許容した

## テスト

- [x] `bun test` 268 pass
- [x] `bun run typecheck`（tsc --noEmit）pass
- [x] `bunx playwright test` 81 pass
- [x] スクリーンショットで通常 / ピン留め中 / ホバー / 320px 幅を確認

## Screenshot

| Before | After（ピン留め中） | After（ホバー） |
|--------|--------------------|----------------|
| ![pin-before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/400d0a177099-pin-before.avif) | ![pin-after-pinned](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/94db9e201818-pin-after-pinned.avif) | ![pin-after-tooltip](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/b329859a4c56-pin-after-tooltip.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aKhxDNdxDUum9qMXiUSzv
