### PR TITLE
ci(web): main への push で Cloudflare Workers を本番へ自動反映する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,91 @@
+# main への push で Cloudflare Workers（本体 + cron）を本番へ反映する。
+#
+# 2 つの Worker を常に両方デプロイするのは、同じ D1 / R2 を共有していて
+# compatibility_date を揃える必要があるため（paths で分けると片方だけ古い版が残る）。
+# E2E はここに入れない: CI 上の wrangler dev + Playwright はハングの報告があり、
+# デプロイが止まる損失の方が大きい（workers-sdk#6280）。
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+# 同時デプロイでバージョンが交差しないよう直列化する。進行中のものは殺さない
+# （デプロイ途中で止めると D1 とコードの版がずれる）。
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: web
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+
+      - run: bun install --frozen-lockfile
+
+      - name: 型チェック
+        run: bun run typecheck
+
+      - name: ユニットテスト
+        run: bun test
+
+      # D1 に down マイグレーションは無いため、ここを通すのは後方互換な変更だけ
+      # （破壊的変更は「追加 → 切替 → 削除」の 3 段階に分ける）。
+      - name: D1 マイグレーション適用
+        run: bunx wrangler d1 migrations apply webscreen-beta-db --remote
+
+      - name: ビルド
+        run: bun run build
+
+      - name: 本体 Worker をデプロイ
+        id: deploy_app
+        run: bunx wrangler deploy -c dist/server/wrangler.json
+
+      - name: cron Worker をデプロイ
+        id: deploy_cron
+        run: bunx wrangler deploy -c cron/wrangler.jsonc
+
+      # 1 人運用では「壊れたことに気づけない」のが最大のリスクなので、
+      # 反映の確認までを workflow の責任にする。
+      - name: 疎通確認
+        id: smoke
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' https://web-screen.net/api/health/ || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "health ok (attempt ${attempt})"
+              exit 0
+            fi
+            echo "health ${code} (attempt ${attempt}) — retrying"
+            sleep 10
+          done
+          echo "::error::デプロイ後の疎通確認に失敗しました"
+          exit 1
+
+      # 疎通に失敗した時だけ直前の版へ戻す。rollback は接続リソース（D1 / R2）を
+      # 戻さないので、スキーマを変えた回はこれだけでは復旧しない点に注意。
+      - name: 失敗時のロールバック
+        if: failure() && steps.deploy_app.outcome == 'success'
+        run: |
+          bunx wrangler rollback --yes || echo "::warning::本体 Worker のロールバックに失敗しました"
+          if [ "${{ steps.deploy_cron.outcome }}" = "success" ]; then
+            bunx wrangler rollback -c cron/wrangler.jsonc --yes \
+              || echo "::warning::cron Worker のロールバックに失敗しました"
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,21 +20,28 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# 本番資格情報を扱う workflow なので、GITHUB_TOKEN はリポジトリ既定値に任せず最小にする。
+permissions:
+  contents: read
+
 jobs:
   deploy:
+    # workflow_dispatch は UI から任意のブランチを選べる。main 以外のコードが
+    # 本番トークン付きで走らないよう、ここで弾く。
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
         working-directory: web
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
     steps:
-      - uses: actions/checkout@v5
+      # サードパーティを含め commit SHA で固定する（タグは動かせるため）。
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.6
 
@@ -46,46 +53,108 @@ jobs:
       - name: ユニットテスト
         run: bun test
 
-      # D1 に down マイグレーションは無いため、ここを通すのは後方互換な変更だけ
-      # （破壊的変更は「追加 → 切替 → 削除」の 3 段階に分ける）。
-      - name: D1 マイグレーション適用
-        run: bunx wrangler d1 migrations apply webscreen-beta-db --remote
-
+      # ビルドは本番へ触る前に済ませる。D1 を先に更新してからビルドが落ちると、
+      # 新しいスキーマと古いコードだけが残り、ロールバックでも戻せない。
       - name: ビルド
         run: bun run build
 
+      # ロールバック先を「この実行が始まる前に稼働していた版」に固定する。
+      # ID を省略すると直前に upload された別の版が選ばれうる。
+      - name: 現在の本番バージョンを記録
+        id: baseline
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          uuid='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+          app=$(bunx wrangler deployments status 2>/dev/null | grep -oE "$uuid" | head -1 || true)
+          cron=$(bunx wrangler deployments status -c cron/wrangler.jsonc 2>/dev/null | grep -oE "$uuid" | head -1 || true)
+          echo "app=${app}" >> "$GITHUB_OUTPUT"
+          echo "cron=${cron}" >> "$GITHUB_OUTPUT"
+          echo "baseline app=${app:-none} cron=${cron:-none}"
+
+      # D1 に down マイグレーションは無いため、ここを通すのは後方互換な変更だけ
+      # （破壊的変更は「追加 → 切替 → 削除」の 3 段階に分ける）。
+      - name: D1 マイグレーション適用
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler d1 migrations apply webscreen-beta-db --remote
+
       - name: 本体 Worker をデプロイ
         id: deploy_app
-        run: bunx wrangler deploy -c dist/server/wrangler.json
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          bunx wrangler deploy -c dist/server/wrangler.json | tee deploy-app.log
+          uuid='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+          version=$(grep -oiE "Current Version ID: ?$uuid" deploy-app.log | grep -oE "$uuid" | head -1 || true)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "deployed version=${version:-unknown}"
 
       - name: cron Worker をデプロイ
         id: deploy_cron
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy -c cron/wrangler.jsonc
 
-      # 1 人運用では「壊れたことに気づけない」のが最大のリスクなので、
-      # 反映の確認までを workflow の責任にする。
+      # 200 が返るだけでは旧版が生きている可能性を否定できないので、
+      # /api/health/ が名乗るバージョンとデプロイしたバージョンを突き合わせる。
       - name: 疎通確認
         id: smoke
+        env:
+          EXPECTED_VERSION: ${{ steps.deploy_app.outputs.version }}
         run: |
           for attempt in 1 2 3 4 5 6; do
-            code=$(curl -s -o /dev/null -w '%{http_code}' https://web-screen.net/api/health/ || echo 000)
-            if [ "$code" = "200" ]; then
-              echo "health ok (attempt ${attempt})"
-              exit 0
-            fi
-            echo "health ${code} (attempt ${attempt}) — retrying"
+            body=$(curl -s --connect-timeout 5 --max-time 15 https://web-screen.net/api/health/ || true)
+            case "$body" in
+              *'"status":"ok"'*)
+                if [ -z "$EXPECTED_VERSION" ]; then
+                  echo "health ok (attempt ${attempt}, バージョン照合はスキップ)"
+                  exit 0
+                fi
+                case "$body" in
+                  *"$EXPECTED_VERSION"*)
+                    echo "health ok かつバージョン一致 (attempt ${attempt})"
+                    exit 0
+                    ;;
+                esac
+                echo "health は ok だがバージョン未反映 (attempt ${attempt})"
+                ;;
+              *)
+                echo "health 応答なし (attempt ${attempt})"
+                ;;
+            esac
             sleep 10
           done
           echo "::error::デプロイ後の疎通確認に失敗しました"
           exit 1
 
-      # 疎通に失敗した時だけ直前の版へ戻す。rollback は接続リソース（D1 / R2）を
-      # 戻さないので、スキーマを変えた回はこれだけでは復旧しない点に注意。
+      # 本番へ触った後に失敗した時だけ戻す。rollback が戻すのは Worker のコードだけで、
+      # D1 / R2 のデータや cron スケジュール・ルートなどの設定は戻らない。
+      # スキーマを変えた回はこれだけでは復旧しないため、必ずログを確認すること。
       - name: 失敗時のロールバック
-        if: failure() && steps.deploy_app.outcome == 'success'
+        if: failure() && (steps.deploy_cron.outcome == 'failure' || steps.smoke.outcome == 'failure')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BASELINE_APP: ${{ steps.baseline.outputs.app }}
+          BASELINE_CRON: ${{ steps.baseline.outputs.cron }}
         run: |
-          bunx wrangler rollback --yes || echo "::warning::本体 Worker のロールバックに失敗しました"
-          if [ "${{ steps.deploy_cron.outcome }}" = "success" ]; then
-            bunx wrangler rollback -c cron/wrangler.jsonc --yes \
+          if [ -n "$BASELINE_APP" ]; then
+            bunx wrangler rollback "$BASELINE_APP" --yes \
+              || echo "::warning::本体 Worker のロールバックに失敗しました"
+          else
+            echo "::warning::ロールバック先のバージョンを記録できていないため本体は戻しません"
+          fi
+
+          if [ "${{ steps.deploy_cron.outcome }}" != "skipped" ] && [ -n "$BASELINE_CRON" ]; then
+            bunx wrangler rollback "$BASELINE_CRON" -c cron/wrangler.jsonc --yes \
               || echo "::warning::cron Worker のロールバックに失敗しました"
           fi
+
+          code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 15 \
+            https://web-screen.net/api/health/ || echo 000)
+          echo "ロールバック後の health: ${code}"

--- a/web/src/pages/api/health.ts
+++ b/web/src/pages/api/health.ts
@@ -1,11 +1,32 @@
 import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
 
 // SSR 経路の疎通確認用。middleware が付ける COOP/COEP の実測点も兼ねる
 // （prerender=true だと静的化され Worker を通らないため false 固定）。
 export const prerender = false;
 
-export const GET: APIRoute = () =>
-  new Response(JSON.stringify({ status: 'ok' }), {
+interface VersionMetadata {
+  id: string;
+  tag?: string;
+}
+
+interface HealthBindings {
+  CF_VERSION_METADATA?: VersionMetadata;
+}
+
+/**
+ * 応答に自分のバージョンを含める。
+ *
+ * デプロイ直後の疎通確認は、200 が返るだけでは「新しい版が配信されている」ことの
+ * 証明にならない（旧版が生きていても 200 を返す）。CI はこの id とデプロイ結果の
+ * バージョン ID を突き合わせて反映を判定する。
+ */
+export const GET: APIRoute = () => {
+  const bindings = env as unknown as HealthBindings;
+  const version = bindings.CF_VERSION_METADATA?.id ?? null;
+
+  return new Response(JSON.stringify({ status: 'ok', version }), {
     status: 200,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
   });
+};

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -43,6 +43,11 @@
       "bucket_name": "webscreen-beta"
     }
   ],
+  // /api/health/ が自分のバージョンを名乗るために使う。デプロイ直後の疎通確認で
+  // 「新しい版が配信されているか」を判定できないと、旧版が返す 200 を成功と誤認する。
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
   // Astro のセッション機能が既定で要求する KV。初回 deploy で wrangler が
   // 自動プロビジョニングしたものを、再デプロイ時の取り違えを防ぐため明示している。
   "kv_namespaces": [


### PR DESCRIPTION
## なぜこの変更が必要か

Cloudflare Worker のデプロイが `bun run deploy` の手動実行だけで、マージしても本番に反映されない状態だった。実際、PR #62 / #63 のどちらも本番へ届いておらず、「直したのに本番で直っていない」という認識のずれが起きた。

## 変更内容

- `.github/workflows/deploy.yml` を追加: 型チェック → ユニットテスト → ビルド → D1 マイグレーション → 本体 Worker → cron Worker → 疎通確認、の直列 1 job
- 疎通に失敗したら実行開始時の稼働バージョンへ自動ロールバック
- `/api/health/` が自分のバージョン ID を名乗るようにした（`version_metadata` binding）

## 意思決定

### 採用アプローチ
- **GitHub Actions**（Workers Builds ではない）。理由: テスト・型チェック・D1 適用をデプロイ前に置く自由度と、設定をリポジトリ側に置けること（Workers Builds はビルド設定が Cloudflare のダッシュボード側にあり、設定の正本が割れる）
- **2 つの Worker を常に両方デプロイ**。同じ D1 / R2 を共有し compatibility_date を揃える必要があるため、paths で分けて片方だけ古い版が残る事故を避ける
- **health にバージョンを持たせる**。200 が返るだけでは旧版が生きている可能性を否定できず、「デプロイした版が実際に配信されているか」を CI が判定できない

### 却下した代替案
- Workers Builds → 上記のとおり前段ゲートの自由度と設定の所在で不採用
- E2E を必須ゲートにする → CI 上の `wrangler dev` + Playwright はハングの報告があり（workers-sdk#6280）、デプロイが止まる損失の方が大きい。別 workflow へ隔離する
- gradual deployment（段階的ロールアウト）→ 1 人運用では監視コストが利益を上回る

### トレードオフ
- マージ即本番反映になる > 事前の承認ゲート: 可逆な変更であれば、回復性（すぐ戻せる）を優先する。そのためロールバックまでを workflow の責任に含めた

## セキュリティ上の配慮（レビュー指摘の反映）

- 本番資格情報は job 全体ではなく、D1・deploy・rollback の各 step にだけ渡す
- `permissions: contents: read` を明示、checkout は `persist-credentials: false`
- `workflow_dispatch` は UI から任意のブランチを選べるため、main 以外では job 自体を実行しない
- サードパーティを含め action を commit SHA で固定

## 既知の制約（workflow のコメントにも記載）

- `wrangler rollback` が戻すのは Worker のコードだけで、D1 / R2 のデータや cron スケジュール・ルートは戻らない。スキーマを変えた回はこれだけでは復旧しない
- D1 に down マイグレーションは無いため、workflow を通すのは後方互換な変更に限る

## テスト

- [x] `bun run typecheck` 通過
- [x] `bun test` 285 件全パス
- [x] `bun run build` 成功
- [x] `bunx playwright test` E2E 81 件全パス
- [x] `wrangler d1 migrations list --remote` で本番 D1 が適用済み（workflow の migration ステップは no-op）であることを確認
- [x] `wrangler deployments status` でバージョン ID が取得できる形式を確認
- [x] codex sol 2 レーン（通常 + セキュリティ xhigh）のレビューを実施し、ブロッキング 7 件を解消

Closes #74

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
