### PR TITLE
fix(web): 保持期間バッチと pin の競合で動画の実体だけが消えるのを防ぐ

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -25,7 +25,7 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `POST /api/uploads/presign/` | R2 へのアップロード先を払い出し、movies に `pending` 行を作る | 本人 | `PresignRequest` / `PresignResponse` |
 | `POST /api/uploads/commit/` | アップロード完了を確定し `ready` にする | 本人（当該 movie の所有者） | `CommitRequest` / `CommitResponse` |
 | `GET /api/history/` | 自分の動画一覧 | 本人 | `HistoryResponse` |
-| `POST /api/movies/{shortId}/pin/` | pin の切り替え（保管期限を 1 年後まで延ばす） | 本人（所有者） | `PinResponse` |
+| `POST /api/movies/{shortId}/pin/` | pin の切り替え（保管期限を 1 年後まで延ばす。期限切れは 410 `EXPIRED`） | 本人（所有者） | `PinResponse` |
 | `PATCH /api/movies/{shortId}/` | ファイル名の変更 | 本人（所有者） | `RenameMovieRequest` / `RenameMovieResponse` |
 | `DELETE /api/movies/{shortId}/` | 動画の削除（R2 の実体 → D1 の行の順） | 本人（所有者） | — |
 

--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -48,7 +48,7 @@ export default {
           severity: 'info',
           kind: 'event',
           cron: event.cron,
-          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies, ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.`,
+          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.`,
           detail: summary,
           durationMs: Date.now() - startedAt,
         })

--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -41,11 +41,15 @@ export default {
         now: new Date(event.scheduledTime),
       });
 
-      console.log(
+      // 実体だけ消えた行は放置すると壊れた URL が残り続けるので、成功ログに埋もれさせない
+      const severity = summary.strandedMovies > 0 ? 'error' : 'info';
+      const log = severity === 'error' ? console.error : console.log;
+
+      log(
         JSON.stringify({
           timestamp: new Date(event.scheduledTime).toISOString(),
           source: SOURCE,
-          severity: 'info',
+          severity,
           kind: 'event',
           cron: event.cron,
           summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.`,

--- a/web/e2e/fixtures/seed.sql
+++ b/web/e2e/fixtures/seed.sql
@@ -41,6 +41,17 @@ VALUES
     datetime('now', '-1 hours'),
     strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+30 days')
   ),
+  -- 期限切れ専用。保持期間バッチは e2e では走らないので、行はそのまま残る。
+  (
+    'E2EExpired01',
+    1,
+    'expired.pdf',
+    1024,
+    'ready',
+    0,
+    datetime('now', '-40 days'),
+    strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-1 days')
+  ),
   -- 削除テスト専用。テストは並列実行されるので、状態を変える試験ごとに行を分ける。
   (
     'E2EDelete001',

--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -302,6 +302,16 @@ test.describe('所有者の操作', () => {
     await expect(hint).toBeHidden();
   });
 
+  test('保管期限を過ぎた動画は pin できず、理由を表示する', async ({ page, context }) => {
+    await signIn(context, E2E_FIXTURES.ownerId);
+    await page.goto(`/${E2E_FIXTURES.expiredShortId}/`);
+
+    await page.getByRole('button', { name: ja.preview.pin }).click();
+
+    // 上限超過（409）と同じ扱いにすると「10 件まで」と出て理由が伝わらない
+    await expect(page.locator('[data-pin-failed]')).toHaveText(ja.preview.pinExpired);
+  });
+
   test('ピン留め中はボタンが解除の操作に変わる', async ({ page, context }) => {
     await signIn(context, E2E_FIXTURES.ownerId);
     await page.goto(`/${E2E_FIXTURES.pinnedShortId}/`);

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -30,6 +30,8 @@ export const E2E_FIXTURES = {
   pinnedRemainingDays: 365,
   /** 3 日前に作られているので、pin を外すと作成 + 30 日 = あと 27 日に戻る。 */
   pinnedRemainingDaysAfterUnpin: 27,
+  /** seed.sql が 1 日前の期限で入れる。pin が 410 で断られることの確認に使う。 */
+  expiredShortId: 'E2EExpired01',
   pendingShortId: 'E2EPending01',
   deletableShortId: 'E2EDelete001',
 } as const;

--- a/web/src/components/MoviePreview.astro
+++ b/web/src/components/MoviePreview.astro
@@ -39,6 +39,7 @@ const pinHint = t.preview.pinHint.replace('{count}', String(MAX_PINNED_MOVIES));
   data-delete-scope
   data-short-id={shortId}
   data-msg-pin-limit={pinLimitMessage}
+  data-msg-pin-expired={t.preview.pinExpired}
   data-msg-pin-failed={t.preview.pinFailed}
   data-msg-rename-failed={t.preview.renameFailed}
   data-msg-delete-failed={t.actions.deleteFailed}

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -73,6 +73,7 @@
     "unpin": "Remove pin",
     "pinHint": "Pinned videos are kept for one year (up to {count})",
     "pinLimit": "You can pin up to {count} videos",
+    "pinExpired": "This video is past its retention date",
     "pinFailed": "Could not change the pin",
     "rename": "Rename",
     "renameSave": "Save",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -73,6 +73,7 @@
     "unpin": "ピン留めを解除",
     "pinHint": "ピン留めした動画は 1 年間保管します（{count} 件まで）",
     "pinLimit": "ピン留めできるのは {count} 件までです",
+    "pinExpired": "保管期限を過ぎているため変更できません",
     "pinFailed": "ピン留めを変更できませんでした",
     "rename": "ファイル名を編集",
     "renameSave": "保存",

--- a/web/src/lib/contracts/api.ts
+++ b/web/src/lib/contracts/api.ts
@@ -44,6 +44,7 @@ export const ERROR_CODES = {
   unauthorized: 'UNAUTHORIZED',
   forbidden: 'FORBIDDEN',
   notFound: 'NOT_FOUND',
+  expired: 'EXPIRED',
   payloadTooLarge: 'PAYLOAD_TOO_LARGE',
   captureFailed: 'CAPTURE_FAILED',
   pageTooLong: 'PAGE_TOO_LONG',

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -56,7 +56,7 @@ export interface MovieBucket {
 /** エントリポイントが HTTP 応答へ変換するドメインエラー。 */
 export class MovieActionError extends Error {
   constructor(
-    public readonly status: 400 | 404 | 409,
+    public readonly status: 400 | 404 | 409 | 410,
     public readonly errorCode: ErrorCode,
     message: string
   ) {
@@ -121,11 +121,26 @@ export async function listHistory(input: ListHistoryInput): Promise<HistoryRespo
  * pin 時は expires_at を今から 365 日後へ延ばし、解除時は元の保管期限
  * （created_at + 30 日）へ戻す。既に過ぎている場合は即時削除にならないよう猶予を与える。
  * pin し直すたびに 365 日後へ延びる（残したい動画は所有者が触り続ける前提）。
+ *
+ * 保管期限を過ぎた動画は 410 で断る。ここを通すと「期限切れ」が終端の状態でなくなり、
+ * 保持期間バッチが R2 の実体を消してから D1 の行を消すまでの間に期限が延びて、
+ * 実体だけが消えた行が残る（services/retention.ts の deleteExpiredMovies）。
+ * 期限切れの動画は毎時のバッチでどのみち消えるので、延命の余地を残さない。
  */
 export async function togglePin(
   input: MovieActionInput & { now?: Date }
 ): Promise<PinResponse> {
   const movie = await findOwnedMovie(input.database, input.userId, input.shortId);
+  const now = input.now ?? new Date();
+
+  if (isExpired(movie.expires_at, now)) {
+    throw new MovieActionError(
+      410,
+      ERROR_CODES.expired,
+      '保管期限を過ぎた動画は変更できません'
+    );
+  }
+
   const nextPinned = movie.pinned === 0;
 
   if (nextPinned) {
@@ -139,7 +154,6 @@ export async function togglePin(
     }
   }
 
-  const now = input.now ?? new Date();
   const expiresAt = nextPinned
     ? new Date(now.getTime() + PINNED_RETENTION_MS).toISOString()
     : restoredExpiry(movie.created_at, now);
@@ -256,6 +270,16 @@ async function countPinnedMovies(database: MoviesDatabase, userId: number): Prom
 }
 
 /** pin 解除時の期限。元の期限が既に過ぎていたら、その場で消えないよう猶予を足す。 */
+/**
+ * 保管期限を過ぎているか。表記が ISO8601 と SQLite の datetime('now') で混在するため
+ * toIsoString で揃えてから比較する（保持期間バッチの datetime() 比較と同じ理由）。
+ */
+function isExpired(expiresAt: string | null, now: Date): boolean {
+  if (expiresAt === null) return false;
+  const timestamp = Date.parse(toIsoString(expiresAt));
+  return Number.isFinite(timestamp) && timestamp <= now.getTime();
+}
+
 function restoredExpiry(createdAt: string, now: Date): string {
   const restored = new Date(new Date(toIsoString(createdAt)).getTime() + MOVIE_RETENTION_MS);
   if (restored.getTime() > now.getTime()) return restored.toISOString();

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -43,7 +43,7 @@ export interface MoviesDatabase {
     bind(...values: unknown[]): {
       first<T>(): Promise<T | null>;
       all<T>(): Promise<{ results: T[] }>;
-      run(): Promise<unknown>;
+      run(): Promise<{ meta: { changes: number } }>;
     };
   };
 }
@@ -126,6 +126,10 @@ export async function listHistory(input: ListHistoryInput): Promise<HistoryRespo
  * 保持期間バッチが R2 の実体を消してから D1 の行を消すまでの間に期限が延びて、
  * 実体だけが消えた行が残る（services/retention.ts の deleteExpiredMovies）。
  * 期限切れの動画は毎時のバッチでどのみち消えるので、延命の余地を残さない。
+ *
+ * 判定は 2 段構え。読んだ値での事前判定は理由（410）を上限超過（409）より先に返すためで、
+ * 競合を防ぐのは UPDATE の WHERE に入れた期限条件の方。読んでから書くまでの間に期限が
+ * 過ぎる可能性があるので、事前判定だけでは同じ競合が残る。
  */
 export async function togglePin(
   input: MovieActionInput & { now?: Date }
@@ -158,12 +162,33 @@ export async function togglePin(
     ? new Date(now.getTime() + PINNED_RETENTION_MS).toISOString()
     : restoredExpiry(movie.created_at, now);
 
-  await input.database
-    .prepare('UPDATE movies SET pinned = ?, expires_at = ? WHERE short_id = ? AND user_id = ?')
-    .bind(nextPinned ? 1 : 0, expiresAt, input.shortId, input.userId)
+  // 比較は保持期間バッチと同じ datetime() で行う（ISO8601 と SQLite の表記が混在し、
+  // 素の文字列比較では大小が逆転するため。精度と演算子も揃えて判定を食い違わせない）。
+  const result = await input.database
+    .prepare(
+      'UPDATE movies SET pinned = ?, expires_at = ? WHERE short_id = ? AND user_id = ?' +
+        ' AND (expires_at IS NULL OR datetime(expires_at) >= datetime(?))'
+    )
+    .bind(nextPinned ? 1 : 0, expiresAt, input.shortId, input.userId, now.toISOString())
     .run();
 
+  // 0 件 = 読んだ後に期限が過ぎたか、行そのものが消えた。成功として返すと
+  // 画面には pin 済みと出るのに実体は消える。
+  if (result.meta.changes === 0) await throwPinConflict(input);
+
   return { shortId: input.shortId, pinned: nextPinned, expiresAt };
+}
+
+/**
+ * pin の UPDATE が 0 件だった理由を引き直して投げる。
+ *
+ * 行が消えていれば 404（他の経路の削除・保持期間バッチと競合）、残っていれば 410（期限切れ）。
+ * 稀な経路なので、通常時に追加のクエリを増やさないようここでだけ読み直す。
+ */
+async function throwPinConflict(input: MovieActionInput): Promise<never> {
+  // 行が消えていればここで 404 になる。残っているなら、WHERE で外れた条件は期限しかない。
+  await findOwnedMovie(input.database, input.userId, input.shortId);
+  throw new MovieActionError(410, ERROR_CODES.expired, '保管期限を過ぎた動画は変更できません');
 }
 
 /**

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -128,8 +128,8 @@ export async function listHistory(input: ListHistoryInput): Promise<HistoryRespo
  * 期限切れの動画は毎時のバッチでどのみち消えるので、延命の余地を残さない。
  *
  * 判定は 2 段構え。読んだ値での事前判定は理由（410）を上限超過（409）より先に返すためで、
- * 競合を防ぐのは UPDATE の WHERE に入れた期限条件の方。読んでから書くまでの間に期限が
- * 過ぎる可能性があるので、事前判定だけでは同じ競合が残る。
+ * 競合を防ぐのは UPDATE の WHERE に入れた期限条件の方（D1 の実行時刻で評価する）。
+ * 事前判定だけでは、判定から書き込みまでの間に期限をまたぐ経路が残る。
  */
 export async function togglePin(
   input: MovieActionInput & { now?: Date }
@@ -162,14 +162,16 @@ export async function togglePin(
     ? new Date(now.getTime() + PINNED_RETENTION_MS).toISOString()
     : restoredExpiry(movie.created_at, now);
 
-  // 比較は保持期間バッチと同じ datetime() で行う（ISO8601 と SQLite の表記が混在し、
-  // 素の文字列比較では大小が逆転するため。精度と演算子も揃えて判定を食い違わせない）。
+  // 期限の判定は D1 の実行時刻（datetime('now')）で行う。リクエスト開始時に読んだ
+  // now を渡すと、件数の問い合わせなどを挟む間に期限をまたいでも更新が通ってしまう。
+  // 比較を datetime() で行うのは保持期間バッチと同じ理由（ISO8601 と SQLite の表記が
+  // 混在し、素の文字列比較では大小が逆転するため）。
   const result = await input.database
     .prepare(
       'UPDATE movies SET pinned = ?, expires_at = ? WHERE short_id = ? AND user_id = ?' +
-        ' AND (expires_at IS NULL OR datetime(expires_at) >= datetime(?))'
+        " AND (expires_at IS NULL OR datetime(expires_at) >= datetime('now'))"
     )
-    .bind(nextPinned ? 1 : 0, expiresAt, input.shortId, input.userId, now.toISOString())
+    .bind(nextPinned ? 1 : 0, expiresAt, input.shortId, input.userId)
     .run();
 
   // 0 件 = 読んだ後に期限が過ぎたか、行そのものが消えた。成功として返すと

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -181,9 +181,16 @@ async function deleteExpiredMovies(
       .bind(row.short_id, threshold)
       .run();
     deleted += result.meta.changes;
-    // 実体を消したのに行が残った = 上の不変条件が破れている。次回の実行では
-    // R2 が空なので気づけないため、この場で数えて可視化する。
-    if (result.meta.changes === 0) stranded += 1;
+    // 0 件は「行が残った」とは限らない（所有者の削除と競合しただけなら正常）。
+    // 実体を消したのに行が残っている時だけ、不変条件が破れた印として数える。
+    // 次回の実行では R2 が空で気づけないため、この場で確かめる。
+    if (result.meta.changes === 0) {
+      const remaining = await database
+        .prepare('SELECT short_id FROM movies WHERE short_id = ?')
+        .bind(row.short_id)
+        .all<ShortIdRow>();
+      if (remaining.results.length > 0) stranded += 1;
+    }
   }
 
   return { deleted, stranded };

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -66,6 +66,8 @@ export interface RetentionBucket {
 export interface RetentionSummary {
   backfilledPinned: number;
   deletedMovies: number;
+  /** R2 の実体を消したのに行が残った件数。0 以外は不変条件が破れた印。 */
+  strandedMovies: number;
   deletedOrphans: number;
   deletedFailed: number;
   deletedCaptures: number;
@@ -91,10 +93,14 @@ interface ShortIdRow {
 export async function runRetention(input: RetentionInput): Promise<RetentionSummary> {
   const { database, bucket, now } = input;
 
+  // 掃除より先に走らせる。期限を入れた直後の行は 1 年先なので同じ実行では消えない。
+  const backfilledPinned = await backfillPinnedExpiry(database, now);
+  const expired = await deleteExpiredMovies(database, bucket, now);
+
   return {
-    // 掃除より先に走らせる。期限を入れた直後の行は 1 年先なので同じ実行では消えない。
-    backfilledPinned: await backfillPinnedExpiry(database, now),
-    deletedMovies: await deleteExpiredMovies(database, bucket, now),
+    backfilledPinned,
+    deletedMovies: expired.deleted,
+    strandedMovies: expired.stranded,
     deletedOrphans: await deletePendingOrphans(database, bucket, now),
     deletedFailed: await deleteFailedMovies(database, now),
     deletedCaptures: await deleteStaleCaptures(bucket, now),
@@ -123,6 +129,11 @@ async function backfillPinnedExpiry(database: RetentionDatabase, now: Date): Pro
  * expires_at を過ぎた ready 動画を削除する。pin の有無では絞らない
  * （pin は保管期間を 365 日へ延ばすだけで、期限が来れば同じように消える）。
  *
+ * R2 と D1 をまたぐ削除は原子的にできないので、「期限切れは終端の状態である」ことに
+ * 依存している。期限を延ばせるのは services/movies.ts の togglePin だけで、そこが
+ * 期限切れの行を 410 で断るため、SELECT から DELETE までの間に期限が延びることはない。
+ * それでも行が残った場合は stranded として数え、cron のログに出す（Fail Loud）。
+ *
  * 比較で datetime() を挟むのは、expires_at が ISO8601（`2026-...T...Z`）、
  * created_at が SQLite の datetime('now')（`2026-... ...`）と表記が混在しており、
  * 素の文字列比較では大小が逆転するため。idx_movies_expires_at は効かなくなるが、
@@ -132,7 +143,7 @@ async function deleteExpiredMovies(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<number> {
+): Promise<{ deleted: number; stranded: number }> {
   const threshold = now.toISOString();
   const { results } = await database
     .prepare(
@@ -142,6 +153,7 @@ async function deleteExpiredMovies(
     .all<ShortIdRow>();
 
   let deleted = 0;
+  let stranded = 0;
   for (const row of results) {
     // 初回 SELECT の後に pin（= 期限の延長）が入った場合、R2 を先に消すと生きた
     // 行だけが残る。R2 削除の直前にも期限を読み直し、実体と行の不整合を防ぐ。
@@ -169,9 +181,12 @@ async function deleteExpiredMovies(
       .bind(row.short_id, threshold)
       .run();
     deleted += result.meta.changes;
+    // 実体を消したのに行が残った = 上の不変条件が破れている。次回の実行では
+    // R2 が空なので気づけないため、この場で数えて可視化する。
+    if (result.meta.changes === 0) stranded += 1;
   }
 
-  return deleted;
+  return { deleted, stranded };
 }
 
 /**

--- a/web/src/lib/ui/preview-actions.ts
+++ b/web/src/lib/ui/preview-actions.ts
@@ -57,6 +57,15 @@ function requestFailureMessage(root: HTMLElement, error: unknown, fallback: stri
   return isUnauthorizedRequestError(error) ? (root.dataset['msgSessionExpired'] ?? fallback) : fallback;
 }
 
+/** pin の失敗理由を文言に落とす。理由ごとに次の行動が変わるので status で分ける。 */
+function pinFailureMessage(root: HTMLElement, error: unknown): string {
+  if (error instanceof JsonRequestError) {
+    if (error.status === 409) return root.dataset['msgPinLimit'] ?? '';
+    if (error.status === 410) return root.dataset['msgPinExpired'] ?? '';
+  }
+  return requestFailureMessage(root, error, root.dataset['msgPinFailed'] ?? '');
+}
+
 /**
  * ホバー / フォーカスで出る補足を Escape で閉じられるようにする（WCAG 1.4.13 Dismissible）。
  *
@@ -107,11 +116,8 @@ function wirePin(root: HTMLElement, fetchImpl: typeof fetch, reload: () => void)
 
       button.disabled = false;
       if (!failure) return;
-      // 409 は「上限に達した」で、それ以外は汎用の失敗として扱う
-      failure.textContent =
-        error instanceof JsonRequestError && error.status === 409
-          ? (root.dataset['msgPinLimit'] ?? '')
-          : requestFailureMessage(root, error, root.dataset['msgPinFailed'] ?? '');
+      // 409 は「上限に達した」、410 は「保管期限を過ぎた」。それ以外は汎用の失敗
+      failure.textContent = pinFailureMessage(root, error);
       failure.hidden = false;
     })();
   });

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -34,6 +34,8 @@ interface TestMovie {
 /** D1 binding の代役。SQL の先頭句で分岐し、実際の movies テーブルの挙動だけを真似る。 */
 class FakeMoviesDatabase implements MoviesDatabase {
   readonly movies = new Map<string, TestMovie>();
+  /** pin の UPDATE 直前に走るフック。期限をまたぐ競合の再現に使う。 */
+  onBeforePinUpdate: (() => void) | undefined;
 
   constructor(movies: TestMovie[] = []) {
     for (const movie of movies) this.movies.set(movie.shortId, { ...movie });
@@ -44,7 +46,7 @@ class FakeMoviesDatabase implements MoviesDatabase {
       bind: (...values: unknown[]) => ({
         first: async <T>(): Promise<T | null> => this.first<T>(query, values),
         all: async <T>(): Promise<{ results: T[] }> => ({ results: this.all<T>(query, values) }),
-        run: async (): Promise<unknown> => this.run(query, values),
+        run: async (): Promise<{ meta: { changes: number } }> => this.run(query, values),
       }),
     };
   }
@@ -82,29 +84,42 @@ class FakeMoviesDatabase implements MoviesDatabase {
       .map((movie) => toRow(movie) as T);
   }
 
-  private run(query: string, values: unknown[]): void {
+  private run(query: string, values: unknown[]): { meta: { changes: number } } {
     if (query.startsWith('UPDATE movies SET filename')) {
       const [filename, shortId, userId] = values as [string, string, number];
       const movie = this.movies.get(shortId);
       if (movie && movie.userId === userId) movie.filename = filename;
-      return;
+      return { meta: { changes: movie && movie.userId === userId ? 1 : 0 } };
     }
 
     if (query.startsWith('UPDATE movies SET pinned')) {
-      const [pinned, expiresAt, shortId, userId] = values as [number, string | null, string, number];
+      const [pinned, expiresAt, shortId, userId, threshold] = values as [
+        number,
+        string | null,
+        string,
+        number,
+        string,
+      ];
+      // UPDATE の直前に走らせるフック（判定から書き込みまでの間の割り込みを再現する）
+      this.onBeforePinUpdate?.();
       const movie = this.movies.get(shortId);
-      if (movie && movie.userId === userId) {
-        movie.pinned = pinned;
-        movie.expiresAt = expiresAt;
+      // 本番の WHERE と同じく、期限が残っている行だけを更新する
+      if (!movie || movie.userId !== userId || isPastExpiry(movie.expiresAt, threshold)) {
+        return { meta: { changes: 0 } };
       }
-      return;
+      movie.pinned = pinned;
+      movie.expiresAt = expiresAt;
+      return { meta: { changes: 1 } };
     }
 
     if (query.startsWith('DELETE FROM movies')) {
       const [shortId, userId] = values as [string, number];
       const movie = this.movies.get(shortId);
       if (movie && movie.userId === userId) this.movies.delete(shortId);
+      return { meta: { changes: movie && movie.userId === userId ? 1 : 0 } };
     }
+
+    return { meta: { changes: 0 } };
   }
 }
 
@@ -132,6 +147,17 @@ const USER_ID = 10;
 const SHORT_ID = 'AbCdEf123456';
 const PUBLIC_URL = 'https://public.example';
 const CREATED_AT = '2026-08-01 00:00:00';
+
+/** 本番の datetime() 比較に相当する判定（秒精度・両表記を UTC として解釈する）。 */
+function isPastExpiry(expiresAt: string | null, threshold: string): boolean {
+  if (expiresAt === null) return false;
+  const toMs = (value: string): number => {
+    const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+    const parsed = Date.parse(/[Z+]|-\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`);
+    return Math.floor(parsed / 1000) * 1000;
+  };
+  return toMs(expiresAt) < toMs(threshold);
+}
 
 function movie(overrides: Partial<TestMovie> = {}): TestMovie {
   return {
@@ -287,7 +313,36 @@ describe('togglePin', () => {
     expect(database.movies.get(SHORT_ID)).toMatchObject({ pinned: 1 });
   });
 
-  it('期限ちょうどでも過ぎている扱いにする（バッチの閾値と食い違わせない）', async () => {
+  it('判定の後・書き込みの前に期限が過ぎたら更新を通さない', async () => {
+    // 読んでから書くまでの間にバッチが拾える状態になる順序。事前判定だけだと
+    // ここで期限が延び、R2 の実体だけ消えた行が残る（Issue #83）
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([movie({ expiresAt: '2026-09-01T00:00:10.000Z' })]);
+    database.onBeforePinUpdate = () => {
+      const target = database.movies.get(SHORT_ID);
+      if (target) target.expiresAt = '2026-08-31T23:59:00.000Z';
+    };
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 410, errorCode: ERROR_CODES.expired });
+    expect(database.movies.get(SHORT_ID)).toMatchObject({ pinned: 0 });
+  });
+
+  it('判定の後・書き込みの前に行が消えていたら 404 を返す', async () => {
+    const now = new Date('2026-08-30T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([movie()]);
+    database.onBeforePinUpdate = () => database.movies.delete(SHORT_ID);
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 404, errorCode: ERROR_CODES.notFound });
+  });
+
+  it('期限ちょうどは断る（バッチより厳しい側に倒す）', async () => {
+    // バッチの削除条件は expires_at < 閾値 なので、ちょうどの行はまだ消えない。
+    // ここで通すと「延長できたのに次の実行で消える」わけではないが、判定の向きは
+    // 常にバッチより厳しい側に寄せておく（緩い側に寄せると競合の余地ができる）。
     const expiresAt = '2026-09-01T00:00:00.000Z';
     const database = new FakeMoviesDatabase([movie({ expiresAt })]);
 

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -34,6 +34,8 @@ interface TestMovie {
 /** D1 binding の代役。SQL の先頭句で分岐し、実際の movies テーブルの挙動だけを真似る。 */
 class FakeMoviesDatabase implements MoviesDatabase {
   readonly movies = new Map<string, TestMovie>();
+  /** SQL 内の datetime('now') に相当する D1 側の時刻。テストから進められる。 */
+  now = new Date('2026-08-30T00:00:00.000Z');
   /** pin の UPDATE 直前に走るフック。期限をまたぐ競合の再現に使う。 */
   onBeforePinUpdate: (() => void) | undefined;
 
@@ -93,17 +95,15 @@ class FakeMoviesDatabase implements MoviesDatabase {
     }
 
     if (query.startsWith('UPDATE movies SET pinned')) {
-      const [pinned, expiresAt, shortId, userId, threshold] = values as [
-        number,
-        string | null,
-        string,
-        number,
-        string,
-      ];
+      const [pinned, expiresAt, shortId, userId] = values as [number, string | null, string, number];
       // UPDATE の直前に走らせるフック（判定から書き込みまでの間の割り込みを再現する）
       this.onBeforePinUpdate?.();
       const movie = this.movies.get(shortId);
-      // 本番の WHERE と同じく、期限が残っている行だけを更新する
+      // 判定に使う時刻は SQL の書き方で決まる。datetime('now') なら実行時点、
+      // バインド値ならその値（実装が古い now を渡していれば、それがそのまま効く）。
+      const threshold = query.includes("datetime('now')")
+        ? this.now.toISOString()
+        : ((values[4] as string | undefined) ?? this.now.toISOString());
       if (!movie || movie.userId !== userId || isPastExpiry(movie.expiresAt, threshold)) {
         return { meta: { changes: 0 } };
       }
@@ -291,6 +291,7 @@ describe('togglePin', () => {
     const database = new FakeMoviesDatabase([
       movie({ expiresAt: '2026-08-31T23:59:59.000Z' }),
     ]);
+    database.now = now;
 
     await expect(
       togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
@@ -306,6 +307,7 @@ describe('togglePin', () => {
     const database = new FakeMoviesDatabase([
       movie({ pinned: 1, expiresAt: '2026-08-31T23:59:59.000Z' }),
     ]);
+    database.now = now;
 
     await expect(
       togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
@@ -318,9 +320,10 @@ describe('togglePin', () => {
     // ここで期限が延び、R2 の実体だけ消えた行が残る（Issue #83）
     const now = new Date('2026-09-01T00:00:00.000Z');
     const database = new FakeMoviesDatabase([movie({ expiresAt: '2026-09-01T00:00:10.000Z' })]);
+    database.now = now;
+    // 期限そのものは動かさず、書き込みまでに実時間が期限を越える
     database.onBeforePinUpdate = () => {
-      const target = database.movies.get(SHORT_ID);
-      if (target) target.expiresAt = '2026-08-31T23:59:00.000Z';
+      database.now = new Date('2026-09-01T00:00:20.000Z');
     };
 
     await expect(
@@ -345,6 +348,7 @@ describe('togglePin', () => {
     // 常にバッチより厳しい側に寄せておく（緩い側に寄せると競合の余地ができる）。
     const expiresAt = '2026-09-01T00:00:00.000Z';
     const database = new FakeMoviesDatabase([movie({ expiresAt })]);
+    database.now = new Date(expiresAt);
 
     await expect(
       togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date(expiresAt) })

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
+import { ERROR_CODES } from '../../src/lib/contracts/api';
+
 import {
   MAX_PINNED_MOVIES,
   MOVIE_RETENTION_MS,
@@ -254,6 +256,44 @@ describe('togglePin', () => {
       togglePin({ database, userId: USER_ID, shortId: SHORT_ID })
     ).rejects.toMatchObject({ status: 409 });
     expect(database.movies.get(SHORT_ID)?.pinned).toBe(0);
+  });
+
+  it('保管期限を過ぎた動画は pin できない', async () => {
+    // 期限切れを終端の状態にしておかないと、保持期間バッチが R2 を消してから
+    // D1 の行を消すまでの間に期限が延び、実体だけ消えた行が残る
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([
+      movie({ expiresAt: '2026-08-31T23:59:59.000Z' }),
+    ]);
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 410, errorCode: ERROR_CODES.expired });
+    expect(database.movies.get(SHORT_ID)).toMatchObject({
+      pinned: 0,
+      expiresAt: '2026-08-31T23:59:59.000Z',
+    });
+  });
+
+  it('保管期限を過ぎた動画は pin の解除もできない（解除も期限を延ばすため）', async () => {
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([
+      movie({ pinned: 1, expiresAt: '2026-08-31T23:59:59.000Z' }),
+    ]);
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 410, errorCode: ERROR_CODES.expired });
+    expect(database.movies.get(SHORT_ID)).toMatchObject({ pinned: 1 });
+  });
+
+  it('期限ちょうどでも過ぎている扱いにする（バッチの閾値と食い違わせない）', async () => {
+    const expiresAt = '2026-09-01T00:00:00.000Z';
+    const database = new FakeMoviesDatabase([movie({ expiresAt })]);
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date(expiresAt) })
+    ).rejects.toMatchObject({ status: 410 });
   });
 
   it('9 件なら 10 件目を pin できる', async () => {

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -66,7 +66,10 @@ class FakeRetentionDatabase implements RetentionDatabase {
     // 削除直前の再確認（short_id と閾値の 2 引数）。pin ではなく status と期限で判定する。
     if (query.includes('WHERE short_id = ?')) {
       const movie = this.movies.get(values[0] as string);
-      if (!movie || !isExpired(movie, parseSqliteTime(values[1] as string))) return [];
+      if (!movie) return [];
+      // 引数が short_id だけなら行の存在確認（stranded の判定に使う）
+      if (values.length === 1) return [{ short_id: movie.shortId }];
+      if (!isExpired(movie, parseSqliteTime(values[1] as string))) return [];
       if (query.includes("status = 'ready'") && movie.status !== 'ready') return [];
       return [{ short_id: movie.shortId }];
     }
@@ -454,6 +457,24 @@ describe('runRetention: 不変条件が破れた時の可視化', () => {
     expect(summary.deletedMovies).toBe(0);
     expect(summary.strandedMovies).toBe(1);
     expect(database.movies.has('strandedAAAA')).toBe(true);
+  });
+
+  it('並行して行が消えていた場合は stranded に数えない', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'racedDeleteA', createdAt: iso(-HOUR_MS), expiresAt: iso(-HOUR_MS) }),
+    ]);
+    const bucket = new FakeRetentionBucket(new Set([movieKey('racedDeleteA')]));
+    // 所有者の削除と競合しただけなら正常（実体も行も無くなる）
+    const originalDelete = bucket.delete.bind(bucket);
+    bucket.delete = async (keys) => {
+      database.movies.delete('racedDeleteA');
+      await originalDelete(keys);
+    };
+
+    const summary = await run(database, bucket);
+
+    expect(summary.deletedMovies).toBe(0);
+    expect(summary.strandedMovies).toBe(0);
   });
 });
 

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -379,6 +379,7 @@ describe('runRetention: サマリ', () => {
     expect(summary).toEqual({
       backfilledPinned: 0,
       deletedMovies: 1,
+      strandedMovies: 0,
       deletedOrphans: 1,
       deletedFailed: 1,
       deletedCaptures: 1,
@@ -427,6 +428,32 @@ describe('runRetention: pin 済みの期限補完', () => {
     expect(summary.backfilledPinned).toBe(0);
     expect(database.movies.get('pinnedDatedA')?.expiresAt).toBe(kept);
     expect(database.movies.get('plainDatedAA')?.expiresAt).toBe(kept);
+  });
+});
+
+describe('runRetention: 不変条件が破れた時の可視化', () => {
+  it('R2 を消したのに行が残ったら stranded として数える', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'strandedAAAA', createdAt: iso(-HOUR_MS), expiresAt: iso(-HOUR_MS) }),
+    ]);
+    // 再確認の後・R2 削除の前に期限が延びる順序を再現する。togglePin は期限切れを
+    // 410 で断るので本来起きないが、起きた時に黙らないことを固定する。
+    const bucket = new FakeRetentionBucket(new Set([movieKey('strandedAAAA')]));
+    const extend = (): void => {
+      const target = database.movies.get('strandedAAAA');
+      if (target) target.expiresAt = iso(365 * DAY_MS);
+    };
+    const originalDelete = bucket.delete.bind(bucket);
+    bucket.delete = async (keys) => {
+      extend();
+      await originalDelete(keys);
+    };
+
+    const summary = await run(database, bucket);
+
+    expect(summary.deletedMovies).toBe(0);
+    expect(summary.strandedMovies).toBe(1);
+    expect(database.movies.has('strandedAAAA')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## なぜこの変更が必要か

保持期間バッチは期限切れの動画を「R2 の実体 → D1 の行」の順で消す（逆にすると行を消した時点でキーを導出できず、実体が回収不能な孤児になる）。この 2 手の間に所有者が pin して期限が延びると、最後の DELETE が 0 件になり、実体だけが消えた行と公開 URL が残る。利用者から見ると「動画が壊れた」状態で、自動では回復しない。

R2 と D1 をまたぐ原子的な削除は作れないので、期限を延ばせる側を塞ぐ。

## 変更内容

- 保管期限を過ぎた動画の pin / 解除を 410 `EXPIRED` で断る（解除も `restoredExpiry` で期限を延ばすため両方向）
- 判定は UPDATE の `WHERE` に入れ、D1 の実行時刻（`datetime('now')`）で評価する。更新 0 件なら理由を引き直して 410（期限切れ）か 404（行が消えた）を返す
- それでも実体を消したのに行が残った場合は `strandedMovies` として数え、cron のログを `severity: error` に上げる
- 画面には専用の文言を出す（409 と同じ扱いにすると「10 件まで」と表示され、理由が伝わらない）

## 意思決定

### 採用アプローチ
- 「期限切れ」を終端の状態にする。期限を延ばせる書き手が `togglePin` だけなので、そこを塞げばバッチの再確認が有効なままになる

### 却下した代替案
- 削除順序を D1 → R2 に変える → 却下: 行を消すとキーを導出できず、実体が孤児になる（元の設計判断）
- D1 に「削除処理中」の列を足して確保する → 却下: スキーマ変更はロールバックで戻らない。条件付き UPDATE で同じ排他が作れる
- 事前判定（読んだ値で期限を見る）だけで済ませる → 却下: 判定から書き込みまでの間に期限をまたぐ経路が残る（レビューで実 SQL による再現の報告あり）

### トレードオフ
- 期限切れ動画の延命不可 > 猶予: 期限を過ぎた動画は毎時のバッチでどのみち消えるため、pin での延命は残さない

## テスト

- [x] `bun test` 330 件（新規: 期限切れの pin / 解除を断る・判定後に期限をまたいでも更新が通らない・判定後に行が消えたら 404・実体を消したのに行が残ったら stranded・並行削除は stranded に数えない）
- [x] `bunx playwright test` 90 件（期限切れの動画で pin を押すと専用の文言が出る）
- [x] `bun run typecheck`
- [x] 回帰テストが修正前に落ちることを確認（古い now をバインドする実装へ戻すと失敗する）

## 後続Issue

- https://github.com/noricha-vr/WebScreen/issues/85
- https://github.com/noricha-vr/WebScreen/issues/86

Closes #83
