### PR TITLE
fix(web): 旧サイトの /robots.txt/ を正規の /robots.txt へ 301 転送する

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -21,6 +21,9 @@
 /record-screen/ / 301
 /streaming/ / 301
 /github/ / 301
+# 旧版は robots.txt を末尾スラッシュ付きで配信していた（router/main.py の @app.get("/robots.txt/")）。
+# クローラが旧 URL を保持しているため、正規の /robots.txt へ転送する。
+/robots.txt/ /robots.txt 301
 
 # --- 言語付き（router/main_page.py）---
 # ja / en を明示列挙しているのは意図的。`/:lang/web/ /:lang/ 301` と書くと未対応言語まで


### PR DESCRIPTION
## なぜこの変更が必要か

旧 FastAPI 版から新版（Astro + Workers）へドメインを切り替えた際の 301 転送に、1 本だけ漏れがあった。
旧版は robots.txt を**末尾スラッシュ付き**の `/robots.txt/` で配信していた（`router/main.py` の `@app.get("/robots.txt/")`）が、
`web/public/_redirects` に対応行が無く、本番で 404 になっていた。旧 URL を保持しているクローラが 404 を踏み続ける。

旧版の GET ページルートを本番で全数実測した結果、転送漏れはこの 1 本のみだった。

## 変更内容

- `web/public/_redirects` の言語なしセクションに `/robots.txt/ /robots.txt 301` を追加（理由コメント付き）

## 意思決定

### 採用アプローチ
- 既存の `_redirects` に 1 行追加。転送先は正規の `/robots.txt`（`web/public/robots.txt` として 200 で存在）

### 対象外にしたもの
- `/stream/{uuid}/{file_name}` → 60 秒で失効する一時ストリーミング URL。被リンク対象ではないため転送しない
- `/cache/{file_path}` → 旧ページ専用の静的アセット配信。新版に対応物が無い
- `/ja` `/en`（末尾スラッシュ無し）の 307 → 旧版も FastAPI の `redirect_slashes` で同じ挙動だったため、旧 URL 由来の被リンクが存在しない。現状維持
- `/fr/` 等の未対応言語の 404 → `_redirects` のコメントに記載済みの意図的な挙動

## テスト

- [x] 旧版の全 GET ページルート 29 パスを本番へ curl で実測。言語なし 8 本・言語付き 7 本 × 2 言語・privacy 2 本はすべて 301 で正しい転送先を確認。`/robots.txt/` のみ 404（本 PR の対象）
- [x] GA4 実データ: 8/28 の page_view は `/ja/` `/en/` のみで旧パスはゼロ（8/27 の旧パス PV は切替デプロイ前の同日分）
- [x] `bun run typecheck` / `bun test`（330 pass / 0 fail）
- [ ] マージ後に本番で `/robots.txt/` → 301 → `/robots.txt` 200 を確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
