### PR TITLE
style(web): プレビューから「変換した動画」「動画の URL」のラベルを外す

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -92,7 +92,7 @@ test.describe('公開プレビュー', () => {
     await page.goto(`/${E2E_FIXTURES.readyShortId}/`);
 
     await expect(page.getByRole('button', { name: en.preview.copy })).toBeVisible();
-    await expect(page.getByText(ja.preview.urlLabel)).toHaveCount(0);
+    await expect(page.getByText(ja.preview.expiry)).toHaveCount(0);
 
     await page.screenshot({ path: screenshotPath('02-preview-en'), fullPage: true });
     await context.close();

--- a/web/src/components/MoviePreview.astro
+++ b/web/src/components/MoviePreview.astro
@@ -47,11 +47,7 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
   class="mx-auto max-w-3xl px-4 py-10"
 >
   <div data-when-preview="ready">
-    <p class="flex items-center gap-2 text-base font-semibold text-brand-700">
-      <i class="fa-solid fa-film" aria-hidden="true"></i>
-      <span>{t.preview.heading}</span>
-    </p>
-    <h1 class="mt-2 flex min-w-0 items-center gap-2 text-3xl font-bold tracking-tight text-slate-900">
+    <h1 class="flex min-w-0 items-center gap-2 text-3xl font-bold tracking-tight text-slate-900">
       <span data-filename-text class="min-w-0 truncate">{filename}</span>
       {
         isOwner && (
@@ -165,15 +161,14 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
       )
     }
 
-    <label for="preview-url" class="mt-8 block text-base font-semibold text-slate-700">
-      {t.preview.urlLabel}
-    </label>
-    <div class="mt-2 flex flex-col gap-3 sm:flex-row">
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+      {/* 見出しラベルは画面から外したが、読み上げには用途が必要なので aria-label に残す。 */}
       <input
         id="preview-url"
         data-preview-url
         type="text"
         readonly
+        aria-label={t.preview.urlLabel}
         value={publicUrl}
         class="min-w-0 flex-1 rounded-md border border-slate-300 bg-slate-50 px-3 py-2 text-base text-slate-900"
       />

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -59,7 +59,6 @@
     "pinned": "Pinned"
   },
   "preview": {
-    "heading": "Your video",
     "urlLabel": "Video URL",
     "copy": "Copy URL",
     "copied": "Copied",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -59,7 +59,6 @@
     "pinned": "ピン留め中"
   },
   "preview": {
-    "heading": "変換した動画",
     "urlLabel": "動画の URL",
     "copy": "URL をコピー",
     "copied": "コピーしました",


### PR DESCRIPTION
## なぜこの変更が必要か

プレビューページの「変換した動画」と「動画の URL」は、直下のファイル名見出しと URL 入力欄を見れば分かる内容で、画面を縦に伸ばすだけになっていた（ユーザー指摘）。

## 変更内容

- `MoviePreview.astro` から「変換した動画」の見出し行（アイコン + テキスト）を削除
- URL 入力欄の `<label>` を削除し、用途は `aria-label` に移して読み上げでの意味を保持
- ラベル削除に伴う余白調整（h1 の `mt-2` を外し、URL 行を `mt-8` に）
- 参照がなくなった `preview.heading` を ja/en の辞書から削除

## 意思決定

### 採用アプローチ
- `<label>` は消しつつ `aria-label={t.preview.urlLabel}` を input に付与。理由: 視覚的なラベルは冗長だが、readonly の URL 入力がスクリーンリーダーで無名になるのは避けたい

### 却下した代替案
- `sr-only` クラスで label を視覚的にだけ隠す → 却下: 同じ結果を DOM を増やさず `aria-label` で達成できる
- `urlLabel` も辞書から削除 → 却下: aria-label の値として引き続き必要

### 影響したテスト
- 「英語表示で日本語文言が出ない」ことの確認に `ja.preview.urlLabel` を使っていたが、画面から消えると常に 0 件になり検証力を失うため、画面に残る `ja.preview.expiry`（保管期限）へ差し替え

## テスト

- [x] `bun run typecheck` 通過
- [x] `bun test` 268 件全パス
- [x] `bun run build` 成功
- [x] `bunx playwright test e2e/preview.spec.ts` 27 件全パス（「タイトル → 保管期限 → URL → 動画 の順に並ぶ」を含む）
- [x] 所有者ビューのスクリーンショットで両ラベルの消失とレイアウト維持を確認

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/97956b044db0-04-preview-owner-ja-20260828022807-.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/7451140bc394-04-preview-owner-ja-20260828022716-.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
