### PR TITLE
fix(web): エンコード段階の 70% 停滞を部分帯域で解消する

### DIFF
--- a/web/src/lib/convert/encode.ts
+++ b/web/src/lib/convert/encode.ts
@@ -1,7 +1,7 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { toBlobURL } from '@ffmpeg/util';
 
-import type { ProgressReporter, VideoFrame } from './types';
+import type { ConversionProgress, ProgressReporter, VideoFrame } from './types';
 
 const CORE_VERSION = '0.12.10';
 const CORE_BASE_URL = `https://cdn.jsdelivr.net/npm/@ffmpeg/core@${CORE_VERSION}/dist/esm`;
@@ -85,24 +85,32 @@ async function loadFfmpeg(): Promise<FFmpeg> {
 }
 
 /**
- * core を読み込みつつ、読み込み区間のバーを進める。
+ * 読み込み中のバーを擬似進捗で進める。戻り値は停止関数。
  *
  * `toBlobURL` の進捗コールバックは使わない。受信バイト数と Content-Length が食い違うと
  * @ffmpeg/util が本文を読み切った Response へ再度 arrayBuffer() を掛けて失敗するため、
  * キャッシュが冷えている時ほど読み込みそのものを壊しうる。
- * タイマーは読み込みの await だけを包んで必ず止める（遅れて発火した tick が
- * 書き出し・実行の報告に割り込むと、枚数の表示が 0 へ戻る）。
+ *
+ * 上限へ達したら自分でタイマーを止める。読み込みが返らないまま（オフライン・CDN 停止）
+ * でも、同じ値を延々と通知し続けないため。停止関数は読み込みの完了・失敗の両方で呼び、
+ * 遅れて発火した tick が書き出し・実行の報告へ割り込む（枚数が 0 へ戻る）のを防ぐ。
  */
-async function loadFfmpegWithProgress(total: number, report?: ProgressReporter): Promise<FFmpeg> {
+export function startLoadPseudoProgress(total: number, report?: ProgressReporter): () => void {
   let elapsed = 0;
   const timer = setInterval(() => {
     elapsed = Math.min(LOAD_PSEUDO_MAX, elapsed + LOAD_TICK_RATIO);
     report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('loading', elapsed, 1) });
+    if (elapsed >= LOAD_PSEUDO_MAX) clearInterval(timer);
   }, LOAD_TICK_MS);
+  return () => clearInterval(timer);
+}
+
+async function loadFfmpegWithProgress(total: number, report?: ProgressReporter): Promise<FFmpeg> {
+  const stopPseudoProgress = startLoadPseudoProgress(total, report);
   try {
     return await loadFfmpeg();
   } finally {
-    clearInterval(timer);
+    stopPseudoProgress();
   }
 }
 
@@ -116,6 +124,22 @@ async function readMp4(ffmpeg: FFmpeg, outputFile: string): Promise<Blob> {
 export function encodedFrameCount(progress: number, total: number): number {
   if (!Number.isFinite(progress)) return 0;
   return Math.min(total, Math.max(0, Math.round(progress * total)));
+}
+
+/**
+ * FFmpeg の実行中の報告を組み立てる。
+ *
+ * バーは生の進み具合から計算する。枚数へ丸めた値を使うと、フレームが少ないほど
+ * 段階が粗くなり（1 枚なら 49% まで区間の先頭で止まり 50% で終端へ飛ぶ）、
+ * 完了前に 95% を表示してしまう。枚数の表示は従来どおり丸めた値を使う。
+ */
+export function runningProgress(progress: number, total: number): ConversionProgress {
+  return {
+    stage: 'encoding',
+    current: encodedFrameCount(progress, total),
+    total,
+    ratio: encodePhaseRatio('running', progress, 1),
+  };
 }
 
 /** PNG フレーム列を順序を保って VRChat 互換 MP4 にエンコードする。 */
@@ -132,10 +156,7 @@ export async function encodeFramesToMp4(frames: readonly VideoFrame[], report?: 
       await ffmpeg.writeFile(frameFileName(index), new Uint8Array(frame.data));
       report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('writing', index + 1, total) });
     }
-    ffmpeg.on('progress', ({ progress }) => {
-      const current = encodedFrameCount(progress, total);
-      report?.({ stage: 'encoding', current, total, ratio: encodePhaseRatio('running', current, total) });
-    });
+    ffmpeg.on('progress', ({ progress }) => report?.(runningProgress(progress, total)));
     const status = await ffmpeg.exec(buildFrameEncodeArgs());
     if (status !== 0) throw new Error(`FFmpeg exited with ${status}`);
     return await readMp4(ffmpeg, 'output.mp4');

--- a/web/src/lib/convert/encode.ts
+++ b/web/src/lib/convert/encode.ts
@@ -9,6 +9,32 @@ const CORE_JS_URL = `${CORE_BASE_URL}/ffmpeg-core.js`;
 const CORE_WASM_URL = `${CORE_BASE_URL}/ffmpeg-core.wasm`;
 const FRAME_RATE = 1;
 
+/** エンコード段階の内部工程。時間の掛かる待ちが 3 つあるので部分帯域に分ける。 */
+export type EncodePhase = 'loading' | 'writing' | 'running';
+
+/**
+ * エンコード段階の中で各工程が占める区間（段階内の 0〜1）。
+ *
+ * UI がエンコード段階へ割り当てている 70〜95% に写すと、読み込み 70→73%、
+ * 書き出し 73→80%、実行 80→95% になる。3 工程を別々に 0 から報告すると同じ段階の中で
+ * 枚数の表示が戻るため、区間へ写すのはバーの進み具合だけにして、枚数は実際に
+ * エンコードされた数だけを出す。
+ */
+const ENCODE_PHASE_BANDS: Readonly<Record<EncodePhase, readonly [start: number, end: number]>> = {
+  loading: [0, 0.12],
+  writing: [0.12, 0.4],
+  running: [0.4, 1],
+};
+
+/** core の取得は残り時間が読めないため、擬似進捗で読み込み区間の中を進める。 */
+const LOAD_TICK_MS = 500;
+const LOAD_TICK_RATIO = 0.05;
+/**
+ * 読み込みが終わる前に区間の端へ届かせない（届くと完了の合図が消える）。
+ * 表示は整数 % へ丸められるので、丸めた後も完了の 73% と重ならない値にする。
+ */
+const LOAD_PSEUDO_MAX = 0.8;
+
 /** フレームの順序を FFmpeg の連番ファイル名へ固定する。 */
 export function frameFileName(index: number): string {
   return `frame-${String(index).padStart(6, '0')}.png`;
@@ -39,6 +65,14 @@ export function buildFrameEncodeArgs(outputFile = 'output.mp4'): string[] {
   ];
 }
 
+/** 内部工程の進み具合を、エンコード段階全体の進み具合（0〜1）へ写す。 */
+export function encodePhaseRatio(phase: EncodePhase, done: number, total: number): number {
+  const [start, end] = ENCODE_PHASE_BANDS[phase];
+  if (!Number.isFinite(done) || !Number.isFinite(total) || total <= 0) return start;
+  const within = Math.min(1, Math.max(0, done / total));
+  return start + (end - start) * within;
+}
+
 async function loadFfmpeg(): Promise<FFmpeg> {
   const ffmpeg = new FFmpeg();
   // Workers Assets に収まらない core/wasm を CDN から取得し、同一オリジン Blob URL として Worker に渡す。
@@ -48,6 +82,28 @@ async function loadFfmpeg(): Promise<FFmpeg> {
   ]);
   await ffmpeg.load({ coreURL, wasmURL });
   return ffmpeg;
+}
+
+/**
+ * core を読み込みつつ、読み込み区間のバーを進める。
+ *
+ * `toBlobURL` の進捗コールバックは使わない。受信バイト数と Content-Length が食い違うと
+ * @ffmpeg/util が本文を読み切った Response へ再度 arrayBuffer() を掛けて失敗するため、
+ * キャッシュが冷えている時ほど読み込みそのものを壊しうる。
+ * タイマーは読み込みの await だけを包んで必ず止める（遅れて発火した tick が
+ * 書き出し・実行の報告に割り込むと、枚数の表示が 0 へ戻る）。
+ */
+async function loadFfmpegWithProgress(total: number, report?: ProgressReporter): Promise<FFmpeg> {
+  let elapsed = 0;
+  const timer = setInterval(() => {
+    elapsed = Math.min(LOAD_PSEUDO_MAX, elapsed + LOAD_TICK_RATIO);
+    report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('loading', elapsed, 1) });
+  }, LOAD_TICK_MS);
+  try {
+    return await loadFfmpeg();
+  } finally {
+    clearInterval(timer);
+  }
 }
 
 async function readMp4(ffmpeg: FFmpeg, outputFile: string): Promise<Blob> {
@@ -66,20 +122,20 @@ export function encodedFrameCount(progress: number, total: number): number {
 export async function encodeFramesToMp4(frames: readonly VideoFrame[], report?: ProgressReporter): Promise<Blob> {
   if (frames.length === 0) throw new Error('At least one frame is required');
   const total = frames.length;
-  // エンコードは「core 読み込み → フレーム書き出し → FFmpeg 実行」と進むが、3 つを
-  // 別々に 0 から報告すると同じ段階の中で枚数の表示が戻る。進捗の単位を「エンコード済み
-  // フレーム数」に統一し、時間のほとんどを占める実行の進み具合だけを報告する。
-  // note: 読み込みと書き出しの間は帯域の先頭で止まる。キャッシュが冷えている時や
-  // フレームが多い時はここが目に見える停滞になる（段階を分けて解消する: Issue #80）。
-  report?.({ stage: 'encoding', current: 0, total });
-  const ffmpeg = await loadFfmpeg();
+  // エンコードは「core 読み込み → フレーム書き出し → FFmpeg 実行」と進む。枚数は実行が
+  // 始まるまで動かせない（書き出し枚数を出すと実行の開始で 0 に戻る）ため、枚数は据え置き、
+  // バーだけを工程ごとの部分帯域で進める。
+  report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('loading', 0, 1) });
+  const ffmpeg = await loadFfmpegWithProgress(total, report);
   try {
     for (const [index, frame] of frames.entries()) {
       await ffmpeg.writeFile(frameFileName(index), new Uint8Array(frame.data));
+      report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('writing', index + 1, total) });
     }
-    ffmpeg.on('progress', ({ progress }) =>
-      report?.({ stage: 'encoding', current: encodedFrameCount(progress, total), total })
-    );
+    ffmpeg.on('progress', ({ progress }) => {
+      const current = encodedFrameCount(progress, total);
+      report?.({ stage: 'encoding', current, total, ratio: encodePhaseRatio('running', current, total) });
+    });
     const status = await ffmpeg.exec(buildFrameEncodeArgs());
     if (status !== 0) throw new Error(`FFmpeg exited with ${status}`);
     return await readMp4(ffmpeg, 'output.mp4');

--- a/web/src/lib/convert/types.ts
+++ b/web/src/lib/convert/types.ts
@@ -21,6 +21,13 @@ export interface ConversionProgress {
   stage: ConversionStage;
   current: number;
   total: number;
+  /**
+   * 段階の中の進み具合（0〜1）。省略時は current / total を使う。
+   *
+   * 枚数が動かせない下ごしらえ（エンコード前の core 読み込み・フレーム書き出し）でも
+   * バーを進めるため、バーの進み具合を枚数と切り離せるようにしている。
+   */
+  ratio?: number;
 }
 
 /** 変換工程で利用する進捗通知。 */

--- a/web/src/lib/ui/upload-flow.ts
+++ b/web/src/lib/ui/upload-flow.ts
@@ -116,7 +116,7 @@ export type UploadEvent =
   | { type: 'selectFile'; filename: string; sizeBytes: number }
   | { type: 'selectFiles'; files: readonly { filename: string; sizeBytes: number }[] }
   | { type: 'selectUrl'; url: string }
-  | { type: 'stageProgress'; stage: ProgressStage; current: number; total: number }
+  | { type: 'stageProgress'; stage: ProgressStage; current: number; total: number; ratio?: number }
   | { type: 'stageRatio'; stage: ProgressStage; ratio: number }
   | { type: 'converted' }
   | { type: 'uploaded'; publicUrl: string; shortId: string }
@@ -229,7 +229,12 @@ export function reduceUpload(state: UploadState, event: UploadEvent): UploadStat
     case 'stageProgress': {
       if (event.total <= 0 || event.current < 0) return state;
       const current = Math.min(event.current, event.total);
-      return advanceStage(state, event.stage, current / event.total, { current, total: event.total });
+      // 枚数が動かせない下ごしらえ（エンコードの core 読み込み・フレーム書き出し）は
+      // ratio を添えてくる。バーはそれで進め、枚数は実態のまま据え置く。
+      return advanceStage(state, event.stage, event.ratio ?? current / event.total, {
+        current,
+        total: event.total,
+      });
     }
 
     case 'stageRatio':

--- a/web/tests/convert/encode.test.ts
+++ b/web/tests/convert/encode.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, jest, test } from 'bun:test';
 
 import {
   buildFrameEncodeArgs,
   encodedFrameCount,
   encodePhaseRatio,
   frameFileName,
+  runningProgress,
+  startLoadPseudoProgress,
 } from '../../src/lib/convert/encode';
 import { fetchImagesInOrder } from '../../src/lib/convert/imageUrls';
 import { assertPdfPageCount, MAX_PDF_PAGES } from '../../src/lib/convert/pdf';
@@ -57,6 +59,38 @@ describe('エンコードの進捗', () => {
     ];
 
     expect(ratios).toEqual([...ratios].sort((a, b) => a - b));
+  });
+
+  test('実行中はバーを生の進み具合、枚数を丸めた値で報告する', () => {
+    // 丸めた枚数からバーを作ると、フレームが 1 枚のときは生進捗 49% まで区間の先頭
+    // （表示 80%）で止まり、50% で終端（表示 95%）へ飛んで完了前に 95% を出してしまう。
+    const ratios = [0, 0.25, 0.49, 0.5, 0.75, 1].map((progress) => runningProgress(progress, 1).ratio ?? 0);
+
+    expect(ratios).toEqual([...ratios].sort((a, b) => a - b));
+    expect(new Set(ratios).size).toBe(ratios.length);
+    expect(ratios[0]).toBeCloseTo(0.4);
+    expect(ratios.at(-1)).toBe(1);
+    // 枚数の表示は従来どおり丸めた値。
+    expect(runningProgress(0.5, 200).current).toBe(100);
+  });
+
+  test('読み込みの擬似進捗は上限に達したら刻むのをやめる', () => {
+    jest.useFakeTimers();
+    const ratios: number[] = [];
+    const stop = startLoadPseudoProgress(200, (progress) => ratios.push(progress.ratio ?? 0));
+
+    jest.advanceTimersByTime(60_000);
+    const cappedCount = ratios.length;
+    jest.advanceTimersByTime(60_000);
+    stop();
+    jest.useRealTimers();
+
+    // 読み込みが返らないまま（オフライン・CDN 停止）でも、上限へ達した後は通知しない。
+    expect(cappedCount).toBeGreaterThan(0);
+    expect(ratios.length).toBe(cappedCount);
+    expect(ratios).toEqual([...ratios].sort((a, b) => a - b));
+    // 読み込み完了の合図（区間の端）へは擬似進捗では届かせない。
+    expect(ratios.at(-1)).toBeLessThan(encodePhaseRatio('loading', 1, 1));
   });
 
   test('総数が 0 や NaN でも工程の区間から出ない', () => {

--- a/web/tests/convert/encode.test.ts
+++ b/web/tests/convert/encode.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 
-import { buildFrameEncodeArgs, encodedFrameCount, frameFileName } from '../../src/lib/convert/encode';
+import {
+  buildFrameEncodeArgs,
+  encodedFrameCount,
+  encodePhaseRatio,
+  frameFileName,
+} from '../../src/lib/convert/encode';
 import { fetchImagesInOrder } from '../../src/lib/convert/imageUrls';
 import { assertPdfPageCount, MAX_PDF_PAGES } from '../../src/lib/convert/pdf';
 
@@ -29,6 +34,36 @@ describe('エンコードの進捗', () => {
   test('範囲外の進み具合でも枚数は 0〜総数に収まる', () => {
     // FFmpeg は 1 を超える進み具合や NaN を返すことがあり、そのまま表示すると枚数が総数を超える。
     expect([1.2, -0.1, Number.NaN].map((progress) => encodedFrameCount(progress, 100))).toEqual([100, 0, 0]);
+  });
+
+  test('内部工程は段階内の区間へ写る（読み込み→書き出し→実行）', () => {
+    // 段階の帯域 70〜95% に写すと 70→73→80→95% になる配分。
+    expect(encodePhaseRatio('loading', 0, 1)).toBe(0);
+    expect(encodePhaseRatio('loading', 1, 1)).toBeCloseTo(0.12);
+    expect(encodePhaseRatio('writing', 0, 200)).toBeCloseTo(0.12);
+    expect(encodePhaseRatio('writing', 200, 200)).toBeCloseTo(0.4);
+    expect(encodePhaseRatio('running', 0, 200)).toBeCloseTo(0.4);
+    expect(encodePhaseRatio('running', 200, 200)).toBe(1);
+  });
+
+  test('工程をまたいでも進み具合は単調増加する', () => {
+    const ratios = [
+      encodePhaseRatio('loading', 0, 1),
+      encodePhaseRatio('loading', 0.9, 1),
+      encodePhaseRatio('writing', 1, 200),
+      encodePhaseRatio('writing', 200, 200),
+      encodePhaseRatio('running', 1, 200),
+      encodePhaseRatio('running', 200, 200),
+    ];
+
+    expect(ratios).toEqual([...ratios].sort((a, b) => a - b));
+  });
+
+  test('総数が 0 や NaN でも工程の区間から出ない', () => {
+    // 枚数が確定していない読み込み中でも、区間の先頭より前へは戻さない。
+    expect(encodePhaseRatio('writing', 1, 0)).toBeCloseTo(0.12);
+    expect(encodePhaseRatio('running', Number.NaN, 200)).toBeCloseTo(0.4);
+    expect(encodePhaseRatio('running', 400, 200)).toBe(1);
   });
 });
 

--- a/web/tests/ui/upload-flow.test.ts
+++ b/web/tests/ui/upload-flow.test.ts
@@ -257,6 +257,34 @@ describe('段階ごとの進捗', () => {
     expect(progresses.at(-1)).toBe(99);
   });
 
+  test('エンコードの下ごしらえ中もバーが進み、枚数は後退しない', () => {
+    // core 読み込みとフレーム書き出しの間は枚数を動かせない（書き出し枚数を出すと実行の
+    // 開始で 0 に戻る）。バーだけを ratio で進め、帯域 70〜95% を 70→73→80→95% と割る。
+    const frames = 200;
+    const events: UploadEvent[] = [
+      { type: 'stageProgress', stage: 'encoding', current: 0, total: frames, ratio: 0 },
+      { type: 'stageProgress', stage: 'encoding', current: 0, total: frames, ratio: 0.12 },
+      { type: 'stageProgress', stage: 'encoding', current: 0, total: frames, ratio: 0.2 },
+      { type: 'stageProgress', stage: 'encoding', current: 0, total: frames, ratio: 0.4 },
+      { type: 'stageProgress', stage: 'encoding', current: 100, total: frames, ratio: 0.7 },
+      { type: 'stageProgress', stage: 'encoding', current: frames, total: frames, ratio: 1 },
+      // 読み込みの擬似進捗が遅れて届いても後退させない。
+      { type: 'stageProgress', stage: 'encoding', current: frames, total: frames, ratio: 0.12 },
+    ];
+
+    const progresses: number[] = [];
+    const currents: (number | null)[] = [];
+    let state = convertingUrl();
+    for (const event of events) {
+      state = reduceUpload(state, event);
+      progresses.push(state.progress);
+      currents.push(state.current);
+    }
+
+    expect(progresses).toEqual([70, 73, 75, 80, 88, 95, 95]);
+    expect(currents).toEqual([0, 0, 0, 0, 100, 200, 200]);
+  });
+
   test('撮影中に総枚数が増えてもバーは戻さない', () => {
     // 遅延読み込みで伸びるページでは総枚数が途中で増える（capture-pages.ts が許容している）。
     // 比率だけ見ると 100/150 → 200/500 で後退するため、到達済みの値を下限にする必要がある。


### PR DESCRIPTION
## なぜこの変更が必要か

進捗表示を 4 段階制にした際、エンコード段階（帯域 70〜95%）の内部「core 読み込み → フレーム書き出し → FFmpeg 実行」のうち最後しか進捗を報告していなかった。キャッシュが冷えている時や 200 枚超のページでは 70% で止まって見える（Issue #80）。

## 変更内容

- `ConversionProgress` に任意の `ratio`（段階内 0〜1）を追加し、バーの進み具合を枚数表示と切り離す
- エンコード段階を「読み込み 70→73 / 書き出し 73→80（フレーム数比例）/ 実行 80→95」の部分帯域に分割（`ENCODE_PHASE_BANDS`）
- core 読み込み中は擬似進捗（500ms tick、上限で停止）。実行中は FFmpeg の生 `progress` からバーを計算し、枚数は従来どおり丸め値
- reducer は `event.ratio ?? current / total` の 1 行追加。段階も表示文言も増やしていない

## 意思決定

### 採用アプローチ
- 段階を 5 つに増やさず部分帯域で解決（文言と状態を増やさない。Issue の方針）
- `toBlobURL` の progress コールバックは使わない: @ffmpeg/util の catch 経路が読み切った Response に再度 `arrayBuffer()` を掛け、Content-Length 不一致で読み込み自体が落ちるため。代わりに擬似進捗タイマー

### 却下した代替案
- 書き出し枚数をそのまま表示 → 実行開始で 0 に戻り、同じ段階内で枚数が後退する

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 346 pass / 0 fail（区間の境界・工程またぎの単調増加・`total=1` の生進捗・タイマーの上限停止・枚数の非後退を追加）
- [ ] ブラウザ実機での見え方は未確認（FFmpeg.wasm 実行が要るためユニット対象外）

## レビューゲート

codex `gpt-5.6-sol` 2 レーン + 再レビュー 1 回。ブロッキング 2 件（1 フレーム入力で 80→95 が 2 段階になる / 擬似進捗タイマーの残留）を修正し、再レビューで指摘なし。

Refs #80

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
