### PR TITLE
fix(web): ピン留めの上限を UPDATE の WHERE で数えて並行時も超えさせない

### DIFF
--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -127,9 +127,10 @@ export async function listHistory(input: ListHistoryInput): Promise<HistoryRespo
  * 実体だけが消えた行が残る（services/retention.ts の deleteExpiredMovies）。
  * 期限切れの動画は毎時のバッチでどのみち消えるので、延命の余地を残さない。
  *
- * 判定は 2 段構え。読んだ値での事前判定は理由（410）を上限超過（409）より先に返すためで、
- * 競合を防ぐのは UPDATE の WHERE に入れた期限条件の方（D1 の実行時刻で評価する）。
- * 事前判定だけでは、判定から書き込みまでの間に期限をまたぐ経路が残る。
+ * 判定は 2 段構え。読んだ値での事前判定は理由（期限切れの 410）を上限超過（409）より先に
+ * 返すためで、競合を防ぐのは UPDATE の WHERE に入れた期限と件数の条件の方（どちらも D1 が
+ * 実行時に評価する）。事前判定だけでは、判定から書き込みまでの間に期限をまたぐ経路と、
+ * 別のリクエストが最後の pin 枠を埋める経路が残る。
  */
 export async function togglePin(
   input: MovieActionInput & { now?: Date }
@@ -149,13 +150,7 @@ export async function togglePin(
 
   if (nextPinned) {
     const pinnedCount = await countPinnedMovies(input.database, input.userId);
-    if (pinnedCount >= MAX_PINNED_MOVIES) {
-      throw new MovieActionError(
-        409,
-        ERROR_CODES.invalidRequest,
-        `ピン留めできるのは ${MAX_PINNED_MOVIES} 件までです`
-      );
-    }
+    if (pinnedCount >= MAX_PINNED_MOVIES) throw pinLimitExceeded();
   }
 
   const expiresAt = nextPinned
@@ -166,17 +161,28 @@ export async function togglePin(
   // now を渡すと、件数の問い合わせなどを挟む間に期限をまたいでも更新が通ってしまう。
   // 比較を datetime() で行うのは保持期間バッチと同じ理由（ISO8601 と SQLite の表記が
   // 混在し、素の文字列比較では大小が逆転するため）。
+  //
+  // pin する時は件数の上限も同じ文で数える。事前に読んだ件数で判定すると、数えてから
+  // 書き込むまでの間に別のリクエストが枠を埋めても通り、上限を超えて 1 年間保管できる。
+  // 解除する側は枠を空ける操作なので条件を足さない（上限に達していても解除はできる）。
+  const pinLimitClause = nextPinned
+    ? ' AND (SELECT COUNT(*) FROM movies AS pinned_movies' +
+      ' WHERE pinned_movies.user_id = ? AND pinned_movies.pinned = 1) < ?'
+    : '';
+  const pinLimitBindings = nextPinned ? [input.userId, MAX_PINNED_MOVIES] : [];
+
   const result = await input.database
     .prepare(
       'UPDATE movies SET pinned = ?, expires_at = ? WHERE short_id = ? AND user_id = ?' +
-        " AND (expires_at IS NULL OR datetime(expires_at) >= datetime('now'))"
+        " AND (expires_at IS NULL OR datetime(expires_at) >= datetime('now'))" +
+        pinLimitClause
     )
-    .bind(nextPinned ? 1 : 0, expiresAt, input.shortId, input.userId)
+    .bind(nextPinned ? 1 : 0, expiresAt, input.shortId, input.userId, ...pinLimitBindings)
     .run();
 
-  // 0 件 = 読んだ後に期限が過ぎたか、行そのものが消えた。成功として返すと
-  // 画面には pin 済みと出るのに実体は消える。
-  if (result.meta.changes === 0) await throwPinConflict(input);
+  // 0 件 = 読んだ後に期限が過ぎた・pin の枠が埋まった・行そのものが消えた、のいずれか。
+  // 成功として返すと、画面には pin 済みと出るのに実体は消える（または上限を超える）。
+  if (result.meta.changes === 0) await throwPinConflict({ ...input, nextPinned, now });
 
   return { shortId: input.shortId, pinned: nextPinned, expiresAt };
 }
@@ -184,13 +190,33 @@ export async function togglePin(
 /**
  * pin の UPDATE が 0 件だった理由を引き直して投げる。
  *
- * 行が消えていれば 404（他の経路の削除・保持期間バッチと競合）、残っていれば 410（期限切れ）。
- * 稀な経路なので、通常時に追加のクエリを増やさないようここでだけ読み直す。
+ * 行が消えていれば 404（他の経路の削除・保持期間バッチと競合）、pin の枠が埋まっていれば
+ * 409、どちらでもなければ 410（期限切れ）。稀な経路なので、通常時に追加のクエリを増やさない
+ * ようここでだけ読み直す。
  */
-async function throwPinConflict(input: MovieActionInput): Promise<never> {
-  // 行が消えていればここで 404 になる。残っているなら、WHERE で外れた条件は期限しかない。
-  await findOwnedMovie(input.database, input.userId, input.shortId);
+async function throwPinConflict(
+  input: MovieActionInput & { nextPinned: boolean; now: Date }
+): Promise<never> {
+  // 行が消えていればここで 404 になる。
+  const movie = await findOwnedMovie(input.database, input.userId, input.shortId);
+
+  // 期限切れは終端の状態なので、上限超過より先に理由として返す（事前判定と同じ順序）。
+  if (input.nextPinned && !isExpired(movie.expires_at, input.now)) {
+    const pinnedCount = await countPinnedMovies(input.database, input.userId);
+    if (pinnedCount >= MAX_PINNED_MOVIES) throw pinLimitExceeded();
+  }
+
+  // 残る WHERE の条件は期限しかない。
   throw new MovieActionError(410, ERROR_CODES.expired, '保管期限を過ぎた動画は変更できません');
+}
+
+/** pin の上限に達したことを伝える 409。事前判定と UPDATE の 0 件判定の両方から投げる。 */
+function pinLimitExceeded(): MovieActionError {
+  return new MovieActionError(
+    409,
+    ERROR_CODES.invalidRequest,
+    `ピン留めできるのは ${MAX_PINNED_MOVIES} 件までです`
+  );
 }
 
 /**

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -79,6 +79,11 @@ interface CountRow {
   total: number | null;
 }
 
+interface ExpiryRow {
+  /** SQLite の真偽値。1 = 保管期限を過ぎている。 */
+  expired: number;
+}
+
 export interface ListHistoryInput {
   database: MoviesDatabase;
   userId: number;
@@ -182,7 +187,7 @@ export async function togglePin(
 
   // 0 件 = 読んだ後に期限が過ぎた・pin の枠が埋まった・行そのものが消えた、のいずれか。
   // 成功として返すと、画面には pin 済みと出るのに実体は消える（または上限を超える）。
-  if (result.meta.changes === 0) await throwPinConflict({ ...input, nextPinned, now });
+  if (result.meta.changes === 0) await throwPinConflict({ ...input, nextPinned });
 
   return { shortId: input.shortId, pinned: nextPinned, expiresAt };
 }
@@ -190,24 +195,53 @@ export async function togglePin(
 /**
  * pin の UPDATE が 0 件だった理由を引き直して投げる。
  *
- * 行が消えていれば 404（他の経路の削除・保持期間バッチと競合）、pin の枠が埋まっていれば
- * 409、どちらでもなければ 410（期限切れ）。稀な経路なので、通常時に追加のクエリを増やさない
- * ようここでだけ読み直す。
+ * 行が消えていれば 404（他の経路の削除・保持期間バッチと競合）、期限切れなら 410、
+ * 期限内で pin しようとしていたなら 409（WHERE に残る条件は件数しかない）。
+ *
+ * 期限は D1 の時刻で判定し、件数は数え直さない。リクエスト開始時の now で判定すると、
+ * 書き込みの直前に期限が過ぎた行を「期限内」と読んで 409 を返す。件数を数え直すと、
+ * 弾かれた直後に別のリクエストが pin を解除しただけで 410 に化ける。どちらも呼び出し側
+ * （ui/preview-actions.ts）が 409 と 410 で別の文言を出すため、そのまま誤案内になる。
  */
 async function throwPinConflict(
-  input: MovieActionInput & { nextPinned: boolean; now: Date }
+  input: MovieActionInput & { nextPinned: boolean }
 ): Promise<never> {
-  // 行が消えていればここで 404 になる。
-  const movie = await findOwnedMovie(input.database, input.userId, input.shortId);
+  const expiry = await findExpiryState(input.database, input.userId, input.shortId);
 
-  // 期限切れは終端の状態なので、上限超過より先に理由として返す（事前判定と同じ順序）。
-  if (input.nextPinned && !isExpired(movie.expires_at, input.now)) {
-    const pinnedCount = await countPinnedMovies(input.database, input.userId);
-    if (pinnedCount >= MAX_PINNED_MOVIES) throw pinLimitExceeded();
+  // 行が消えていた（他の経路の削除・保持期間バッチと競合）。
+  if (expiry === null) {
+    throw new MovieActionError(404, ERROR_CODES.notFound, '対象の動画が見つかりません');
   }
 
-  // 残る WHERE の条件は期限しかない。
+  // 期限切れは終端の状態なので、上限超過より先に理由として返す（事前判定と同じ順序）。
+  if (expiry.expired !== 0) {
+    throw new MovieActionError(410, ERROR_CODES.expired, '保管期限を過ぎた動画は変更できません');
+  }
+
+  if (input.nextPinned) throw pinLimitExceeded();
+
+  // 解除側の WHERE は期限と所有者だけなので、ここへは到達しない想定。
   throw new MovieActionError(410, ERROR_CODES.expired, '保管期限を過ぎた動画は変更できません');
+}
+
+/**
+ * 行の有無と、D1 の時刻での期限切れ判定だけを引く。
+ *
+ * 比較の向きは UPDATE の WHERE（datetime(expires_at) >= datetime('now')）の裏返し。
+ * 同じ式で判定しないと、0 件の理由が期限だったのかどうかを取り違える。
+ */
+async function findExpiryState(
+  database: MoviesDatabase,
+  userId: number,
+  shortId: string
+): Promise<ExpiryRow | null> {
+  return database
+    .prepare(
+      "SELECT (expires_at IS NOT NULL AND datetime(expires_at) < datetime('now')) AS expired" +
+        ' FROM movies WHERE short_id = ? AND user_id = ?'
+    )
+    .bind(shortId, userId)
+    .first<ExpiryRow>();
 }
 
 /** pin の上限に達したことを伝える 409。事前判定と UPDATE の 0 件判定の両方から投げる。 */

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -107,6 +107,12 @@ class FakeMoviesDatabase implements MoviesDatabase {
       if (!movie || movie.userId !== userId || isPastExpiry(movie.expiresAt, threshold)) {
         return { meta: { changes: 0 } };
       }
+      // 件数の上限も WHERE で評価する。実装が読み取り側だけで判定していれば SQL に
+      // 件数条件が現れないので、この分岐は素通りする（古い実装をそのまま再現する）。
+      if (query.includes('SELECT COUNT(*)')) {
+        const [countUserId, limit] = values.slice(4) as [number, number];
+        if (pinnedCountOf(this, countUserId) >= limit) return { meta: { changes: 0 } };
+      }
       movie.pinned = pinned;
       movie.expiresAt = expiresAt;
       return { meta: { changes: 1 } };
@@ -176,6 +182,13 @@ function pinnedMovies(count: number): TestMovie[] {
   return Array.from({ length: count }, (_unused, index) =>
     movie({ shortId: `pinned${String(index).padStart(6, '0')}`, pinned: 1, expiresAt: null })
   );
+}
+
+/** そのユーザーが現在 pin している件数。上限を超えていないかの検証に使う。 */
+function pinnedCountOf(database: FakeMoviesDatabase, userId: number): number {
+  return [...database.movies.values()].filter(
+    (candidate) => candidate.userId === userId && candidate.pinned === 1
+  ).length;
 }
 
 describe('listHistory', () => {
@@ -353,6 +366,46 @@ describe('togglePin', () => {
     await expect(
       togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date(expiresAt) })
     ).rejects.toMatchObject({ status: 410 });
+  });
+
+  it('判定の後・書き込みの前に他の pin が確定したら上限を超えさせない', async () => {
+    // 件数を読んでから書き込むまでの間に、別のリクエストが最後の枠を埋める順序。
+    // 事前判定だけだと 11 件目が通り、1 ユーザーが上限を超えて 1 年間占有できる（Issue #85）
+    const now = new Date('2026-08-10T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([
+      ...pinnedMovies(MAX_PINNED_MOVIES - 1),
+      movie({ shortId: 'other0000001' }),
+      movie(),
+    ]);
+    database.onBeforePinUpdate = () => {
+      const concurrent = database.movies.get('other0000001');
+      if (concurrent) concurrent.pinned = 1;
+    };
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 409, errorCode: ERROR_CODES.invalidRequest });
+    expect(database.movies.get(SHORT_ID)?.pinned).toBe(0);
+    expect(pinnedCountOf(database, USER_ID)).toBe(MAX_PINNED_MOVIES);
+  });
+
+  it('残り 2 枠へ 3 本を並行させても 2 本しか通らない', async () => {
+    const now = new Date('2026-08-10T00:00:00.000Z');
+    const shortIds = ['race00000001', 'race00000002', 'race00000003'];
+    const database = new FakeMoviesDatabase([
+      ...pinnedMovies(MAX_PINNED_MOVIES - 2),
+      ...shortIds.map((shortId) => movie({ shortId })),
+    ]);
+
+    const results = await Promise.allSettled(
+      shortIds.map((shortId) => togglePin({ database, userId: USER_ID, shortId, now }))
+    );
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(2);
+    const rejected = results.filter((result) => result.status === 'rejected');
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({ status: 409 });
+    expect(pinnedCountOf(database, USER_ID)).toBe(MAX_PINNED_MOVIES);
   });
 
   it('9 件なら 10 件目を pin できる', async () => {

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -38,6 +38,8 @@ class FakeMoviesDatabase implements MoviesDatabase {
   now = new Date('2026-08-30T00:00:00.000Z');
   /** pin の UPDATE 直前に走るフック。期限をまたぐ競合の再現に使う。 */
   onBeforePinUpdate: (() => void) | undefined;
+  /** pin の UPDATE 直後に走るフック。0 件の理由を引き直す間の競合の再現に使う。 */
+  onAfterPinUpdate: (() => void) | undefined;
 
   constructor(movies: TestMovie[] = []) {
     for (const movie of movies) this.movies.set(movie.shortId, { ...movie });
@@ -54,6 +56,13 @@ class FakeMoviesDatabase implements MoviesDatabase {
   }
 
   private first<T>(query: string, values: unknown[]): T | null {
+    if (query.includes('AS expired')) {
+      const [shortId, userId] = values as [string, number];
+      const movie = this.movies.get(shortId);
+      if (!movie || movie.userId !== userId) return null;
+      return { expired: isPastExpiry(movie.expiresAt, this.now.toISOString()) ? 1 : 0 } as T;
+    }
+
     if (query.includes('COUNT(*)')) {
       const userId = values[0] as number;
       const total = [...this.movies.values()].filter(
@@ -105,16 +114,21 @@ class FakeMoviesDatabase implements MoviesDatabase {
         ? this.now.toISOString()
         : ((values[4] as string | undefined) ?? this.now.toISOString());
       if (!movie || movie.userId !== userId || isPastExpiry(movie.expiresAt, threshold)) {
+        this.onAfterPinUpdate?.();
         return { meta: { changes: 0 } };
       }
       // 件数の上限も WHERE で評価する。実装が読み取り側だけで判定していれば SQL に
       // 件数条件が現れないので、この分岐は素通りする（古い実装をそのまま再現する）。
       if (query.includes('SELECT COUNT(*)')) {
         const [countUserId, limit] = values.slice(4) as [number, number];
-        if (pinnedCountOf(this, countUserId) >= limit) return { meta: { changes: 0 } };
+        if (pinnedCountOf(this, countUserId) >= limit) {
+          this.onAfterPinUpdate?.();
+          return { meta: { changes: 0 } };
+        }
       }
       movie.pinned = pinned;
       movie.expiresAt = expiresAt;
+      this.onAfterPinUpdate?.();
       return { meta: { changes: 1 } };
     }
 
@@ -406,6 +420,50 @@ describe('togglePin', () => {
     expect(rejected).toHaveLength(1);
     expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({ status: 409 });
     expect(pinnedCountOf(database, USER_ID)).toBe(MAX_PINNED_MOVIES);
+  });
+
+  it('上限で弾いた直後に枠が空いても 409 のまま返す', async () => {
+    // 0 件の理由を件数の再集計で決めると、弾かれた直後の解除で 9 件に見えて 410 に化ける。
+    // 呼び出し側（ui/preview-actions.ts）は 409 と 410 で別の文言を出すので誤案内になる。
+    const now = new Date('2026-08-10T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([
+      ...pinnedMovies(MAX_PINNED_MOVIES - 1),
+      movie({ shortId: 'other0000001' }),
+      movie(),
+    ]);
+    database.onBeforePinUpdate = () => {
+      const concurrent = database.movies.get('other0000001');
+      if (concurrent) concurrent.pinned = 1;
+    };
+    database.onAfterPinUpdate = () => {
+      const released = database.movies.get('pinned000000');
+      if (released) released.pinned = 0;
+    };
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 409, errorCode: ERROR_CODES.invalidRequest });
+  });
+
+  it('期限切れと上限到達が重なったら期限切れ（410）を優先する', async () => {
+    // 理由の判定にリクエスト開始時の now を使うと、書き込みの直前に過ぎた期限を見落として
+    // 409 を返す。期限切れは終端の状態なので、D1 の時刻で判定して 410 を優先する。
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    const database = new FakeMoviesDatabase([
+      ...pinnedMovies(MAX_PINNED_MOVIES - 1),
+      movie({ shortId: 'other0000001', expiresAt: null }),
+      movie({ expiresAt: '2026-09-01T00:00:10.000Z' }),
+    ]);
+    database.now = now;
+    database.onBeforePinUpdate = () => {
+      const concurrent = database.movies.get('other0000001');
+      if (concurrent) concurrent.pinned = 1;
+      database.now = new Date('2026-09-01T00:00:20.000Z');
+    };
+
+    await expect(
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now })
+    ).rejects.toMatchObject({ status: 410, errorCode: ERROR_CODES.expired });
   });
 
   it('9 件なら 10 件目を pin できる', async () => {


### PR DESCRIPTION
## なぜこの変更が必要か

ピン留めは保管期間を 1 年へ延ばす操作で、1 ユーザー 10 件の上限がある。判定が「COUNT を読む → UPDATE する」の 2 手だったため、同時に複数の pin を投げると全部が COUNT=9 を読んで上限を超えられた（Issue #85、PR #87 のセキュリティレビューで指摘）。

## 変更内容

- `togglePin` の UPDATE に `(SELECT COUNT(*) ... pinned = 1) < ?` の条件を足し、上限判定を 1 文で原子化（pin する時だけ。解除は枠を空ける操作なので条件なし）
- UPDATE が 0 件だった理由の引き直しを `throwPinConflict` に集約: 行なし 404 → 期限切れ 410（D1 の時刻で判定）→ 上限 409
- 上限超過の 409 は既存の文言・エラーコードを再利用
- 再発防止テスト 4 本（UPDATE 直前の割り込み / 残り 2 枠へ 3 本並行 / 上限で弾いた直後に解除されても 409 / 直前に期限切れ + 上限なら 410）

## 意思決定

### 採用アプローチ
- UPDATE の WHERE で数える。D1 は DB ごとにクエリを逐次処理するので単文が原子境界になる。期限判定を `UPDATE ... WHERE` へ寄せた PR #87 と同じ形
- 0 件の理由は再集計した COUNT ではなく「行の有無 + D1 時刻の期限」だけで決める。再集計は競合で件数が動き 409/410 を取り違える（レビューゲートの指摘で修正）

### 却下した代替案
- トランザクション（BEGIN/COMMIT）→ D1 の batch は複数文の原子性を保証するが、条件付き単文で足りる
- 事前 COUNT の撤去 → 通常時の 409 の理由付けに残した（追加クエリは pin 時のみ）

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 344 pass / 0 fail
- [x] 再発防止テストは修正前に失敗することを確認（`30 pass 2 fail` → 全 green）
- [x] 実 sqlite3 で SQL の妥当性を確認（上限時 `changes=0`、枠を空けると `changes=1`）

## レビューゲート

codex `gpt-5.6-sol` 2 レーン + 再レビュー 1 回。ブロッキング 1 件（409/410 の誤分類）を修正。残る指摘（期限ちょうど ±1 秒の `datetime()` 境界）は PR #87 由来の既存挙動で本 PR の範囲外として却下（review-ledger 記録済み）。

Refs #85

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
