### PR TITLE
feat(web): ダウンロード経路を Range リクエストに対応させる

### DIFF
--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -139,6 +139,34 @@ test.describe('公開プレビュー', () => {
     expect(response.headers()['content-range']).toMatch(/^bytes \*\/\d+$/);
   });
 
+  test('HEAD は Range を無視して 200 と総量だけを返す', async ({ request }) => {
+    const size = (await (await request.get(`/${E2E_FIXTURES.readyShortId}/download/`)).body())
+      .byteLength;
+
+    const response = await request.head(`/${E2E_FIXTURES.readyShortId}/download/`, {
+      headers: { Range: 'bytes=0-99' },
+    });
+
+    // RFC 9110 14.2 は GET 以外の Range を無視させる
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-range']).toBeUndefined();
+    expect(response.headers()['content-length']).toBe(String(size));
+    expect(response.headers()['accept-ranges']).toBe('bytes');
+    expect(response.headers()['content-disposition']).toContain('filename="slides.mp4"');
+    expect((await response.body()).byteLength).toBe(0);
+  });
+
+  test('If-Range が実体と一致しなければ全体を返す', async ({ request }) => {
+    const response = await request.get(`/${E2E_FIXTURES.readyShortId}/download/`, {
+      headers: { Range: 'bytes=0-99', 'If-Range': '"not-the-current-etag"' },
+    });
+
+    // 差し替わった実体の一部を継ぎ足すと、壊れたファイルが出来上がる
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-range']).toBeUndefined();
+    expect((await response.body()).byteLength).toBeGreaterThan(100);
+  });
+
   test('存在しない動画のダウンロードは 404', async ({ request }) => {
     expect((await request.get('/E2EMissing001/download/')).status()).toBe(404);
   });

--- a/web/e2e/preview.spec.ts
+++ b/web/e2e/preview.spec.ts
@@ -106,6 +106,37 @@ test.describe('公開プレビュー', () => {
     const body = await response.body();
     expect(body.byteLength).toBeGreaterThan(0);
     expect(body.subarray(4, 8).toString('ascii')).toBe('ftyp');
+
+    // 総量が分かって初めて進捗表示と再開の判断ができる
+    expect(response.headers()['content-length']).toBe(String(body.byteLength));
+    expect(response.headers()['accept-ranges']).toBe('bytes');
+  });
+
+  test('Range 要求には 206 で要求された範囲だけを返す', async ({ request }) => {
+    const response = await request.get(`/${E2E_FIXTURES.readyShortId}/download/`, {
+      headers: { Range: 'bytes=0-99' },
+    });
+
+    expect(response.status()).toBe(206);
+    expect(response.headers()['content-range']).toMatch(/^bytes 0-99\/\d+$/);
+    expect(response.headers()['content-length']).toBe('100');
+    expect(response.headers()['accept-ranges']).toBe('bytes');
+    // 再開したダウンロードでも保存名が変わらないこと
+    expect(response.headers()['content-disposition']).toContain('filename="slides.mp4"');
+
+    const body = await response.body();
+    expect(body.byteLength).toBe(100);
+    expect(body.subarray(4, 8).toString('ascii')).toBe('ftyp');
+  });
+
+  test('実体と重ならない Range は 416 と総量を返す', async ({ request }) => {
+    const response = await request.get(`/${E2E_FIXTURES.readyShortId}/download/`, {
+      headers: { Range: 'bytes=99999999-' },
+    });
+
+    expect(response.status()).toBe(416);
+    // 総量を返さないと、クライアントは範囲を直して要求し直せない
+    expect(response.headers()['content-range']).toMatch(/^bytes \*\/\d+$/);
   });
 
   test('存在しない動画のダウンロードは 404', async ({ request }) => {

--- a/web/src/lib/services/download.ts
+++ b/web/src/lib/services/download.ts
@@ -64,6 +64,7 @@ export function attachmentDisposition(filename: string): string {
 export function downloadHeaders(input: {
   filename: string;
   contentLength: number;
+  etag: string;
   contentRange?: string;
 }): Record<string, string> {
   const headers: Record<string, string> = {
@@ -72,14 +73,33 @@ export function downloadHeaders(input: {
     'Content-Length': String(input.contentLength),
     // 部分取得に対応していることは、要求される前に伝える必要がある
     'Accept-Ranges': 'bytes',
+    // 中断した続きを要求する側が、実体が同じかを判断するための validator
+    ETag: input.etag,
     // cdn 側の Transform Rule はこの経路に効かないため、ここで明示する。
     'X-Robots-Tag': 'noindex',
+    // 表示名は利用者が変えられる。宣言した video/mp4 以外として解釈させない
+    'X-Content-Type-Options': 'nosniff',
     'Cache-Control': CACHE_CONTROL,
   };
 
   if (input.contentRange !== undefined) headers['Content-Range'] = input.contentRange;
 
   return headers;
+}
+
+/**
+ * If-Range 付きの部分取得を、その実体に対して認めてよいか判定する。
+ *
+ * 中断前と実体が変わっていたら、続きを継ぎ足した結果は壊れたファイルになる。
+ * 一致しない時は範囲を無視して全体を返すのが RFC 9110 13.1.5 の求める挙動。
+ * 比較は strong comparison なので、`W/` 付きの弱い validator は常に一致しない。
+ */
+export function rangeApplies(ifRange: string | null, etag: string): boolean {
+  if (ifRange === null) return true;
+
+  // 日付形式の If-Range も一致扱いにしない（Last-Modified を返していないため
+  // クライアントは日付を持っておらず、送られてきても比較の根拠がない）
+  return ifRange.trim() === etag;
 }
 
 /**

--- a/web/src/lib/services/download.ts
+++ b/web/src/lib/services/download.ts
@@ -1,6 +1,33 @@
 /** 保存名の既定。表示名から ASCII の手がかりが何も残らなかった時に使う。 */
 const DEFAULT_DOWNLOAD_NAME = 'movie.mp4';
 
+/** R2 に入る実体は常に mp4。表示名の拡張子は保存名の正規化にしか使わない。 */
+const CONTENT_TYPE = 'video/mp4';
+
+/**
+ * 同じ動画への連続アクセスをエッジで吸収しつつ、削除後に配信され続ける窓は
+ * 短く抑える（cdn 直の既定 TTL 120 分より大幅に短い）。
+ */
+const CACHE_CONTROL = 'public, max-age=300';
+
+/** Range ヘッダーで唯一受け付ける単位。 */
+const BYTES_UNIT_PREFIX = 'bytes=';
+
+/** `bytes=<first>-<last>` の両端。片方は省略できる（両方の省略は不正）。 */
+const BYTES_RANGE_SPEC = /^(\d*)-(\d*)$/;
+
+/**
+ * Range 要求を実体の総量と突き合わせた結果。
+ *
+ * - `full`: 範囲を無視して全体を返す（ヘッダー無し・未知の単位・複数レンジ）
+ * - `partial`: 206 で返す確定した範囲
+ * - `unsatisfiable`: 416 を返す（実体と重ならない・構文が壊れている）
+ */
+export type ResolvedRange =
+  | { kind: 'full' }
+  | { kind: 'partial'; offset: number; length: number }
+  | { kind: 'unsatisfiable' };
+
 /**
  * 保存に使うファイル名を決める。
  *
@@ -25,6 +52,96 @@ export function attachmentDisposition(filename: string): string {
   const encoded = encodeRFC5987(normalized);
 
   return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+/**
+ * ダウンロード応答のヘッダーを組み立てる。
+ *
+ * 200 と 206 で 1 箇所に集約するのは、再開したダウンロードだけ保存名や noindex が
+ * 落ちるのを防ぐため。`Content-Length` を明示しないと本文が chunked になり、
+ * 受け取り側で総量が分からず進捗表示も再開の判断もできない。
+ */
+export function downloadHeaders(input: {
+  filename: string;
+  contentLength: number;
+  contentRange?: string;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': CONTENT_TYPE,
+    'Content-Disposition': attachmentDisposition(input.filename),
+    'Content-Length': String(input.contentLength),
+    // 部分取得に対応していることは、要求される前に伝える必要がある
+    'Accept-Ranges': 'bytes',
+    // cdn 側の Transform Rule はこの経路に効かないため、ここで明示する。
+    'X-Robots-Tag': 'noindex',
+    'Cache-Control': CACHE_CONTROL,
+  };
+
+  if (input.contentRange !== undefined) headers['Content-Range'] = input.contentRange;
+
+  return headers;
+}
+
+/**
+ * Range ヘッダーを実体の総量と突き合わせ、R2 へ渡せる範囲まで確定させる。
+ *
+ * R2 の `range` は長さの超過ぶんを切り詰めるが、開始位置が総量を超えた場合の挙動は
+ * ドキュメントに規定がない。総量が分かった時点でこちら側で 416 を判断し、R2 には
+ * 必ず満たせる `{offset, length}` だけを渡す（返却される `range` の形にも依存しない）。
+ */
+export function resolveRangeRequest(header: string | null, size: number): ResolvedRange {
+  if (header === null) return { kind: 'full' };
+
+  const value = header.trim();
+  // 単位を理解できない要求は無視して全体を返す（RFC 9110 14.2）
+  if (!value.toLowerCase().startsWith(BYTES_UNIT_PREFIX)) return { kind: 'full' };
+
+  const spec = value.slice(BYTES_UNIT_PREFIX.length).trim();
+  // 複数レンジは multipart/byteranges になるため未対応。満たせる要求なので 416 にはしない
+  if (spec.includes(',')) return { kind: 'full' };
+
+  const match = BYTES_RANGE_SPEC.exec(spec);
+  if (!match) return { kind: 'unsatisfiable' };
+
+  const [, startText = '', endText = ''] = match;
+  if (startText === '') return resolveSuffix(endText, size);
+
+  const start = Number(startText);
+  if (!Number.isSafeInteger(start) || start >= size) return { kind: 'unsatisfiable' };
+  if (endText === '') return { kind: 'partial', offset: start, length: size - start };
+
+  const end = Number(endText);
+  if (!Number.isSafeInteger(end) || end < start) return { kind: 'unsatisfiable' };
+
+  // 実体より後ろまで要求されても末尾で止める（RFC 9110 14.1.1）
+  const last = Math.min(end, size - 1);
+  return { kind: 'partial', offset: start, length: last - start + 1 };
+}
+
+/** 206 の Content-Range。末尾の位置は範囲に含む。 */
+export function partialContentRange(
+  range: { offset: number; length: number },
+  size: number
+): string {
+  return `bytes ${range.offset}-${range.offset + range.length - 1}/${size}`;
+}
+
+/** 416 の Content-Range。満たせる範囲が無いことと総量だけを伝える。 */
+export function unsatisfiedContentRange(size: number): string {
+  return `bytes */${size}`;
+}
+
+/** `bytes=-N`（末尾 N バイト）を解決する。0 バイトの要求は満たせる範囲が無い。 */
+function resolveSuffix(suffixText: string, size: number): ResolvedRange {
+  if (suffixText === '') return { kind: 'unsatisfiable' };
+
+  const suffix = Number(suffixText);
+  if (!Number.isSafeInteger(suffix) || suffix === 0 || size === 0) {
+    return { kind: 'unsatisfiable' };
+  }
+
+  const length = Math.min(suffix, size);
+  return { kind: 'partial', offset: size - length, length };
 }
 
 /**

--- a/web/src/pages/[shortId]/download.ts
+++ b/web/src/pages/[shortId]/download.ts
@@ -6,18 +6,29 @@ import { findPublicMovie, type MoviesDatabase } from '../../lib/services/movies'
 import {
   downloadHeaders,
   partialContentRange,
+  rangeApplies,
   resolveRangeRequest,
   unsatisfiedContentRange,
 } from '../../lib/services/download';
 
 export const prerender = false;
 
+interface DownloadObject {
+  body: ReadableStream | null;
+  size: number;
+  httpEtag: string;
+}
+
 interface DownloadBucket {
-  head(key: string): Promise<{ size: number } | null>;
+  /** `etag` は引用符なし、`httpEtag` は引用符付き。用途が違うので両方使う。 */
+  head(key: string): Promise<{ size: number; etag: string; httpEtag: string } | null>;
   get(
     key: string,
-    options?: { range: { offset: number; length: number } }
-  ): Promise<{ body: ReadableStream | null; size: number } | null>;
+    options?: {
+      range: { offset: number; length: number };
+      onlyIf: { etagMatches: string };
+    }
+  ): Promise<DownloadObject | null>;
 }
 
 interface DownloadBindings {
@@ -38,13 +49,8 @@ interface DownloadBindings {
  */
 export const GET: APIRoute = async ({ params, request }) => {
   const bindings = env as unknown as DownloadBindings;
-  const shortId = params.shortId ?? '';
 
-  const movie = await findPublicMovie({
-    database: bindings.DB,
-    shortId,
-    publicBaseUrl: bindings.R2_PUBLIC_BASE_URL,
-  });
+  const movie = await findMovie(bindings, params.shortId ?? '');
   if (!movie) return notFound();
 
   const key = movieKey(movie.shortId);
@@ -56,26 +62,71 @@ export const GET: APIRoute = async ({ params, request }) => {
   const head = await bindings.BUCKET.head(key);
   if (!head) return notFound();
 
+  // 中断前と実体が変わっていたら、続きを継ぎ足しても壊れたファイルにしかならない
+  if (!rangeApplies(request.headers.get('If-Range'), head.httpEtag)) {
+    return await fullResponse(bindings.BUCKET, key, movie.filename);
+  }
+
   const resolved = resolveRangeRequest(rangeHeader, head.size);
   if (resolved.kind === 'unsatisfiable') return rangeNotSatisfiable(head.size);
   if (resolved.kind === 'full') return await fullResponse(bindings.BUCKET, key, movie.filename);
 
   const object = await bindings.BUCKET.get(key, {
     range: { offset: resolved.offset, length: resolved.length },
+    // head と get の間で差し替わると、別の実体の断片を返してしまう。
+    // 条件に渡す etag は引用符なし（httpEtag を渡すと R2 が TypeError を投げる）
+    onlyIf: { etagMatches: head.etag },
   });
-  if (!object?.body) return notFound();
+  if (!object) return notFound();
+  // 条件が外れた時は本文が付かない。総量も変わっているので全体を取り直す
+  if (!object.body) return await fullResponse(bindings.BUCKET, key, movie.filename);
 
   return new Response(object.body, {
     status: 206,
     headers: downloadHeaders({
       filename: movie.filename,
       contentLength: resolved.length,
+      etag: object.httpEtag,
       contentRange: partialContentRange(resolved, head.size),
     }),
   });
 };
 
-/** 全体を 200 で返す。Range 無しと、範囲を無視した（未知の単位・複数レンジ）場合の経路。 */
+/**
+ * 本文を伴わないメタデータの問い合わせ。
+ *
+ * 明示しないと Astro が GET を呼んで本文だけ捨てるため、Range 付きの HEAD に
+ * 206 と Content-Range を返してしまう（RFC 9110 14.2 は GET 以外の Range を無視させる）。
+ */
+export const HEAD: APIRoute = async ({ params }) => {
+  const bindings = env as unknown as DownloadBindings;
+
+  const movie = await findMovie(bindings, params.shortId ?? '');
+  if (!movie) return notFound();
+
+  const head = await bindings.BUCKET.head(movieKey(movie.shortId));
+  if (!head) return notFound();
+
+  return new Response(null, {
+    status: 200,
+    headers: downloadHeaders({
+      filename: movie.filename,
+      contentLength: head.size,
+      etag: head.httpEtag,
+    }),
+  });
+};
+
+/** 公開中の動画を引く。GET と HEAD で 404 の条件を揃える。 */
+async function findMovie(bindings: DownloadBindings, shortId: string) {
+  return await findPublicMovie({
+    database: bindings.DB,
+    shortId,
+    publicBaseUrl: bindings.R2_PUBLIC_BASE_URL,
+  });
+}
+
+/** 全体を 200 で返す。Range 無しと、範囲を無視した（未知の単位・複数レンジ・If-Range 不一致）場合の経路。 */
 async function fullResponse(
   bucket: DownloadBucket,
   key: string,
@@ -86,7 +137,11 @@ async function fullResponse(
 
   return new Response(object.body, {
     status: 200,
-    headers: downloadHeaders({ filename, contentLength: object.size }),
+    headers: downloadHeaders({
+      filename,
+      contentLength: object.size,
+      etag: object.httpEtag,
+    }),
   });
 }
 

--- a/web/src/pages/[shortId]/download.ts
+++ b/web/src/pages/[shortId]/download.ts
@@ -3,12 +3,21 @@ import { env } from 'cloudflare:workers';
 
 import { movieKey } from '../../lib/contracts/r2key';
 import { findPublicMovie, type MoviesDatabase } from '../../lib/services/movies';
-import { attachmentDisposition } from '../../lib/services/download';
+import {
+  downloadHeaders,
+  partialContentRange,
+  resolveRangeRequest,
+  unsatisfiedContentRange,
+} from '../../lib/services/download';
 
 export const prerender = false;
 
 interface DownloadBucket {
-  get(key: string): Promise<{ body: ReadableStream | null; size?: number } | null>;
+  head(key: string): Promise<{ size: number } | null>;
+  get(
+    key: string,
+    options?: { range: { offset: number; length: number } }
+  ): Promise<{ body: ReadableStream | null; size: number } | null>;
 }
 
 interface DownloadBindings {
@@ -27,7 +36,7 @@ interface DownloadBindings {
  *
  * 動画そのものが公開なので、この経路も認証しない（所有者以外もダウンロードできる）。
  */
-export const GET: APIRoute = async ({ params }) => {
+export const GET: APIRoute = async ({ params, request }) => {
   const bindings = env as unknown as DownloadBindings;
   const shortId = params.shortId ?? '';
 
@@ -38,27 +47,66 @@ export const GET: APIRoute = async ({ params }) => {
   });
   if (!movie) return notFound();
 
-  const object = await bindings.BUCKET.get(movieKey(movie.shortId));
+  const key = movieKey(movie.shortId);
+  const rangeHeader = request.headers.get('Range');
+  if (rangeHeader === null) return await fullResponse(bindings.BUCKET, key, movie.filename);
+
+  // 総量は範囲の確定にも 416 の Content-Range にも要るので、本文を取りに行く前に
+  // メタデータだけ引く（実体を読まないので Range 要求のときしか払わない）。
+  const head = await bindings.BUCKET.head(key);
+  if (!head) return notFound();
+
+  const resolved = resolveRangeRequest(rangeHeader, head.size);
+  if (resolved.kind === 'unsatisfiable') return rangeNotSatisfiable(head.size);
+  if (resolved.kind === 'full') return await fullResponse(bindings.BUCKET, key, movie.filename);
+
+  const object = await bindings.BUCKET.get(key, {
+    range: { offset: resolved.offset, length: resolved.length },
+  });
+  if (!object?.body) return notFound();
+
+  return new Response(object.body, {
+    status: 206,
+    headers: downloadHeaders({
+      filename: movie.filename,
+      contentLength: resolved.length,
+      contentRange: partialContentRange(resolved, head.size),
+    }),
+  });
+};
+
+/** 全体を 200 で返す。Range 無しと、範囲を無視した（未知の単位・複数レンジ）場合の経路。 */
+async function fullResponse(
+  bucket: DownloadBucket,
+  key: string,
+  filename: string
+): Promise<Response> {
+  const object = await bucket.get(key);
   if (!object?.body) return notFound();
 
   return new Response(object.body, {
     status: 200,
-    headers: {
-      'Content-Type': 'video/mp4',
-      'Content-Disposition': attachmentDisposition(movie.filename),
-      // cdn 側の Transform Rule はこの経路に効かないため、ここで明示する。
-      'X-Robots-Tag': 'noindex',
-      // 同じ動画への連続アクセスをエッジで吸収しつつ、削除後に配信され続ける窓は
-      // 短く抑える（cdn 直の既定 TTL 120 分より大幅に短い）。
-      'Cache-Control': 'public, max-age=300',
-    },
+    headers: downloadHeaders({ filename, contentLength: object.size }),
   });
-};
+}
 
 /** 存在しない・未完成の動画。ready へ変わった後も 404 が残らないようキャッシュさせない。 */
 function notFound(): Response {
   return new Response(null, {
     status: 404,
     headers: { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' },
+  });
+}
+
+/** 要求された範囲が実体と重ならない。総量を返して要求し直せるようにする。 */
+function rangeNotSatisfiable(size: number): Response {
+  return new Response(null, {
+    status: 416,
+    headers: {
+      'Content-Range': unsatisfiedContentRange(size),
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': 'no-store',
+      'X-Robots-Tag': 'noindex',
+    },
   });
 }

--- a/web/tests/services/download.test.ts
+++ b/web/tests/services/download.test.ts
@@ -5,6 +5,7 @@ import {
   downloadFilename,
   downloadHeaders,
   partialContentRange,
+  rangeApplies,
   resolveRangeRequest,
   unsatisfiedContentRange,
 } from '../../src/lib/services/download';
@@ -168,27 +169,62 @@ describe('unsatisfiedContentRange', () => {
   });
 });
 
+describe('rangeApplies', () => {
+  const ETAG = '"abc123"';
+
+  it('If-Range が無ければ範囲をそのまま使う', () => {
+    expect(rangeApplies(null, ETAG)).toBe(true);
+  });
+
+  it('実体の validator と一致すれば範囲を使う', () => {
+    expect(rangeApplies(ETAG, ETAG)).toBe(true);
+  });
+
+  it('一致しなければ範囲を使わない', () => {
+    // 続きのつもりで別の実体を継ぎ足すと、壊れたファイルが出来上がる
+    expect(rangeApplies('"stale"', ETAG)).toBe(false);
+  });
+
+  it('弱い validator は一致扱いにしない', () => {
+    // strong comparison が要る（RFC 9110 13.1.5）
+    expect(rangeApplies(`W/${ETAG}`, ETAG)).toBe(false);
+  });
+
+  it('日付形式の If-Range も一致扱いにしない', () => {
+    // Last-Modified を返していないので、日付は比較の根拠にならない
+    expect(rangeApplies('Wed, 21 Oct 2026 07:28:00 GMT', ETAG)).toBe(false);
+  });
+});
+
 describe('downloadHeaders', () => {
   it('部分取得でも保存名と noindex を落とさない', () => {
     // 再開したダウンロードだけ別扱いになると、保存名やインデックス制御が抜ける
     const headers = downloadHeaders({
       filename: 'slides.pdf',
       contentLength: 100,
+      etag: '"abc123"',
       contentRange: 'bytes 0-99/1000',
     });
 
     expect(headers['Content-Range']).toBe('bytes 0-99/1000');
     expect(headers['Content-Length']).toBe('100');
     expect(headers['Accept-Ranges']).toBe('bytes');
+    expect(headers['ETag']).toBe('"abc123"');
     expect(headers['Content-Disposition']).toContain('filename="slides.mp4"');
     expect(headers['X-Robots-Tag']).toBe('noindex');
+    expect(headers['X-Content-Type-Options']).toBe('nosniff');
   });
 
   it('全体を返すときは Content-Range を付けない', () => {
-    const headers = downloadHeaders({ filename: 'slides.pdf', contentLength: 1000 });
+    const headers = downloadHeaders({
+      filename: 'slides.pdf',
+      contentLength: 1000,
+      etag: '"abc123"',
+    });
 
     expect(headers['Content-Range']).toBeUndefined();
     expect(headers['Content-Length']).toBe('1000');
     expect(headers['Accept-Ranges']).toBe('bytes');
+    expect(headers['ETag']).toBe('"abc123"');
   });
 });

--- a/web/tests/services/download.test.ts
+++ b/web/tests/services/download.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'bun:test';
 
-import { attachmentDisposition, downloadFilename } from '../../src/lib/services/download';
+import {
+  attachmentDisposition,
+  downloadFilename,
+  downloadHeaders,
+  partialContentRange,
+  resolveRangeRequest,
+  unsatisfiedContentRange,
+} from '../../src/lib/services/download';
 
 describe('attachmentDisposition', () => {
   it('ASCII のファイル名はそのまま quoted-string に入る', () => {
@@ -61,5 +68,127 @@ describe('downloadFilename', () => {
 
   it('拡張子しかない名前は既定名にする', () => {
     expect(downloadFilename('.mp4')).toBe('movie.mp4');
+  });
+});
+
+describe('resolveRangeRequest', () => {
+  const SIZE = 1000;
+
+  it('Range が無ければ全体を返す', () => {
+    expect(resolveRangeRequest(null, SIZE)).toEqual({ kind: 'full' });
+  });
+
+  it('開始と終了を指定した範囲をそのまま解決する', () => {
+    expect(resolveRangeRequest('bytes=0-99', SIZE)).toEqual({
+      kind: 'partial',
+      offset: 0,
+      length: 100,
+    });
+  });
+
+  it('終了を省いた範囲は末尾までにする', () => {
+    expect(resolveRangeRequest('bytes=900-', SIZE)).toEqual({
+      kind: 'partial',
+      offset: 900,
+      length: 100,
+    });
+  });
+
+  it('実体より後ろまで要求されても末尾で止める', () => {
+    // R2 側でも切り詰められるが、Content-Range は実際に返す長さと一致させる必要がある
+    expect(resolveRangeRequest('bytes=900-9999', SIZE)).toEqual({
+      kind: 'partial',
+      offset: 900,
+      length: 100,
+    });
+  });
+
+  it('suffix は末尾からの長さとして解決する', () => {
+    expect(resolveRangeRequest('bytes=-100', SIZE)).toEqual({
+      kind: 'partial',
+      offset: 900,
+      length: 100,
+    });
+  });
+
+  it('総量より大きい suffix は全体になる', () => {
+    expect(resolveRangeRequest('bytes=-5000', SIZE)).toEqual({
+      kind: 'partial',
+      offset: 0,
+      length: SIZE,
+    });
+  });
+
+  it('開始位置が総量以上なら満たせない', () => {
+    // R2 は開始位置が総量を超えた時の挙動を規定していないため、渡す前に弾く
+    expect(resolveRangeRequest('bytes=1000-1099', SIZE)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('終了が開始より小さい範囲は満たせない', () => {
+    expect(resolveRangeRequest('bytes=500-100', SIZE)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('0 バイトの suffix は満たせない', () => {
+    expect(resolveRangeRequest('bytes=-0', SIZE)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('数値として壊れている範囲は満たせない', () => {
+    expect(resolveRangeRequest('bytes=abc', SIZE)).toEqual({ kind: 'unsatisfiable' });
+    expect(resolveRangeRequest('bytes=-', SIZE)).toEqual({ kind: 'unsatisfiable' });
+    expect(resolveRangeRequest('bytes=', SIZE)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('桁あふれする開始位置は満たせない', () => {
+    // Number 化で精度が落ちた値を R2 へ渡すと、意図しない位置から読み出される
+    expect(resolveRangeRequest('bytes=99999999999999999999-', SIZE)).toEqual({
+      kind: 'unsatisfiable',
+    });
+  });
+
+  it('未知の単位は無視して全体を返す', () => {
+    // RFC 9110 14.2 が無視を求めている。416 は満たせる要求への誤答になる
+    expect(resolveRangeRequest('items=0-5', SIZE)).toEqual({ kind: 'full' });
+  });
+
+  it('複数レンジは未対応なので全体を返す', () => {
+    expect(resolveRangeRequest('bytes=0-99,200-299', SIZE)).toEqual({ kind: 'full' });
+  });
+});
+
+describe('partialContentRange', () => {
+  it('末尾の位置を範囲に含めて組み立てる', () => {
+    expect(partialContentRange({ offset: 0, length: 100 }, 1000)).toBe('bytes 0-99/1000');
+    expect(partialContentRange({ offset: 900, length: 100 }, 1000)).toBe('bytes 900-999/1000');
+  });
+});
+
+describe('unsatisfiedContentRange', () => {
+  it('満たせる範囲が無いことと総量を伝える', () => {
+    expect(unsatisfiedContentRange(1000)).toBe('bytes */1000');
+  });
+});
+
+describe('downloadHeaders', () => {
+  it('部分取得でも保存名と noindex を落とさない', () => {
+    // 再開したダウンロードだけ別扱いになると、保存名やインデックス制御が抜ける
+    const headers = downloadHeaders({
+      filename: 'slides.pdf',
+      contentLength: 100,
+      contentRange: 'bytes 0-99/1000',
+    });
+
+    expect(headers['Content-Range']).toBe('bytes 0-99/1000');
+    expect(headers['Content-Length']).toBe('100');
+    expect(headers['Accept-Ranges']).toBe('bytes');
+    expect(headers['Content-Disposition']).toContain('filename="slides.mp4"');
+    expect(headers['X-Robots-Tag']).toBe('noindex');
+  });
+
+  it('全体を返すときは Content-Range を付けない', () => {
+    const headers = downloadHeaders({ filename: 'slides.pdf', contentLength: 1000 });
+
+    expect(headers['Content-Range']).toBeUndefined();
+    expect(headers['Content-Length']).toBe('1000');
+    expect(headers['Accept-Ranges']).toBe('bytes');
   });
 });


### PR DESCRIPTION
## なぜこの変更が必要か

`/{shortId}/download/` は `Range` を無視して常に全体を 200 で返し、`Content-Length` も付かなかった。中断したダウンロードが最初からやり直しになり、進捗の総量も出ない（Issue #78）。

## 変更内容

- `Range` を読んで R2 の `get()` に `{offset, length}` で渡し、206 + `Content-Range` + `Accept-Ranges: bytes` を返す。範囲外は 416（`Content-Range: bytes */{size}`）
- 通常応答にも `Content-Length` と `Accept-Ranges` を付ける
- 明示的な `HEAD` ハンドラ（Astro は HEAD を GET にフォールバックするため、Range 付き HEAD が 206 になっていた）
- 200 / 206 に `ETag` を付け、`If-Range` を strong 比較。不一致なら Range を無視して 200 全体
- head → get の間に実体が差し替わっても本文とヘッダーがずれないよう、ranged get に `onlyIf: { etagMatches }` を渡し、本文なしで返ったら全体を取り直す
- `X-Content-Type-Options: nosniff`

## 意思決定

### 採用アプローチ
- Range のパースと応答ヘッダーの組み立ては `services/download.ts`、pages 側は I/O 変換のみ
- Range 要求時だけ `head()` で総量を先に引く（416 の総量表記に要る / 開始位置が総量を超えた時の R2 `get()` の挙動が公式に未記載）
- R2 の `onlyIf.etagMatches` には引用符なしの `etag` を渡す（`httpEtag` だと workerd が `TypeError: Conditional ETag should not be wrapped in quotes` を投げる。E2E で判明）

### 却下した代替案
- 構文が壊れた Range を 200 で無視（RFC 9110 が許容）→ Issue の指示どおり 416。ただし未知の単位と複数レンジは「満たせる要求への誤答」を避けるため 200 全体
- `If-Match` の評価 → 本 Issue の範囲外（再開クライアントは `If-Range` を使う）。必要なら別 Issue

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 362 pass / 0 fail（Range パース: 正常 / suffix / 不正 / 範囲外 / If-Range 一致・不一致）
- [x] E2E `e2e/preview.spec.ts` 36 pass（206 / 416 / HEAD + Range → 200 / If-Range 不一致 → 200 を wrangler dev の実ランタイムで確認。新規 E2E は修正前に失敗することを確認）

## レビューゲート

codex `gpt-5.6-sol` 2 レーン + 再レビュー 1 回。ブロッキング 2 件（HEAD + Range が 206 / If-Range 未対応と head→get 差し替え）を修正。残る指摘（If-Match 未評価）は範囲外として却下（review-ledger 記録済み）。

Refs #78

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
