### PR TITLE
feat(web): リリースノートへの導線と、ログイン必須化のお知らせ・ピン留めの訴求を足す

### DIFF
--- a/web/src/components/LpSections.astro
+++ b/web/src/components/LpSections.astro
@@ -1,4 +1,5 @@
 ---
+import PinHighlight from './PinHighlight.astro';
 import { useTranslations, type Locale } from '../i18n';
 
 interface Props {
@@ -108,6 +109,10 @@ const sections: Section[] = [
         </article>
       ))
     }
+  </div>
+
+  <div class="mt-14">
+    <PinHighlight lang={lang} />
   </div>
 
   <p class="mt-12 text-sm text-slate-500">{t.lp.comingSoon}</p>

--- a/web/src/components/NoticeBanner.astro
+++ b/web/src/components/NoticeBanner.astro
@@ -1,0 +1,55 @@
+---
+import { useTranslations, type Locale } from '../i18n';
+
+interface Props {
+  lang: Locale;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+
+const RELEASES_URL = 'https://github.com/noricha-vr/WebScreen/releases';
+
+/**
+ * 掲載をやめる日（この日いっぱいまで表示）。
+ *
+ * ここでは日付を評価しない。ページは静的生成なので、ビルド時に判定するとデプロイ時刻で
+ * 結果が焼き付き、期限が来ても消えない。判定は lib/ui/notice.ts が描画後に行う。
+ */
+const NOTICE_UNTIL = '2026-10-31';
+---
+
+<!-- ルートに display ユーティリティを置かない（hidden 属性での非表示と競合させないため）。 -->
+<aside
+  data-notice
+  data-notice-until={NOTICE_UNTIL}
+  class="mb-10 rounded-lg border border-slate-200 bg-slate-50 p-5"
+>
+  <div class="flex items-start gap-3">
+    <i class="fa-solid fa-circle-info mt-1 text-brand-500" aria-hidden="true"></i>
+
+    <div>
+      <h2 class="text-lg font-semibold tracking-tight text-slate-900">{t.notice.heading}</h2>
+      <p class="mt-2 text-base leading-relaxed text-slate-700">{t.notice.body}</p>
+
+      <a
+        href={RELEASES_URL}
+        target="_blank"
+        rel="noopener"
+        class="mt-3 inline-flex items-center gap-2 text-base text-slate-700 underline hover:text-brand-700"
+      >
+        <i class="fa-solid fa-tag" aria-hidden="true"></i>
+        <span>{t.notice.link}</span>
+      </a>
+    </div>
+  </div>
+</aside>
+
+<script>
+  // 期限判定はビルド時ではなく描画時に行う（静的生成のため）。
+  import { mountNotice } from '../lib/ui/notice';
+
+  for (const notice of document.querySelectorAll<HTMLElement>('[data-notice]')) {
+    mountNotice(notice);
+  }
+</script>

--- a/web/src/components/PinHighlight.astro
+++ b/web/src/components/PinHighlight.astro
@@ -1,0 +1,47 @@
+---
+import { useTranslations, type Locale } from '../i18n';
+import { MAX_PINNED_MOVIES, MOVIE_RETENTION_MS } from '../lib/services/quota';
+
+interface Props {
+  lang: Locale;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// 保管期間と件数は quota.ts の定数が正本。文言側に数字を焼き付けない。
+const normalValue = t.lp.pinNormalValue.replace('{days}', String(MOVIE_RETENTION_MS / MS_PER_DAY));
+const pinLimit = t.lp.pinLimit.replace('{count}', String(MAX_PINNED_MOVIES));
+// ピン留め側の「1 年」は quota.ts の PINNED_RETENTION_MS（365 日）に対応する。
+---
+
+<article class="rounded-xl border border-slate-200 bg-slate-50 p-6 sm:p-8">
+  <h2
+    class="flex items-start justify-center gap-3 text-center text-2xl font-bold leading-snug tracking-tight text-slate-900"
+  >
+    <i class="fa-solid fa-thumbtack mt-1 text-brand-500" aria-hidden="true"></i>
+    <span>{t.lp.pinHeading}</span>
+  </h2>
+
+  <!-- 縦積みになるモバイルでは矢印も下向きにする（横向きのまま折り返すと流れが読めない）。 -->
+  <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
+    <div class="text-center text-slate-500">
+      <p class="text-base">{t.lp.pinNormalLabel}</p>
+      <p class="mt-1 text-3xl font-semibold">{normalValue}</p>
+    </div>
+
+    <i
+      class="fa-solid fa-arrow-right rotate-90 text-xl text-slate-400 sm:rotate-0"
+      aria-hidden="true"></i>
+
+    <div class="text-center text-brand-700">
+      <p class="text-base font-semibold">{t.lp.pinPinnedLabel}</p>
+      <p class="mt-1 text-4xl font-bold">{t.lp.pinPinnedValue}</p>
+      <p class="mt-1 text-base text-slate-600">{pinLimit}</p>
+    </div>
+  </div>
+
+  <p class="mt-8 text-center text-base leading-relaxed text-slate-700">{t.lp.pinBody}</p>
+</article>

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -10,6 +10,7 @@ const t = useTranslations(lang);
 const other = alternateLocale(lang);
 
 const REPOSITORY_URL = 'https://github.com/noricha-vr/WebScreen';
+const RELEASES_URL = `${REPOSITORY_URL}/releases`;
 ---
 
 <footer class="mt-16 border-t border-slate-200 bg-slate-50">
@@ -27,6 +28,15 @@ const REPOSITORY_URL = 'https://github.com/noricha-vr/WebScreen';
       >
         <i class="fa-brands fa-github" aria-hidden="true"></i>
         <span>{t.footer.github}</span>
+      </a>
+      <a
+        href={RELEASES_URL}
+        target="_blank"
+        rel="noopener"
+        class="inline-flex items-center gap-2 text-slate-700 underline hover:text-brand-700"
+      >
+        <i class="fa-solid fa-tag" aria-hidden="true"></i>
+        <span>{t.footer.releases}</span>
       </a>
       <a
         href={`/${lang}/privacy/`}

--- a/web/src/components/TopPage.astro
+++ b/web/src/components/TopPage.astro
@@ -2,6 +2,7 @@
 import ConvertPanel from './ConvertPanel.astro';
 import GuestHero from './GuestHero.astro';
 import LpSections from './LpSections.astro';
+import NoticeBanner from './NoticeBanner.astro';
 import type { Locale } from '../i18n';
 
 interface Props {
@@ -14,6 +15,7 @@ const { lang } = Astro.props;
 <div class="mx-auto max-w-5xl px-4 py-12">
   <!-- 未ログイン / ログイン済みの両方を出しておき、data-auth-state で切り替える -->
   <div data-auth-only="guest">
+    <NoticeBanner lang={lang} />
     <GuestHero lang={lang} />
   </div>
 

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -14,6 +14,11 @@
     "bannerAlt": "WebScreen logo",
     "avatarAlt": "Account avatar"
   },
+  "notice": {
+    "heading": "WebScreen has been rebuilt",
+    "body": "We now ask you to sign in with Discord so that you can find your converted videos in your history. There is no password to create.",
+    "link": "See what changed"
+  },
   "hero": {
     "title": "Drag and drop a file, get a video URL for VRChat.",
     "lead": "Upload a PDF or image and WebScreen returns an MP4 URL that plays in VRChat video players.",
@@ -99,6 +104,7 @@
   },
   "footer": {
     "github": "GitHub",
+    "releases": "Release notes",
     "privacy": "Cookies and privacy",
     "langSwitch": "日本語",
     "note": "WebScreen β"
@@ -151,8 +157,15 @@
     "pdfBody": "Export PowerPoint or Google Slides as a PDF and convert it to video to run your presentation on a video player or a slide system.",
     "pdfMediaAlt": "A PDF being turned into a video",
     "historyHeading": "Check your history",
-    "historyBody": "Your history keeps the link to every video you converted. Videos are stored for 30 days, and the 10 videos you pin are kept for one year.",
+    "historyBody": "Your history keeps the link to every video you converted.",
     "historyMediaAlt": "The history of converted videos",
+    "pinHeading": "Keep the videos that matter for a year",
+    "pinNormalLabel": "Standard",
+    "pinNormalValue": "{days} days",
+    "pinPinnedLabel": "Pinned",
+    "pinPinnedValue": "1 year",
+    "pinLimit": "up to {count}",
+    "pinBody": "A link you put in a world or on a poster will not stop working partway through.",
     "comingSoon": "Screen recording and screen sharing are still on the way"
   }
 }

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -14,6 +14,11 @@
     "bannerAlt": "WebScreen のロゴ",
     "avatarAlt": "アカウントのアバター"
   },
+  "notice": {
+    "heading": "WebScreen は新しくなりました",
+    "body": "変換した動画を履歴から探せるようにするため、Discord でのログインをお願いしています。パスワードの登録は必要ありません。",
+    "link": "更新内容を見る"
+  },
   "hero": {
     "title": "VRChat に映せる動画 URL を、ドラッグ&ドロップで。",
     "lead": "PDF・画像をアップロードすると、VRChat のビデオプレイヤーで再生できる MP4 の URL を発行します。",
@@ -99,6 +104,7 @@
   },
   "footer": {
     "github": "GitHub",
+    "releases": "更新履歴",
     "privacy": "Cookie とプライバシー",
     "langSwitch": "English",
     "note": "WebScreen β"
@@ -151,8 +157,15 @@
     "pdfBody": "パワーポイントや Google スライドを PDF で書き出して動画に変換すれば、動画プレイヤーやスライドシステムでプレゼンを始められます。",
     "pdfMediaAlt": "PDF が動画に変換される様子",
     "historyHeading": "履歴を確認",
-    "historyBody": "変換した動画のリンクは、履歴からいつでも確認できます。動画は 30 日間保管し、ピン留めした 10 件は 1 年間残ります。",
+    "historyBody": "変換した動画のリンクは、履歴からいつでも確認できます。",
     "historyMediaAlt": "変換した動画の履歴",
+    "pinHeading": "大事な動画は 1 年間残せる",
+    "pinNormalLabel": "通常",
+    "pinNormalValue": "{days} 日",
+    "pinPinnedLabel": "ピン留め",
+    "pinPinnedValue": "1 年",
+    "pinLimit": "{count} 件まで",
+    "pinBody": "ワールドやポスターに貼った URL が途中で切れません。",
     "comingSoon": "画面録画・画面共有は対応中です"
   }
 }

--- a/web/src/lib/ui/notice.ts
+++ b/web/src/lib/ui/notice.ts
@@ -1,0 +1,55 @@
+/**
+ * 期限付きのお知らせ枠の表示/ 非表示を決める。
+ *
+ * ページは静的生成（output: 'static'）なので、テンプレート側で `new Date()` を評価すると
+ * ビルド時刻で結果が固定され、期限が来ても枠が消えない。判定は描画後にブラウザで行う。
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * `YYYY-MM-DD` を UTC の 0 時として解釈する。日付として成立しない値は null を返す。
+ *
+ * `Date.UTC` は 13 月や 32 日を翌月へ繰り上げてしまうため、往復させて一致を確認する。
+ */
+function parseUtcDate(value: string): number | null {
+  const matched = DATE_PATTERN.exec(value);
+  if (!matched) return null;
+
+  const year = Number(matched[1]);
+  const month = Number(matched[2]);
+  const day = Number(matched[3]);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const date = new Date(timestamp);
+
+  const rolledOver =
+    date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day;
+
+  return rolledOver ? null : timestamp;
+}
+
+/**
+ * `until`（`YYYY-MM-DD`）を過ぎているか。当日いっぱいは表示し、翌日 0 時から期限切れとする。
+ *
+ * 境界は UTC で見る。閲覧者のタイムゾーンで判定すると同じ静的 HTML が地域ごとに違う
+ * 出方をし、テストも実行環境依存になる。お知らせの性質上、数時間のずれは問題にならない。
+ *
+ * 日付として読めない値は「期限切れではない」に倒す（文字列の書き間違いで告知が
+ * 黙って消えるより、出続けて気づける方が害が小さい）。
+ */
+export function isNoticeExpired(until: string, now: Date): boolean {
+  const timestamp = parseUtcDate(until);
+  if (timestamp === null) return false;
+
+  return now.getTime() >= timestamp + MS_PER_DAY;
+}
+
+/** `data-notice-until` を読み、期限切れなら枠を隠す。 */
+export function mountNotice(element: HTMLElement, now: Date = new Date()): void {
+  const until = element.dataset['noticeUntil'];
+  if (until === undefined) return;
+
+  element.hidden = isNoticeExpired(until, now);
+}

--- a/web/src/lib/ui/notice.ts
+++ b/web/src/lib/ui/notice.ts
@@ -46,8 +46,19 @@ export function isNoticeExpired(until: string, now: Date): boolean {
   return now.getTime() >= timestamp + MS_PER_DAY;
 }
 
+/**
+ * `mountNotice` が触る最小の面。
+ *
+ * `HTMLElement` 全体を要求しないのは、配線（data 属性の読みと hidden の反映）を
+ * DOM 実装なしでテストするため。実行時は HTMLElement をそのまま渡せる。
+ */
+export interface NoticeElement {
+  dataset: DOMStringMap;
+  hidden: boolean;
+}
+
 /** `data-notice-until` を読み、期限切れなら枠を隠す。 */
-export function mountNotice(element: HTMLElement, now: Date = new Date()): void {
+export function mountNotice(element: NoticeElement, now: Date = new Date()): void {
   const until = element.dataset['noticeUntil'];
   if (until === undefined) return;
 

--- a/web/tests/i18n/quota-copy.test.ts
+++ b/web/tests/i18n/quota-copy.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+
+import { PINNED_RETENTION_MS } from '../../src/lib/services/quota';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * LP のピン留めカード（PinHighlight.astro）は「1 年」を文言側に固定で持っている。
+ * 日数から「1 年」という表記を機械的には導けないため、定数を変えたらここで気づけるようにする。
+ *
+ * 通常の保管期間と件数はプレースホルダ経由で定数から流し込んでいるので、ここでは見ない。
+ */
+describe('保管期間の文言が前提にしている定数', () => {
+  test('ピン留めの保管期間が 365 日である（LP の「1 年」表記の根拠）', () => {
+    expect(PINNED_RETENTION_MS / MS_PER_DAY).toBe(365);
+  });
+});

--- a/web/tests/ui/notice.test.ts
+++ b/web/tests/ui/notice.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isNoticeExpired } from '../../src/lib/ui/notice';
+
+/** 実行環境のタイムゾーンで結果が変わらないよう、時刻は必ず UTC で組み立てる。 */
+const UNTIL = '2026-10-31';
+
+describe('isNoticeExpired', () => {
+  test('期限前は表示したままにする', () => {
+    expect(isNoticeExpired(UNTIL, new Date('2026-10-30T12:00:00Z'))).toBe(false);
+  });
+
+  test('期限当日は日付が変わるまで表示する', () => {
+    expect(isNoticeExpired(UNTIL, new Date('2026-10-31T23:59:59Z'))).toBe(false);
+  });
+
+  test('翌日 0 時からは期限切れにする', () => {
+    expect(isNoticeExpired(UNTIL, new Date('2026-11-01T00:00:00Z'))).toBe(true);
+  });
+
+  test('日付として読めない値は期限切れにしない', () => {
+    const now = new Date('2030-01-01T00:00:00Z');
+    expect(isNoticeExpired('2026/10/31', now)).toBe(false);
+    expect(isNoticeExpired('2026-13-45', now)).toBe(false);
+    expect(isNoticeExpired('', now)).toBe(false);
+  });
+});

--- a/web/tests/ui/notice.test.ts
+++ b/web/tests/ui/notice.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isNoticeExpired } from '../../src/lib/ui/notice';
+import { isNoticeExpired, mountNotice, type NoticeElement } from '../../src/lib/ui/notice';
 
 /** 実行環境のタイムゾーンで結果が変わらないよう、時刻は必ず UTC で組み立てる。 */
 const UNTIL = '2026-10-31';
@@ -23,5 +23,36 @@ describe('isNoticeExpired', () => {
     expect(isNoticeExpired('2026/10/31', now)).toBe(false);
     expect(isNoticeExpired('2026-13-45', now)).toBe(false);
     expect(isNoticeExpired('', now)).toBe(false);
+  });
+});
+
+describe('mountNotice', () => {
+  /** `data-notice-until` 付きの要素を模す（触るのは dataset と hidden だけ）。 */
+  function element(until?: string): NoticeElement {
+    return { dataset: until === undefined ? {} : { noticeUntil: until }, hidden: false };
+  }
+
+  test('期限前は表示したままにする', () => {
+    const notice = element(UNTIL);
+    mountNotice(notice, new Date('2026-10-30T12:00:00Z'));
+    expect(notice.hidden).toBe(false);
+  });
+
+  test('期限を過ぎたら隠す', () => {
+    const notice = element(UNTIL);
+    mountNotice(notice, new Date('2026-11-01T00:00:00Z'));
+    expect(notice.hidden).toBe(true);
+  });
+
+  test('data-notice-until が無い要素には触らない', () => {
+    const notice = element();
+    mountNotice(notice, new Date('2030-01-01T00:00:00Z'));
+    expect(notice.hidden).toBe(false);
+  });
+
+  test('期限前なら隠れていた要素も表示に戻す（毎回判定し直す）', () => {
+    const notice: NoticeElement = { dataset: { noticeUntil: UNTIL }, hidden: true };
+    mountNotice(notice, new Date('2026-10-30T12:00:00Z'));
+    expect(notice.hidden).toBe(false);
   });
 });


### PR DESCRIPTION
## なぜこの変更が必要か

旧 FastAPI 版の WebScreen は**ログイン不要**だった。Cloudflare 版に切り替わったことで、既存ユーザーがトップページを開くといきなり Discord ログインを求められる。理由の説明がどこにも無く、戸惑って離脱する。

あわせて、ピン留め（1 年保管）の訴求が弱い問題も直す。通常 30 日に対してピン留めは 365 日残るのに、仕様リストの 1 行と LP 内の 1 文でしか触れておらず、VRChat のワールドやポスターに貼る URL が切れないという一番の利点が埋もれていた。

リリースノート（[v0.1.0-beta](https://github.com/noricha-vr/WebScreen/releases/tag/v0.1.0-beta)）を公開したので、そこへの導線も足す。

## 変更内容

- 未ログイン時のヒーロー上に**期限付きのお知らせ枠**を追加（リニューアルの告知 + ログインをお願いする理由 + 更新履歴へのリンク）。掲載は 2026-10-31 まで
- LP の最後に**ピン留めの訴求カード**を追加（「通常 30 日 → ピン留め 1 年（10 件まで）」の対比）。重複する記述を `lp.historyBody` から外した
- フッターに**更新履歴**（GitHub Releases）へのリンクを追加
- 文言は `i18n/ja.json` `en.json` の両方に追加

## 意思決定

### 採用アプローチ

- **期限判定はクライアント側 JS**（`web/src/lib/ui/notice.ts`）。`/ja/` `/en/` は Astro の静的生成なので、テンプレート側で `new Date()` を評価すると結果がデプロイ時刻で固定され、期限が来ても枠が消えない。既存の `session-view.ts`（`data-auth-state` の出し分け）と同じ流儀に合わせた
- **境界は UTC**。同じ静的 HTML が閲覧者の地域で違う出方をするのを避けるため。告知の性質上、数時間のずれは許容する
- **ピン留めカードは画像を使わず数字の対比**。既存 4 項目（Web / 画像 / PDF / 履歴）はメディア付きの左右交互レイアウトだが、保管期間は「30 日 → 1 年」の数字がそのまま訴求になる。レイアウトを変えることでかえって目立つ

### 却下した代替案

- ボタン下の注記を 1 文増やすだけ → 気づかれにくい
- お知らせ枠を閉じられるようにする（localStorage） → 状態を持つ分だけ複雑になる。未ログイン画面は初回しか見ない人が多い
- ピン留めの実画面スクショを撮って他 4 項目と揃える → 撮影とアップロードの手間の割に、伝わるのは数字

### トレードオフ

- **JS 無効環境では期限後も表示され続ける** > 静的生成の速さ: 日付を過ぎたらコードごと削除する運用で担保する（[#90](https://github.com/noricha-vr/WebScreen/issues/90) に登録済み）

## テスト

- [x] `bun run typecheck`（`tsc --noEmit`、エラーなし）
- [x] `bun test` — 339 pass / 0 fail（`isNoticeExpired` 4 ケース + `mountNotice` 4 ケース + 定数同期 1 ケースを追加）
- [x] `bun run build`
- [x] コードレビュー 2 レーン（gpt-5.6-sol high）— セキュリティは指摘なし。通常レビューの blocking 1 件（`mountNotice` の配線が未検証）と non-blocking 1 件（「1 年」表記が定数から導出されていない）は `9efb91b` で対応
- [x] `data-notice-until` を過去日にした HTML で枠が非表示になることを確認

## Screenshot

| Before（本番の現状） | After（お知らせ枠） |
|--------|-------|
| ![Before](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/996f50933a53-before-top-ja.avif) | ![After](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/2beff637e375-01-notice-banner-20260830.avif) |

| ピン留めの訴求カード | フッターの更新履歴リンク |
|--------|-------|
| ![Pin](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/4315a6dfbacc-02-pin-highlight-20260830.avif) | ![Footer](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/1b400fe72ea6-03-footer-releases-20260830.avif) |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgoMd7tiihVyzrBaZe8ZGq
