### PR TITLE
fix(web): 320px 幅で横スクロールが出ないようにする

### DIFF
--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -507,3 +507,31 @@ test.describe('ログイン済み', () => {
     await expect(panel.getByText(rawMessage)).toHaveCount(0);
   });
 });
+
+// 320px は想定する最小幅。ここで横スクロールが出ると、狭い画面でヘッダーが
+// 画面外へ流れる（本番の実測 scrollWidth = 388。Refs #60）。
+test.describe('狭い画面のヘッダー', () => {
+  const CHARACTERS_IMAGE = 'header img[src$="logo-characters.png"]';
+
+  test.describe('320px', () => {
+    test.use({ viewport: { width: 320, height: 800 } });
+
+    test('横スクロールが出ない', async ({ page }) => {
+      await page.goto('/ja/');
+
+      const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+      expect(scrollWidth).toBeLessThanOrEqual(320);
+    });
+  });
+
+  test.describe('375px', () => {
+    test.use({ viewport: { width: 375, height: 800 } });
+
+    // 既存の見た目を保つ幅。装飾のキャラクター画像を隠すのは 375px 未満だけにする。
+    test('キャラクター画像は表示したままにする', async ({ page }) => {
+      await page.goto('/ja/');
+
+      await expect(page.locator(CHARACTERS_IMAGE)).toBeVisible();
+    });
+  });
+});

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -19,7 +19,9 @@ const RELEASES_URL = `${REPOSITORY_URL}/releases`;
   >
     <p>{t.footer.note}</p>
 
-    <nav class="flex items-center gap-4">
+    {/* 4 つのリンクは 320px 幅で 1 行に収まらず、折り返さないとページごと横スクロールする。
+        収まる幅では折り返しが起きないので、広い画面の見た目は変わらない。 */}
+    <nav class="flex flex-wrap items-center gap-4">
       <a
         href={REPOSITORY_URL}
         target="_blank"

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -35,12 +35,15 @@ const LOGOUT_URL = '/api/auth/logout/';
         <span class="rounded-full bg-brand-50 px-2 py-0.5 text-sm font-semibold text-brand-700">
           β
         </span>
+        {/* 装飾なので 375px 未満では隠す。ロゴ + β + この画像の固有幅がビューポートを
+            超え、ページ全体に横スクロールが出るため（縮小ではなく非表示にするのは、
+            情報を持たない画像で、狭い画面ほどロゴの可読性を優先したいから）。 */}
         <img
           src={`${BANNER_BASE_URL}logo-characters.png`}
           alt=""
           width="620"
           height="200"
-          class="h-11 w-auto sm:h-14"
+          class="hidden h-11 w-auto min-[375px]:block sm:h-14"
         />
       </a>
     </div>


### PR DESCRIPTION
## なぜこの変更が必要か

320px 幅でヘッダーのキャラクター画像が右端 388px まで伸び、ページ全体に横スクロールが出ていた（Issue #60、本番で実測）。

## 変更内容

- `SiteHeader.astro`: キャラクター画像を 375px 未満では隠す（`hidden min-[375px]:block`）。装飾で情報を持たないため縮小ではなく非表示
- `SiteFooter.astro`: nav に `flex-wrap`。4 リンクが 342px あり 320px に収まらなかった（ヘッダーだけ直しても scrollWidth 358 が残った）。収まる幅では折り返さないので広い画面は不変
- E2E 2 本（320px で `scrollWidth <= 320` / 375px でキャラクター画像が表示）

## テスト

- [x] `cd web && bun run typecheck` / `bun test` 340 pass
- [x] E2E `e2e/top.spec.ts` 21 pass（新規 2 本は修正前に失敗: scrollWidth 359 → 358 → 320）

スタイリングのみの変更のためレビューゲート（codex）は省略。

Refs #60

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
