### PR TITLE
fix(web): 失敗した変換が履歴に「処理中」で残り続ける問題を直す

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -361,7 +361,6 @@ test.describe('履歴ドロップダウン', () => {
     await stubHistory(page, [
       historyMovie(),
       historyMovie({ shortId: E2E_FIXTURES.pinnedShortId, filename: 'pinned.mp4', pinned: true }),
-      historyMovie({ shortId: 'E2EPending99', filename: 'wip.pdf', status: 'pending' }),
     ]);
     await page.goto('/ja/');
 
@@ -369,11 +368,10 @@ test.describe('履歴ドロップダウン', () => {
     await menu.locator('summary').click();
 
     const rows = menu.locator('[data-history-row]');
-    await expect(rows).toHaveCount(3);
+    await expect(rows).toHaveCount(2);
     await expect(rows.first().getByText(E2E_FIXTURES.readyFilename)).toBeVisible();
     await expect(rows.first().getByText('3 分前')).toBeVisible();
     await expect(rows.nth(1).getByText(ja.history.pinned)).toBeVisible();
-    await expect(rows.nth(2).getByText(ja.history.processing)).toBeVisible();
 
     await page.screenshot({ path: screenshotPath('03-history-ja') });
 

--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -269,6 +269,30 @@ test.describe('ログイン済み', () => {
     await expect(page).toHaveURL(/\/Ab12Cd34Ef56\/$/, { timeout: 120_000 });
   });
 
+  test('アップロードに失敗したら予約した動画を取り消す', async ({ page }) => {
+    // presign を通った時点で pending の行が予約される。ここで失敗を放置すると
+    // 誰も failed へ落とさないまま履歴に「処理中」として残り続けていた。
+    test.setTimeout(180_000);
+    await signIn(page);
+    await mockUploadEndpoints(page, E2E_FIXTURES.readyShortId);
+    // R2 への PUT だけを失敗させる（presign は成功済み = 予約が残る状況を作る）
+    await page.route('https://upload.test/r2-upload', (route) => route.fulfill({ status: 500 }));
+
+    const deleteRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'DELETE' &&
+        request.url().includes(`/api/movies/${E2E_FIXTURES.readyShortId}/`)
+    );
+
+    await page.goto('/ja/');
+    await page
+      .locator('[data-convert-panel] [data-file-input]')
+      .setInputFiles([{ name: 'first.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG }]);
+
+    await deleteRequest;
+    await expect(page.locator('[data-convert-panel] [data-file-error]')).toBeVisible();
+  });
+
   test('対応外の形式は変換を始めずエラーを出す', async ({ page }) => {
     await signIn(page);
     await page.goto('/ja/');

--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -6,6 +6,7 @@ import { expect, test, type Page } from '@playwright/test';
 import en from '../src/i18n/en.json' with { type: 'json' };
 import ja from '../src/i18n/ja.json' with { type: 'json' };
 import { E2E_FIXTURES } from '../playwright.config';
+import { signIn as signInAsOwner } from './session';
 import { signIn as signInWithSessionCookie } from './session';
 import { SESSION_COOKIE_NAME } from '../src/lib/contracts/session';
 
@@ -269,19 +270,22 @@ test.describe('ログイン済み', () => {
     await expect(page).toHaveURL(/\/Ab12Cd34Ef56\/$/, { timeout: 120_000 });
   });
 
-  test('アップロードに失敗したら予約した動画を取り消す', async ({ page }) => {
+  test('アップロードに失敗したら予約した動画を実際に取り消す', async ({ page, context }) => {
     // presign を通った時点で pending の行が予約される。ここで失敗を放置すると
     // 誰も failed へ落とさないまま履歴に「処理中」として残り続けていた。
     test.setTimeout(180_000);
+    // 実セッションを張る（DELETE が 401 でも通ってしまうテストにしない）
+    await signInAsOwner(context, E2E_FIXTURES.ownerId);
     await signIn(page);
-    await mockUploadEndpoints(page, E2E_FIXTURES.readyShortId);
+    // seed 済みの pending 行を予約結果に見立てる
+    await mockUploadEndpoints(page, E2E_FIXTURES.pendingShortId);
     // R2 への PUT だけを失敗させる（presign は成功済み = 予約が残る状況を作る）
     await page.route('https://upload.test/r2-upload', (route) => route.fulfill({ status: 500 }));
 
-    const deleteRequest = page.waitForRequest(
-      (request) =>
-        request.method() === 'DELETE' &&
-        request.url().includes(`/api/movies/${E2E_FIXTURES.readyShortId}/`)
+    const deleteResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'DELETE' &&
+        response.url().includes(`/api/movies/${E2E_FIXTURES.pendingShortId}/`)
     );
 
     await page.goto('/ja/');
@@ -289,8 +293,41 @@ test.describe('ログイン済み', () => {
       .locator('[data-convert-panel] [data-file-input]')
       .setInputFiles([{ name: 'first.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG }]);
 
-    await deleteRequest;
+    // 送信されたことではなく、サーバーが受理したことを確認する
+    expect((await deleteResponse).status()).toBe(204);
     await expect(page.locator('[data-convert-panel] [data-file-error]')).toBeVisible();
+
+    // 対象が実際に消えている（pending は元から公開されないので、2 回目の DELETE が 404）
+    // Astro の origin チェック（CSRF 保護）が効いているため Origin を明示する
+    const second = await context.request.delete(`/api/movies/${E2E_FIXTURES.pendingShortId}/`, {
+      headers: { Origin: new URL(page.url()).origin },
+    });
+    expect(second.status()).toBe(404);
+  });
+
+  test('commit の応答が壊れていても完成した動画は消さない', async ({ page, context }) => {
+    // commit が成功して ready になった後に応答だけ失われるケース。ここで取り消すと
+    // 完成した動画を失うため、サーバーがエラーを返した時以外は触らない。
+    test.setTimeout(180_000);
+    await signInAsOwner(context, E2E_FIXTURES.ownerId);
+    await signIn(page);
+    await mockUploadEndpoints(page, E2E_FIXTURES.pinnedShortId);
+    await page.route('**/api/uploads/commit/', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: 'not-json' })
+    );
+
+    let deleteSeen = false;
+    page.on('request', (req) => {
+      if (req.method() === 'DELETE' && req.url().includes('/api/movies/')) deleteSeen = true;
+    });
+
+    await page.goto('/ja/');
+    await page
+      .locator('[data-convert-panel] [data-file-input]')
+      .setInputFiles([{ name: 'first.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG }]);
+
+    await expect(page.locator('[data-convert-panel] [data-file-error]')).toBeVisible();
+    expect(deleteSeen).toBe(false);
   });
 
   test('対応外の形式は変換を始めずエラーを出す', async ({ page }) => {

--- a/web/src/components/HistoryDropdown.astro
+++ b/web/src/components/HistoryDropdown.astro
@@ -76,10 +76,6 @@ const t = useTranslations(lang);
             <i class="fa-solid fa-thumbtack" aria-hidden="true"></i>
             <span>{t.history.pinned}</span>
           </span>
-          <span data-entry-processing hidden class="inline-flex items-center gap-1 text-amber-800">
-            <i class="fa-solid fa-hourglass-half" aria-hidden="true"></i>
-            <span>{t.history.processing}</span>
-          </span>
         </span>
       </a>
 

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -57,7 +57,6 @@
     "loading": "Loading",
     "empty": "You have not converted any video yet",
     "error": "Could not load your history",
-    "processing": "Processing",
     "pinned": "Pinned"
   },
   "preview": {
@@ -97,7 +96,7 @@
     "github": "GitHub",
     "privacy": "Cookies and privacy",
     "langSwitch": "日本語",
-    "note": "WebScreen β — an early release of the Cloudflare edition"
+    "note": "WebScreen β"
   },
   "privacy": {
     "heading": "Cookies and privacy",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -57,7 +57,6 @@
     "loading": "読み込んでいます",
     "empty": "変換した動画はまだありません",
     "error": "履歴を取得できませんでした",
-    "processing": "処理中",
     "pinned": "ピン留め中"
   },
   "preview": {
@@ -97,7 +96,7 @@
     "github": "GitHub",
     "privacy": "Cookie とプライバシー",
     "langSwitch": "English",
-    "note": "WebScreen β — Cloudflare 版の先行公開です"
+    "note": "WebScreen β"
   },
   "privacy": {
     "heading": "Cookie とプライバシー",

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -86,14 +86,21 @@ export interface MovieActionInput {
   shortId: string;
 }
 
-/** 自分の movies を新しい順に返す（未完了の pending も進捗確認のために含める）。 */
+/**
+ * 自分の movies を新しい順に返す。
+ *
+ * ready だけを返すのは、履歴を「共有できる動画の一覧」に揃えるため。pending は
+ * presign から commit までの数秒しか続かない一方、アップロードが失敗すると誰も
+ * failed へ落とさないまま残り、cron が回収する 24 時間後まで「処理中」と表示され
+ * 続けていた（進捗は変換パネル側が持っているので履歴に出す必要がない）。
+ */
 export async function listHistory(input: ListHistoryInput): Promise<HistoryResponse> {
   // created_at は秒精度なので、同一秒の挿入で並びが揺れないよう short_id を第 2 キーにする。
   const { results } = await input.database
     .prepare(
       `SELECT short_id, user_id, filename, status, pinned, created_at, expires_at
        FROM movies
-       WHERE user_id = ? AND status IN ('pending', 'ready')
+       WHERE user_id = ? AND status = 'ready'
        ORDER BY created_at DESC, short_id DESC
        LIMIT ?`
     )

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -15,6 +15,7 @@ import {
   type UploadKind,
 } from '../contracts/api';
 import { isShortId } from '../contracts/r2key';
+import { movieEndpoint } from './history-view';
 import { ConversionError, convertFilesToMp4, convertImageUrlsToMp4 } from '../convert';
 import {
   INITIAL_UPLOAD_STATE,
@@ -88,6 +89,24 @@ function asCaptureResponse(value: unknown): CaptureResponse {
   return { images: value.images as string[] };
 }
 
+/**
+ * 予約だけ済んで実体が上がらなかった動画を取り消す。
+ *
+ * keepalive を付けるのは、タブを閉じる直前の失敗でも送信を試みるため。ここが
+ * 失敗しても利用者に見せる情報は無い（cron の回収に委ねる）ので握りつぶす。
+ */
+function abandonUpload(shortId: string): void {
+  try {
+    void fetch(movieEndpoint(shortId), {
+      method: 'DELETE',
+      credentials: 'same-origin',
+      keepalive: true,
+    }).catch(() => undefined);
+  } catch {
+    // 送信自体が組み立てられない場合も、変換失敗の表示を優先して無視する
+  }
+}
+
 async function uploadMp4(
   mp4: Blob,
   filename: string,
@@ -108,21 +127,30 @@ async function uploadMp4(
     })
   );
   dispatch({ type: 'progress', value: 20 }, runGeneration);
-  const upload = await fetch(presign.uploadUrl, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'video/mp4' },
-    body: mp4,
-  });
-  if (!upload.ok) throw new Error(`Upload failed: ${upload.status}`);
-  dispatch({ type: 'progress', value: 80 }, runGeneration);
-  const committed = asCommitResponse(
-    await requestJson('/api/uploads/commit/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ shortId: presign.shortId }),
-    })
-  );
-  dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
+
+  // presign を通った時点で pending の行が予約されている。ここから先で失敗すると
+  // 誰も failed へ落とさないまま残り、cron が回収するまで容量を占め続けるため、
+  // 失敗を検知したその場で予約を取り消す。
+  try {
+    const upload = await fetch(presign.uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'video/mp4' },
+      body: mp4,
+    });
+    if (!upload.ok) throw new Error(`Upload failed: ${upload.status}`);
+    dispatch({ type: 'progress', value: 80 }, runGeneration);
+    const committed = asCommitResponse(
+      await requestJson('/api/uploads/commit/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ shortId: presign.shortId }),
+      })
+    );
+    dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
+  } catch (error) {
+    abandonUpload(presign.shortId);
+    throw error;
+  }
 }
 
 const API_ERROR_TO_UPLOAD_ERROR: Readonly<Partial<Record<ErrorCode, UploadErrorCode>>> = {

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -129,8 +129,8 @@ async function uploadMp4(
   dispatch({ type: 'progress', value: 20 }, runGeneration);
 
   // presign を通った時点で pending の行が予約されている。ここから先で失敗すると
-  // 誰も failed へ落とさないまま残り、cron が回収するまで容量を占め続けるため、
-  // 失敗を検知したその場で予約を取り消す。
+  // 誰も failed へ落とさないまま残り、cron が回収するまで容量を占め続ける。
+  // ただし取り消してよいのは「まだ ready になっていないと確信できる」失敗だけ。
   try {
     const upload = await fetch(presign.uploadUrl, {
       method: 'PUT',
@@ -138,7 +138,15 @@ async function uploadMp4(
       body: mp4,
     });
     if (!upload.ok) throw new Error(`Upload failed: ${upload.status}`);
-    dispatch({ type: 'progress', value: 80 }, runGeneration);
+  } catch (error) {
+    // R2 への PUT 段階の失敗。commit を送っていないので確実に pending のまま。
+    abandonUpload(presign.shortId);
+    throw error;
+  }
+
+  dispatch({ type: 'progress', value: 80 }, runGeneration);
+
+  try {
     const committed = asCommitResponse(
       await requestJson('/api/uploads/commit/', {
         method: 'POST',
@@ -148,7 +156,12 @@ async function uploadMp4(
     );
     dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
   } catch (error) {
-    abandonUpload(presign.shortId);
+    // サーバーが 4xx / 5xx を返した時だけ取り消す。通信断や、200 なのに本文が
+    // 壊れている応答では commit が成功して ready になっている可能性があり、
+    // 消すと完成した動画を失う（その場合の pending 残りは cron の回収に委ねる）。
+    if (error instanceof JsonRequestError && error.status >= 400) {
+      abandonUpload(presign.shortId);
+    }
     throw error;
   }
 }

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -44,9 +44,6 @@ function fillRow(
 
   const pin = row.querySelector<HTMLElement>('[data-entry-pinned]');
   if (pin) pin.hidden = !entry.pinned;
-
-  const processing = row.querySelector<HTMLElement>('[data-entry-processing]');
-  if (processing) processing.hidden = entry.status !== 'pending';
 }
 
 /** 削除の 2 段階確認（トリガー → 確認 → 実行）。confirm() は使わない。 */

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -66,10 +66,14 @@ class FakeMoviesDatabase implements MoviesDatabase {
     return movie && movie.userId === userId ? (toRow(movie) as T) : null;
   }
 
-  private all<T>(_query: string, values: unknown[]): T[] {
+  private all<T>(query: string, values: unknown[]): T[] {
     const [userId, limit] = values as [number, number];
+    // 履歴は ready だけを返す。他の一覧クエリは failed を除くだけに留める。
+    const isVisible = query.includes("status = 'ready'")
+      ? (status: string) => status === 'ready'
+      : (status: string) => status !== 'failed';
     return [...this.movies.values()]
-      .filter((movie) => movie.userId === userId && movie.status !== 'failed')
+      .filter((movie) => movie.userId === userId && isVisible(movie.status))
       .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
       .slice(0, limit)
       .map((movie) => toRow(movie) as T);
@@ -146,22 +150,34 @@ function pinnedMovies(count: number): TestMovie[] {
 }
 
 describe('listHistory', () => {
-  it('自分の pending と ready を新しい順に返し、日時を ISO8601 へ揃える', async () => {
+  it('ready を新しい順に返し、日時を ISO8601 へ揃える', async () => {
     const database = new FakeMoviesDatabase([
       movie({ shortId: 'old000000001', createdAt: '2026-08-01 00:00:00' }),
-      movie({ shortId: 'new000000002', createdAt: '2026-08-20 09:30:00', status: 'pending' }),
+      movie({ shortId: 'new000000002', createdAt: '2026-08-20 09:30:00' }),
     ]);
 
     const { movies } = await listHistory({ database, userId: USER_ID, publicBaseUrl: PUBLIC_URL });
 
     expect(movies.map((entry) => entry.shortId)).toEqual(['new000000002', 'old000000001']);
     expect(movies[0]).toMatchObject({
-      status: 'pending',
+      status: 'ready',
       pinned: false,
       // "YYYY-MM-DD HH:MM:SS" は UTC。ローカル時刻として解釈すると実行環境でずれる
       createdAt: '2026-08-20T09:30:00.000Z',
       publicUrl: `${PUBLIC_URL}/movies/new000000002.mp4`,
     });
+  });
+
+  it('アップロード未完了（pending）は履歴に出さない', async () => {
+    // 失敗した変換が誰にも failed へ落とされないまま「処理中」として残り続けていた。
+    const database = new FakeMoviesDatabase([
+      movie({ shortId: 'ready0000001' }),
+      movie({ shortId: 'pending00001', status: 'pending' }),
+    ]);
+
+    const { movies } = await listHistory({ database, userId: USER_ID, publicBaseUrl: PUBLIC_URL });
+
+    expect(movies.map((entry) => entry.shortId)).toEqual(['ready0000001']);
   });
 
   it('他人の動画は返さない', async () => {


### PR DESCRIPTION
## なぜこの変更が必要か

アップロードに失敗した変換が、履歴に「処理中」として最長 25 時間残り続けていた（ユーザー報告のスクリーンショットで「13 時間前・処理中」が複数）。

原因は 2 つ:
- presign の時点で pending の行が予約されるが、その後 PUT / commit が失敗しても誰も `failed` へ落とさない
- 履歴の SQL が pending も返していた

回収は cron の 24 時間猶予（`retention.ts`）に委ねられていたため、その間ずっと「処理中」に見えていた。

## 変更内容

- 履歴は `ready` だけを返す。pending は presign から commit までの数秒しか続かず、進捗は変換パネル側が持っているので履歴に出す意味がない
- アップロードの失敗を検知したその場で、予約した動画を `DELETE` で取り消す（`keepalive` 付き）
- フッターの「— Cloudflare 版の先行公開です」を削除

## 意思決定

### 採用アプローチ
- 表示側（履歴を ready に絞る）と発生源側（失敗時に取り消す）の両方を直す。片方だけだと、表示は消えても残骸は残る / 残骸は減っても取りこぼしが表示される

### 取り消しの条件（レビューで厳格化）
**commit の結果が不明な失敗では取り消さない。** サーバー側の `DELETE` は status を限定せず R2 と D1 を削除するため、commit が成功して `ready` になった後に応答だけ失われたケースで取り消すと、**完成した動画を消してしまう**。

取り消すのは次の 2 つだけ:
- R2 への PUT 段階の失敗（commit を送っていないので確実に pending）
- commit が 4xx / 5xx を返した場合（サーバーが ready にしていないことが確定）

通信断や「200 だが本文が壊れている」応答では触らず、cron の回収に委ねる。

### 却下した代替案
- cron の pending 猶予を 24h → 1〜2h に短縮 → 却下: 最大 2 時間は「処理中」が残るうえ、発生源が消えない
- 経過時間で「失敗」と推定して表示する → 却下: 履歴を ready に絞れば推定自体が不要

## テスト

- [x] `bun test` 286 件全パス（履歴が pending を返さないことを検証するケースを追加）
- [x] `bun run typecheck` / `bun run build` 成功
- [x] E2E 83 件全パス。**実セッション（署名済み Cookie）** で以下を追加:
  - R2 への PUT だけを失敗させ、`DELETE` が 204 で受理され、対象が実際に消える（2 回目が 404）
  - commit の応答が壊れていても完成した動画を消さない（このテストが最初の実装の誤りを実際に捕まえた）
- [x] codex sol 2 レーン（通常 + セキュリティ）のレビューを実施し、ブロッキング 2 件を解消

## 補足

E2E の追加中に、Astro の origin チェック（CSRF 保護）が `DELETE` に効いていることを確認した（Origin ヘッダーなしの API 呼び出しは 403）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

