### PR TITLE
style(web): ヘッダーロゴの右余白を左余白に合わせて詰める

### DIFF
--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -22,12 +22,15 @@ const LOGOUT_URL = '/api/auth/logout/';
   <div class="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-4 py-0">
     <div class="flex items-center gap-3">
       <a href={`/${lang}/`} class="flex items-center gap-2 no-underline">
+        {/* logo-text.png は左余白 6px に対し右余白が 135px と非対称なので、表示比を
+            731:200 にして右を切り落とす（object-left でクロップ位置を左端に固定）。
+            画像自体は他サービスからも参照しているため差し替えない。 */}
         <img
           src={`${BANNER_BASE_URL}logo-text.png`}
           alt={t.nav.bannerAlt}
-          width="860"
+          width="731"
           height="200"
-          class="h-11 w-auto sm:h-14"
+          class="h-11 w-auto aspect-[731/200] object-cover object-left sm:h-14"
         />
         <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
           β


### PR DESCRIPTION
## なぜこの変更が必要か

ヘッダーの `logo-text.png` は画像内の余白が左 6px・右 135px と非対称で、ロゴと β バッジの間が不自然に空いて見えていた（ユーザー報告）。

## 変更内容

- `SiteHeader.astro` のロゴ img に `aspect-[731/200] object-cover object-left` を付与し、右側の余分な余白（129px 相当）だけをクロップ
- `width` 属性を 860 → 731 に更新（レイアウトシフト防止の意図を維持）
- 理由をコメントで明記

## 意思決定

### 採用アプローチ
- CSS の表示比 + `object-left` クロップを採用。理由: 画像を差し替えずリポジトリ内で完結し、他サービスからの参照に影響しない

### 却下した代替案
- GCS 上の画像自体をトリミングして差し替え → 却下: `noricha-public` の画像は他サービスからも参照されており、影響範囲が読めない
- `clip-path` + negative margin → 却下: 要素幅が変わらないため隣接要素との間隔がずれる

### トレードオフ
- 元画像に無駄な余白が残る > 差し替えの影響範囲リスク: 表示上は同じ結果になるため、リスクの低い方を選択

## テスト

- [x] `bun run typecheck` 通過
- [x] `bun test` 268 件全パス
- [x] `bun run build` 成功
- [x] dev サーバー（1280px / 390px）でヘッダーを撮影し、レンダリング後の左余白 1.8px / 右余白 2.0px（元画像換算 6.2 / 7.1）で左右がほぼ揃うことを実測
- [x] ロゴ文字（"WEB SCREEN" の末尾 N）が切れていないことを目視確認

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/d22f16d102bf-05-before-20260828-113500.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/cce8537e0a73-05-after-20260828-113500.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
