### PR TITLE
fix(web): pending の掃除と commit の競合で動画の実体だけが消えるのを防ぐ

### DIFF
--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -41,9 +41,16 @@ export default {
         now: new Date(event.scheduledTime),
       });
 
-      // 実体だけ消えた行は放置すると壊れた URL が残り続けるので、成功ログに埋もれさせない
-      const severity = summary.strandedMovies > 0 ? 'error' : 'info';
-      const log = severity === 'error' ? console.error : console.log;
+      // error は回収不能な異常だけに使う。実体だけ消えた行（stranded）は壊れた URL が
+      // 残り続けるので error、R2 の削除失敗（deferred）は行が残っていて次回に回収できるので warn。
+      const severity =
+        summary.strandedMovies > 0 ? 'error' : summary.deferredObjectDeletions > 0 ? 'warn' : 'info';
+      const log =
+        severity === 'error' ? console.error : severity === 'warn' ? console.warn : console.log;
+      const deferred =
+        summary.deferredObjectDeletions > 0
+          ? ` ${summary.deferredObjectDeletions} object deletions deferred to the next run.`
+          : '';
 
       log(
         JSON.stringify({
@@ -52,7 +59,7 @@ export default {
           severity,
           kind: 'event',
           cron: event.cron,
-          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.`,
+          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.${deferred}`,
           detail: summary,
           durationMs: Date.now() - startedAt,
         })

--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -44,13 +44,18 @@ export default {
       // error は回収不能な異常だけに使う。実体だけ消えた行（stranded）は壊れた URL が
       // 残り続けるので error、R2 の削除失敗（deferred）は行が残っていて次回に回収できるので warn。
       const severity =
-        summary.strandedMovies > 0 ? 'error' : summary.deferredObjectDeletions > 0 ? 'warn' : 'info';
+        summary.strandedMovies > 0
+          ? 'error'
+          : summary.deferredObjectDeletions > 0 || summary.sweepCapped
+            ? 'warn'
+            : 'info';
       const log =
         severity === 'error' ? console.error : severity === 'warn' ? console.warn : console.log;
       const deferred =
         summary.deferredObjectDeletions > 0
           ? ` ${summary.deferredObjectDeletions} object deletions deferred to the next run.`
           : '';
+      const capped = summary.sweepCapped ? ' Movie sweep hit the per-run cap; the rest waits for the next run.' : '';
 
       log(
         JSON.stringify({
@@ -59,7 +64,7 @@ export default {
           severity,
           kind: 'event',
           cron: event.cron,
-          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.${deferred}`,
+          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures.${deferred}${capped}`,
           detail: summary,
           durationMs: Date.now() - startedAt,
         })

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -38,6 +38,16 @@ export const MAX_CAPTURE_DELETIONS_PER_RUN = 1000;
  */
 export const CAPTURE_KEY_PREFIX = 'captures/';
 
+/**
+ * 1 回の実行で処理する movies の行数の上限（pending の回収と failed の掃除で共通）。
+ * failed は容量計算の対象外なので行数は利用者側から無制限に増やせる。上限を置かないと
+ * D1 のクエリ数と Workers の subrequest を使い切って実行ごと落ちる。残りは次回が拾う。
+ */
+export const MAX_MOVIE_DELETIONS_PER_RUN = 500;
+
+/** 1 文の DELETE に載せる short_id の数。D1 のバインド変数の上限（100）に収める。 */
+const MAX_IDS_PER_DELETE = 50;
+
 /** D1 の最小操作面。バッチが必要とするのは all / run だけ。 */
 export interface RetentionDatabase {
   prepare(query: string): {
@@ -77,6 +87,8 @@ export interface RetentionSummary {
   deletedFailed: number;
   /** R2 の削除に失敗して次回の実行へ持ち越した件数。行は残るので取り残しにはならない。 */
   deferredObjectDeletions: number;
+  /** movies の掃除が 1 回の上限に達して打ち切ったか。true なら残りは次回の実行が拾う。 */
+  sweepCapped: boolean;
   deletedCaptures: number;
 }
 
@@ -103,7 +115,7 @@ export async function runRetention(input: RetentionInput): Promise<RetentionSumm
   // 掃除より先に走らせる。期限を入れた直後の行は 1 年先なので同じ実行では消えない。
   const backfilledPinned = await backfillPinnedExpiry(database, now);
   const expired = await deleteExpiredMovies(database, bucket, now);
-  const deletedOrphans = await deletePendingOrphans(database, bucket, now);
+  const orphans = await deletePendingOrphans(database, bucket, now);
   // 孤児の確保で R2 の削除に失敗した行も failed として残っているため、同じ実行の
   // ここで拾い直せる（猶予はどちらも 24 時間）。取りこぼしても次回の実行が同じ条件で拾う。
   const failed = await deleteFailedMovies(database, bucket, now);
@@ -112,9 +124,10 @@ export async function runRetention(input: RetentionInput): Promise<RetentionSumm
     backfilledPinned,
     deletedMovies: expired.deleted,
     strandedMovies: expired.stranded,
-    deletedOrphans,
+    deletedOrphans: orphans.deleted,
     deletedFailed: failed.deleted,
     deferredObjectDeletions: failed.deferred,
+    sweepCapped: orphans.capped || failed.capped,
     deletedCaptures: await deleteStaleCaptures(bucket, now),
   };
 }
@@ -222,13 +235,13 @@ async function deletePendingOrphans(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<number> {
+): Promise<{ deleted: number; capped: boolean }> {
   const threshold = new Date(now.getTime() - PENDING_ORPHAN_GRACE_MS).toISOString();
   const { results } = await database
     .prepare(
-      "SELECT short_id FROM movies WHERE status = 'pending' AND datetime(created_at) < datetime(?)"
+      "SELECT short_id FROM movies WHERE status = 'pending' AND datetime(created_at) < datetime(?) LIMIT ?"
     )
-    .bind(threshold)
+    .bind(threshold, MAX_MOVIE_DELETIONS_PER_RUN)
     .all<ShortIdRow>();
 
   let deleted = 0;
@@ -252,7 +265,7 @@ async function deletePendingOrphans(
     deleted += result.meta.changes;
   }
 
-  return deleted;
+  return { deleted, capped: results.length === MAX_MOVIE_DELETIONS_PER_RUN };
 }
 
 /**
@@ -275,38 +288,46 @@ async function deleteMovieObject(bucket: RetentionBucket, shortId: string): Prom
  * 一定期間を過ぎた failed 行を削除する。
  *
  * 通常の failed（commit の上限超過）は実体が削除済みだが、pending の確保で R2 の削除に
- * 失敗した行もここへ来る。存在しないキーの delete は成功するので、どちらも同じ
- * 「R2 → D1」の順序で扱える。R2 が落ちている行だけ次回へ持ち越す。
+ * 失敗した行もここへ来る。存在しないキーの delete は成功するので head で確認せず、
+ * まとめて delete してから行を消す（R2 → D1 の順は維持する）。R2 が落ちていれば
+ * 行を残したまま次回へ持ち越す。
  */
 async function deleteFailedMovies(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<{ deleted: number; deferred: number }> {
+): Promise<{ deleted: number; deferred: number; capped: boolean }> {
   const threshold = new Date(now.getTime() - FAILED_RETENTION_MS).toISOString();
   const { results } = await database
     .prepare(
-      "SELECT short_id FROM movies WHERE status = 'failed' AND datetime(created_at) < datetime(?)"
+      "SELECT short_id FROM movies WHERE status = 'failed' AND datetime(created_at) < datetime(?) LIMIT ?"
     )
-    .bind(threshold)
+    .bind(threshold, MAX_MOVIE_DELETIONS_PER_RUN)
     .all<ShortIdRow>();
 
-  let deleted = 0;
-  let deferred = 0;
-  for (const row of results) {
-    if (!(await deleteMovieObject(bucket, row.short_id))) {
-      deferred += 1;
-      continue;
-    }
+  const capped = results.length === MAX_MOVIE_DELETIONS_PER_RUN;
+  if (results.length === 0) return { deleted: 0, deferred: 0, capped };
 
+  const shortIds = results.map((row) => row.short_id);
+  try {
+    await bucket.delete(shortIds.map(movieKey));
+  } catch {
+    // R2 が落ちている間に行だけ消すと実体が孤児になるため、この実行では行を残す。
+    return { deleted: 0, deferred: shortIds.length, capped };
+  }
+
+  let deleted = 0;
+  for (let index = 0; index < shortIds.length; index += MAX_IDS_PER_DELETE) {
+    const chunk = shortIds.slice(index, index + MAX_IDS_PER_DELETE);
+    const placeholders = chunk.map(() => '?').join(', ');
     const result = await database
-      .prepare("DELETE FROM movies WHERE short_id = ? AND status = 'failed'")
-      .bind(row.short_id)
+      .prepare(`DELETE FROM movies WHERE status = 'failed' AND short_id IN (${placeholders})`)
+      .bind(...chunk)
       .run();
     deleted += result.meta.changes;
   }
 
-  return { deleted, deferred };
+  return { deleted, deferred: 0, capped };
 }
 
 /**

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -4,15 +4,14 @@
  * D1 / R2 はインターフェースで注入し、現在時刻も引数で受け取る（Date.now を呼ぶのは
  * cron の entry 層だけ）。これで workerd なしでも全分岐をテストできる。
  *
- * 削除の順序は原則「R2 → D1」。逆にすると D1 の行を消した時点で R2 のキーを
- * 導出できなくなり、実体だけが残って回収不能になる（R2 の delete は存在しない
- * キーでも成功するため、この順序なら途中失敗しても次回実行でやり直せる）。
+ * 実体を消してから行を消す（R2 → D1）。逆にすると D1 の行を消した時点で R2 のキーを
+ * 導出できなくなり、実体だけが残って回収不能になる（R2 の delete は存在しないキーでも
+ * 成功するため、この順序なら途中失敗しても次回実行でやり直せる）。
  *
- * 例外は pending の回収だけ。pending には commit という並行の書き手がいて、R2 を
- * 先に消すと commit が ready を確定させた動画の実体だけが消える（公開 URL が残るのに
- * 再生できない）。そのため pending では条件付き DELETE で先に行を確保し、勝った時だけ
- * R2 を消す。代償は R2 削除に失敗した時のオブジェクトの取り残しで、これは
- * strandedOrphanObjects として数え、cron のログに出す（Fail Loud）。
+ * pending には commit という並行の書き手がいるため、R2 に触る前に条件付き UPDATE で
+ * pending → failed の「確保」を挟む。commit の UPDATE も status = 'pending' を条件に
+ * 持つので、勝つのは必ず一方だけになる。確保した行は failed として残るため、R2 の削除に
+ * 失敗しても行は消えず、failed の掃除が同じ順序（R2 → D1）で回収し直せる。
  */
 
 import { movieKey } from '../contracts/r2key';
@@ -75,9 +74,9 @@ export interface RetentionSummary {
   /** R2 の実体を消したのに行が残った件数。0 以外は不変条件が破れた印。 */
   strandedMovies: number;
   deletedOrphans: number;
-  /** 行を確保した後に R2 の削除が失敗した件数。0 以外は実体が取り残された印。 */
-  strandedOrphanObjects: number;
   deletedFailed: number;
+  /** R2 の削除に失敗して次回の実行へ持ち越した件数。行は残るので取り残しにはならない。 */
+  deferredObjectDeletions: number;
   deletedCaptures: number;
 }
 
@@ -104,15 +103,18 @@ export async function runRetention(input: RetentionInput): Promise<RetentionSumm
   // 掃除より先に走らせる。期限を入れた直後の行は 1 年先なので同じ実行では消えない。
   const backfilledPinned = await backfillPinnedExpiry(database, now);
   const expired = await deleteExpiredMovies(database, bucket, now);
-  const orphans = await deletePendingOrphans(database, bucket, now);
+  const deletedOrphans = await deletePendingOrphans(database, bucket, now);
+  // 孤児の確保で R2 の削除に失敗した行も failed として残っているため、同じ実行の
+  // ここで拾い直せる（猶予はどちらも 24 時間）。取りこぼしても次回の実行が同じ条件で拾う。
+  const failed = await deleteFailedMovies(database, bucket, now);
 
   return {
     backfilledPinned,
     deletedMovies: expired.deleted,
     strandedMovies: expired.stranded,
-    deletedOrphans: orphans.deleted,
-    strandedOrphanObjects: orphans.stranded,
-    deletedFailed: await deleteFailedMovies(database, now),
+    deletedOrphans,
+    deletedFailed: failed.deleted,
+    deferredObjectDeletions: failed.deferred,
     deletedCaptures: await deleteStaleCaptures(bucket, now),
   };
 }
@@ -209,18 +211,18 @@ async function deleteExpiredMovies(
 /**
  * commit されないまま放置された pending を回収する。
  *
- * 実体が上がっていれば消す（presign 後にアップロードだけ成功して commit に
- * 到達しなかったケースが R2 に残り続けるのを防ぐ）。
- *
- * R2 に触る前に、条件付き DELETE で行を確保する。同時に走る commit の UPDATE も
- * `status = 'pending'` を条件に持つため、勝つのは必ずどちらか一方だけになる。
+ * R2 に触る前に、条件付き UPDATE で pending → failed の確保を行う。同時に走る commit の
+ * UPDATE も status = 'pending' を条件に持つため、勝つのは必ずどちらか一方だけになる。
  * 負けた側（= 0 件）は実体が ready の行のものなので R2 に触らない。
+ *
+ * 行を消すのは R2 の削除に成功した後だけ。失敗した行は failed のまま残り、
+ * failed の掃除（deleteFailedMovies）が同じ順序で回収し直す。
  */
 async function deletePendingOrphans(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<{ deleted: number; stranded: number }> {
+): Promise<number> {
   const threshold = new Date(now.getTime() - PENDING_ORPHAN_GRACE_MS).toISOString();
   const { results } = await database
     .prepare(
@@ -230,39 +232,81 @@ async function deletePendingOrphans(
     .all<ShortIdRow>();
 
   let deleted = 0;
-  let stranded = 0;
   for (const row of results) {
     // SELECT 後に commit が確定した行を巻き込まないよう、確保時にも猶予を再確認する。
     const claim = await database
       .prepare(
-        "DELETE FROM movies WHERE short_id = ? AND status = 'pending' AND datetime(created_at) < datetime(?)"
+        "UPDATE movies SET status = 'failed' WHERE short_id = ? AND status = 'pending' AND datetime(created_at) < datetime(?)"
       )
       .bind(row.short_id, threshold)
       .run();
     if (claim.meta.changes === 0) continue;
 
-    deleted += claim.meta.changes;
-    const key = movieKey(row.short_id);
-    try {
-      if (await bucket.head(key)) await bucket.delete(key);
-    } catch {
-      // 行は確保済みなので次回の実行では拾えない。実体だけが残るため数えて表に出す。
-      stranded += 1;
-    }
+    // 削除に失敗した行は failed のまま残す（件数は failed の掃除が数える）。
+    if (!(await deleteMovieObject(bucket, row.short_id))) continue;
+
+    const result = await database
+      .prepare("DELETE FROM movies WHERE short_id = ? AND status = 'failed'")
+      .bind(row.short_id)
+      .run();
+    deleted += result.meta.changes;
   }
 
-  return { deleted, stranded };
+  return deleted;
 }
 
-/** 一定期間を過ぎた failed 行を削除する（実体は commit 時に削除済み）。 */
-async function deleteFailedMovies(database: RetentionDatabase, now: Date): Promise<number> {
-  const threshold = new Date(now.getTime() - FAILED_RETENTION_MS).toISOString();
-  const result = await database
-    .prepare("DELETE FROM movies WHERE status = 'failed' AND datetime(created_at) < datetime(?)")
-    .bind(threshold)
-    .run();
+/**
+ * 動画の実体を R2 から消す。成功（元から無い場合を含む）で true を返す。
+ *
+ * R2 が落ちている間に D1 の行だけ消すと実体が孤児になるため、呼び出し側は false の時に
+ * 行を残し、次回の実行へ持ち越す。
+ */
+async function deleteMovieObject(bucket: RetentionBucket, shortId: string): Promise<boolean> {
+  const key = movieKey(shortId);
+  try {
+    if (await bucket.head(key)) await bucket.delete(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-  return result.meta.changes;
+/**
+ * 一定期間を過ぎた failed 行を削除する。
+ *
+ * 通常の failed（commit の上限超過）は実体が削除済みだが、pending の確保で R2 の削除に
+ * 失敗した行もここへ来る。存在しないキーの delete は成功するので、どちらも同じ
+ * 「R2 → D1」の順序で扱える。R2 が落ちている行だけ次回へ持ち越す。
+ */
+async function deleteFailedMovies(
+  database: RetentionDatabase,
+  bucket: RetentionBucket,
+  now: Date
+): Promise<{ deleted: number; deferred: number }> {
+  const threshold = new Date(now.getTime() - FAILED_RETENTION_MS).toISOString();
+  const { results } = await database
+    .prepare(
+      "SELECT short_id FROM movies WHERE status = 'failed' AND datetime(created_at) < datetime(?)"
+    )
+    .bind(threshold)
+    .all<ShortIdRow>();
+
+  let deleted = 0;
+  let deferred = 0;
+  for (const row of results) {
+    if (!(await deleteMovieObject(bucket, row.short_id))) {
+      deferred += 1;
+      continue;
+    }
+
+    const result = await database
+      .prepare("DELETE FROM movies WHERE short_id = ? AND status = 'failed'")
+      .bind(row.short_id)
+      .run();
+    deleted += result.meta.changes;
+  }
+
+  return { deleted, deferred };
 }
 
 /**

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -39,11 +39,18 @@ export const MAX_CAPTURE_DELETIONS_PER_RUN = 1000;
 export const CAPTURE_KEY_PREFIX = 'captures/';
 
 /**
- * 1 回の実行で処理する movies の行数の上限（pending の回収と failed の掃除で共通）。
- * failed は容量計算の対象外なので行数は利用者側から無制限に増やせる。上限を置かないと
- * D1 のクエリ数と Workers の subrequest を使い切って実行ごと落ちる。残りは次回が拾う。
+ * 1 回の実行で確保する pending の行数の上限。1 行あたり最大 4 subrequest
+ * （確保 UPDATE / head / delete / DELETE）を使うため、4 × 200 = 800 で Workers の
+ * 上限（1000）に収まる値にしている。残りは次回の実行が拾う。
  */
-export const MAX_MOVIE_DELETIONS_PER_RUN = 500;
+export const MAX_PENDING_CLAIMS_PER_RUN = 200;
+
+/**
+ * 1 回の実行で削除する failed の行数の上限。failed は容量計算の対象外なので行数は
+ * 利用者側から無制限に増やせる。実体の削除はキー配列で 1 回、行の削除は 50 件ずつの
+ * まとめ DELETE なので 500 行でも subrequest は十数回に収まる。残りは次回が拾う。
+ */
+export const MAX_FAILED_DELETIONS_PER_RUN = 500;
 
 /** 1 文の DELETE に載せる short_id の数。D1 のバインド変数の上限（100）に収める。 */
 const MAX_IDS_PER_DELETE = 50;
@@ -241,7 +248,7 @@ async function deletePendingOrphans(
     .prepare(
       "SELECT short_id FROM movies WHERE status = 'pending' AND datetime(created_at) < datetime(?) LIMIT ?"
     )
-    .bind(threshold, MAX_MOVIE_DELETIONS_PER_RUN)
+    .bind(threshold, MAX_PENDING_CLAIMS_PER_RUN)
     .all<ShortIdRow>();
 
   let deleted = 0;
@@ -265,7 +272,7 @@ async function deletePendingOrphans(
     deleted += result.meta.changes;
   }
 
-  return { deleted, capped: results.length === MAX_MOVIE_DELETIONS_PER_RUN };
+  return { deleted, capped: results.length === MAX_PENDING_CLAIMS_PER_RUN };
 }
 
 /**
@@ -302,10 +309,10 @@ async function deleteFailedMovies(
     .prepare(
       "SELECT short_id FROM movies WHERE status = 'failed' AND datetime(created_at) < datetime(?) LIMIT ?"
     )
-    .bind(threshold, MAX_MOVIE_DELETIONS_PER_RUN)
+    .bind(threshold, MAX_FAILED_DELETIONS_PER_RUN)
     .all<ShortIdRow>();
 
-  const capped = results.length === MAX_MOVIE_DELETIONS_PER_RUN;
+  const capped = results.length === MAX_FAILED_DELETIONS_PER_RUN;
   if (results.length === 0) return { deleted: 0, deferred: 0, capped };
 
   const shortIds = results.map((row) => row.short_id);

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -4,9 +4,15 @@
  * D1 / R2 はインターフェースで注入し、現在時刻も引数で受け取る（Date.now を呼ぶのは
  * cron の entry 層だけ）。これで workerd なしでも全分岐をテストできる。
  *
- * 削除の順序は必ず「R2 → D1」。逆にすると D1 の行を消した時点で R2 のキーを
+ * 削除の順序は原則「R2 → D1」。逆にすると D1 の行を消した時点で R2 のキーを
  * 導出できなくなり、実体だけが残って回収不能になる（R2 の delete は存在しない
  * キーでも成功するため、この順序なら途中失敗しても次回実行でやり直せる）。
+ *
+ * 例外は pending の回収だけ。pending には commit という並行の書き手がいて、R2 を
+ * 先に消すと commit が ready を確定させた動画の実体だけが消える（公開 URL が残るのに
+ * 再生できない）。そのため pending では条件付き DELETE で先に行を確保し、勝った時だけ
+ * R2 を消す。代償は R2 削除に失敗した時のオブジェクトの取り残しで、これは
+ * strandedOrphanObjects として数え、cron のログに出す（Fail Loud）。
  */
 
 import { movieKey } from '../contracts/r2key';
@@ -69,6 +75,8 @@ export interface RetentionSummary {
   /** R2 の実体を消したのに行が残った件数。0 以外は不変条件が破れた印。 */
   strandedMovies: number;
   deletedOrphans: number;
+  /** 行を確保した後に R2 の削除が失敗した件数。0 以外は実体が取り残された印。 */
+  strandedOrphanObjects: number;
   deletedFailed: number;
   deletedCaptures: number;
 }
@@ -96,12 +104,14 @@ export async function runRetention(input: RetentionInput): Promise<RetentionSumm
   // 掃除より先に走らせる。期限を入れた直後の行は 1 年先なので同じ実行では消えない。
   const backfilledPinned = await backfillPinnedExpiry(database, now);
   const expired = await deleteExpiredMovies(database, bucket, now);
+  const orphans = await deletePendingOrphans(database, bucket, now);
 
   return {
     backfilledPinned,
     deletedMovies: expired.deleted,
     strandedMovies: expired.stranded,
-    deletedOrphans: await deletePendingOrphans(database, bucket, now),
+    deletedOrphans: orphans.deleted,
+    strandedOrphanObjects: orphans.stranded,
     deletedFailed: await deleteFailedMovies(database, now),
     deletedCaptures: await deleteStaleCaptures(bucket, now),
   };
@@ -199,14 +209,18 @@ async function deleteExpiredMovies(
 /**
  * commit されないまま放置された pending を回収する。
  *
- * 実体が上がっていれば消してから行を削除する（presign 後にアップロードだけ
- * 成功して commit に到達しなかったケースが R2 に残り続けるのを防ぐ）。
+ * 実体が上がっていれば消す（presign 後にアップロードだけ成功して commit に
+ * 到達しなかったケースが R2 に残り続けるのを防ぐ）。
+ *
+ * R2 に触る前に、条件付き DELETE で行を確保する。同時に走る commit の UPDATE も
+ * `status = 'pending'` を条件に持つため、勝つのは必ずどちらか一方だけになる。
+ * 負けた側（= 0 件）は実体が ready の行のものなので R2 に触らない。
  */
 async function deletePendingOrphans(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<number> {
+): Promise<{ deleted: number; stranded: number }> {
   const threshold = new Date(now.getTime() - PENDING_ORPHAN_GRACE_MS).toISOString();
   const { results } = await database
     .prepare(
@@ -216,22 +230,28 @@ async function deletePendingOrphans(
     .all<ShortIdRow>();
 
   let deleted = 0;
+  let stranded = 0;
   for (const row of results) {
+    // SELECT 後に commit が確定した行を巻き込まないよう、確保時にも猶予を再確認する。
+    const claim = await database
+      .prepare(
+        "DELETE FROM movies WHERE short_id = ? AND status = 'pending' AND datetime(created_at) < datetime(?)"
+      )
+      .bind(row.short_id, threshold)
+      .run();
+    if (claim.meta.changes === 0) continue;
+
+    deleted += claim.meta.changes;
     const key = movieKey(row.short_id);
     try {
       if (await bucket.head(key)) await bucket.delete(key);
     } catch {
-      continue;
+      // 行は確保済みなので次回の実行では拾えない。実体だけが残るため数えて表に出す。
+      stranded += 1;
     }
-
-    const result = await database
-      .prepare("DELETE FROM movies WHERE short_id = ? AND status = 'pending'")
-      .bind(row.short_id)
-      .run();
-    deleted += result.meta.changes;
   }
 
-  return deleted;
+  return { deleted, stranded };
 }
 
 /** 一定期間を過ぎた failed 行を削除する（実体は commit 時に削除済み）。 */

--- a/web/src/lib/services/uploads.ts
+++ b/web/src/lib/services/uploads.ts
@@ -20,7 +20,7 @@ export interface UploadDatabase extends QuotaDatabase {
   prepare(query: string): {
     bind(...values: unknown[]): {
       first<T>(): Promise<T | null>;
-      run(): Promise<unknown>;
+      run(): Promise<{ meta: { changes: number } }>;
     };
   };
 }
@@ -154,14 +154,40 @@ export async function commitUpload(input: CommitUploadInput): Promise<CommitResp
     );
   }
 
-  await input.database
+  const updated = await input.database
     .prepare(
       "UPDATE movies SET status = 'ready', size_bytes = ? WHERE short_id = ? AND user_id = ? AND status = 'pending'"
     )
     .bind(object.size, input.shortId, input.userId)
     .run();
 
+  // 0 件 = SELECT と R2 確認の間に行が pending でなくなった。成功として返すと、
+  // 保持期間バッチが回収した動画の公開 URL を返してしまう（行も実体も無いのに再生できる想定になる）。
+  if (updated.meta.changes === 0) return resolveCommitConflict(input);
+
   return toCommitResponse({ ...movie, size_bytes: object.size, status: 'ready' }, input.publicBaseUrl);
+}
+
+/**
+ * ready への UPDATE が 0 件だった理由を引き直して返す。
+ *
+ * 行が消えていれば 404（pending の掃除が勝った）、既に ready なら並行 commit が
+ * 先に確定しただけなので同じ応答で成功する（services/movies.ts の pin と同じ形）。
+ * 稀な経路なので、通常時に追加のクエリを増やさないようここでだけ読み直す。
+ */
+async function resolveCommitConflict(input: CommitUploadInput): Promise<CommitResponse> {
+  const current = await input.database
+    .prepare(
+      'SELECT short_id, user_id, size_bytes, status, expires_at FROM movies WHERE short_id = ? AND user_id = ?'
+    )
+    .bind(input.shortId, input.userId)
+    .first<MovieRow>();
+
+  if (!current) {
+    throw new UploadError(404, ERROR_CODES.notFound, '対象の動画が見つかりません');
+  }
+  if (current.status === 'ready') return toCommitResponse(current, input.publicBaseUrl);
+  throw new UploadError(400, ERROR_CODES.invalidRequest, 'この動画は commit できません');
 }
 
 function createPublicUrl(publicBaseUrl: string, key: string): string {

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -108,6 +108,13 @@ class FakeRetentionDatabase implements RetentionDatabase {
     if (query.includes('expires_at') && !isExpired(movie, parseSqliteTime(values[1] as string))) {
       return 0;
     }
+    // pending の claim（DELETE ... AND datetime(created_at) < datetime(?)）の再現。
+    if (
+      query.includes('created_at') &&
+      parseSqliteTime(movie.createdAt) >= parseSqliteTime(values[1] as string)
+    ) {
+      return 0;
+    }
     if (query.includes("status = 'ready'") && movie.status !== 'ready') return 0;
     if (query.includes("status = 'pending'") && movie.status !== 'pending') return 0;
     this.movies.delete(movie.shortId);
@@ -261,7 +268,7 @@ describe('runRetention: 期限切れ動画', () => {
 });
 
 describe('runRetention: pending 孤児と failed', () => {
-  it('24h を過ぎた pending は実体があれば消してから行を削除する', async () => {
+  it('24h を過ぎた pending は行を確保してから実体を消す', async () => {
     const database = new FakeRetentionDatabase([
       movie({ shortId: 'orphanAAAAAA', status: 'pending', createdAt: iso(-DAY_MS - HOUR_MS) }),
     ]);
@@ -271,6 +278,42 @@ describe('runRetention: pending 孤児と failed', () => {
 
     expect(summary.deletedOrphans).toBe(1);
     expect(bucket.deleted).toEqual([movieKey('orphanAAAAAA')]);
+    expect(database.movies.size).toBe(0);
+  });
+
+  it('SELECT 後に commit が確定した pending は R2 を消さず ready のまま残す', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({
+        shortId: 'raceCommitAA',
+        status: 'pending',
+        createdAt: iso(-DAY_MS - HOUR_MS),
+        expiresAt: iso(30 * DAY_MS),
+      }),
+    ]);
+    const bucket = new FakeRetentionBucket(new Set([movieKey('raceCommitAA')]));
+    // SELECT 直後に所有者の commit が通った状況（pending → ready）。
+    database.onSelect = (rows) => {
+      for (const row of rows) row.status = 'ready';
+    };
+
+    const summary = await run(database, bucket);
+
+    expect(summary.deletedOrphans).toBe(0);
+    expect(bucket.deleted).toEqual([]);
+    expect(database.movies.get('raceCommitAA')?.status).toBe('ready');
+  });
+
+  it('行を確保した後の R2 削除失敗は stranded として数える', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'orphanFailAA', status: 'pending', createdAt: iso(-2 * DAY_MS) }),
+    ]);
+    const bucket = new FakeRetentionBucket(new Set([movieKey('orphanFailAA')]));
+    bucket.failingKeys.add(movieKey('orphanFailAA'));
+
+    const summary = await run(database, bucket);
+
+    expect(summary.deletedOrphans).toBe(1);
+    expect(summary.strandedOrphanObjects).toBe(1);
     expect(database.movies.size).toBe(0);
   });
 
@@ -384,6 +427,7 @@ describe('runRetention: サマリ', () => {
       deletedMovies: 1,
       strandedMovies: 0,
       deletedOrphans: 1,
+      strandedOrphanObjects: 0,
       deletedFailed: 1,
       deletedCaptures: 1,
     });

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -4,6 +4,7 @@ import { captureKey, movieKey } from '../../src/lib/contracts/r2key';
 import {
   CAPTURE_KEY_PREFIX,
   MAX_CAPTURE_DELETIONS_PER_RUN,
+  MAX_MOVIE_DELETIONS_PER_RUN,
   runRetention,
   type RetentionBucket,
   type RetentionDatabase,
@@ -75,11 +76,12 @@ class FakeRetentionDatabase implements RetentionDatabase {
     }
 
     const threshold = parseSqliteTime(values[0] as string);
-    const rows = [...this.movies.values()].filter((movie) => {
+    const matched = [...this.movies.values()].filter((movie) => {
       if (query.includes("status = 'ready'")) return movie.status === 'ready' && isExpired(movie, threshold);
       const status = query.includes("status = 'failed'") ? 'failed' : 'pending';
       return movie.status === status && parseSqliteTime(movie.createdAt) < threshold;
     });
+    const rows = query.includes('LIMIT ?') ? matched.slice(0, values[1] as number) : matched;
     this.onSelect?.(rows);
     return rows.map((movie) => ({ short_id: movie.shortId }));
   }
@@ -101,6 +103,15 @@ class FakeRetentionDatabase implements RetentionDatabase {
       if (parseSqliteTime(target.createdAt) >= parseSqliteTime(values[1] as string)) return 0;
       target.status = 'failed';
       return 1;
+    }
+
+    // failed のまとめ削除（DELETE ... short_id IN (?, ...)）。
+    if (query.includes('short_id IN (')) {
+      const targets = (values as string[]).filter(
+        (shortId) => this.movies.get(shortId)?.status === 'failed'
+      );
+      for (const shortId of targets) this.movies.delete(shortId);
+      return targets.length;
     }
 
     const movie = this.movies.get(values[0] as string);
@@ -358,6 +369,27 @@ describe('runRetention: pending 孤児と failed', () => {
     expect(database.movies.has('oldFailedAAA')).toBe(false);
     expect(database.movies.has('newFailedAAA')).toBe(true);
   });
+
+  it('上限を超える failed 行は上限分だけ処理し、残りは次回へ持ち越す', async () => {
+    const overflow = 2;
+    const database = new FakeRetentionDatabase(
+      Array.from({ length: MAX_MOVIE_DELETIONS_PER_RUN + overflow }, (_, index) =>
+        movie({
+          shortId: `failed${String(index).padStart(6, '0')}`,
+          status: 'failed',
+          createdAt: iso(-2 * DAY_MS),
+        })
+      )
+    );
+    const bucket = new FakeRetentionBucket();
+
+    const summary = await run(database, bucket);
+
+    expect(summary.deletedFailed).toBe(MAX_MOVIE_DELETIONS_PER_RUN);
+    expect(summary.sweepCapped).toBe(true);
+    expect(bucket.deleted).toHaveLength(MAX_MOVIE_DELETIONS_PER_RUN);
+    expect(database.movies.size).toBe(overflow);
+  });
 });
 
 describe('runRetention: captures', () => {
@@ -432,6 +464,7 @@ describe('runRetention: サマリ', () => {
       deletedOrphans: 1,
       deletedFailed: 1,
       deferredObjectDeletions: 0,
+      sweepCapped: false,
       deletedCaptures: 1,
     });
     expect(database.movies.size).toBe(0);

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -75,18 +75,18 @@ class FakeRetentionDatabase implements RetentionDatabase {
     }
 
     const threshold = parseSqliteTime(values[0] as string);
-    const rows = [...this.movies.values()].filter((movie) =>
-      query.includes("status = 'ready'")
-        ? movie.status === 'ready' && isExpired(movie, threshold)
-        : movie.status === 'pending' && parseSqliteTime(movie.createdAt) < threshold
-    );
+    const rows = [...this.movies.values()].filter((movie) => {
+      if (query.includes("status = 'ready'")) return movie.status === 'ready' && isExpired(movie, threshold);
+      const status = query.includes("status = 'failed'") ? 'failed' : 'pending';
+      return movie.status === status && parseSqliteTime(movie.createdAt) < threshold;
+    });
     this.onSelect?.(rows);
     return rows.map((movie) => ({ short_id: movie.shortId }));
   }
 
   private delete(query: string, values: unknown[]): number {
     // backfill の UPDATE も run() を通る。pin 済みで期限を持たない行だけを埋める。
-    if (query.startsWith('UPDATE')) {
+    if (query.startsWith('UPDATE') && query.includes('expires_at = ?')) {
       const targets = [...this.movies.values()].filter(
         (movie) => movie.pinned === 1 && movie.expiresAt === null
       );
@@ -94,13 +94,13 @@ class FakeRetentionDatabase implements RetentionDatabase {
       return targets.length;
     }
 
-    if (query.includes("status = 'failed'")) {
-      const threshold = parseSqliteTime(values[0] as string);
-      const targets = [...this.movies.values()].filter(
-        (movie) => movie.status === 'failed' && parseSqliteTime(movie.createdAt) < threshold
-      );
-      for (const movie of targets) this.movies.delete(movie.shortId);
-      return targets.length;
+    // pending の確保（pending → failed）。commit と同じく status を条件に持つ。
+    if (query.startsWith('UPDATE') && query.includes("SET status = 'failed'")) {
+      const target = this.movies.get(values[0] as string);
+      if (!target || target.status !== 'pending') return 0;
+      if (parseSqliteTime(target.createdAt) >= parseSqliteTime(values[1] as string)) return 0;
+      target.status = 'failed';
+      return 1;
     }
 
     const movie = this.movies.get(values[0] as string);
@@ -108,15 +108,8 @@ class FakeRetentionDatabase implements RetentionDatabase {
     if (query.includes('expires_at') && !isExpired(movie, parseSqliteTime(values[1] as string))) {
       return 0;
     }
-    // pending の claim（DELETE ... AND datetime(created_at) < datetime(?)）の再現。
-    if (
-      query.includes('created_at') &&
-      parseSqliteTime(movie.createdAt) >= parseSqliteTime(values[1] as string)
-    ) {
-      return 0;
-    }
     if (query.includes("status = 'ready'") && movie.status !== 'ready') return 0;
-    if (query.includes("status = 'pending'") && movie.status !== 'pending') return 0;
+    if (query.includes("status = 'failed'") && movie.status !== 'failed') return 0;
     this.movies.delete(movie.shortId);
     return 1;
   }
@@ -303,17 +296,27 @@ describe('runRetention: pending 孤児と failed', () => {
     expect(database.movies.get('raceCommitAA')?.status).toBe('ready');
   });
 
-  it('行を確保した後の R2 削除失敗は stranded として数える', async () => {
+  it('確保後に R2 の削除が失敗した pending は failed 行として残り、次回の実行で回収される', async () => {
     const database = new FakeRetentionDatabase([
       movie({ shortId: 'orphanFailAA', status: 'pending', createdAt: iso(-2 * DAY_MS) }),
     ]);
     const bucket = new FakeRetentionBucket(new Set([movieKey('orphanFailAA')]));
     bucket.failingKeys.add(movieKey('orphanFailAA'));
 
-    const summary = await run(database, bucket);
+    const first = await run(database, bucket);
 
-    expect(summary.deletedOrphans).toBe(1);
-    expect(summary.strandedOrphanObjects).toBe(1);
+    expect(first.deletedOrphans).toBe(0);
+    expect(first.deferredObjectDeletions).toBe(1);
+    expect(bucket.deleted).toEqual([]);
+    expect(database.movies.get('orphanFailAA')?.status).toBe('failed');
+
+    // R2 が復旧した次の実行で、実体を消してから行を消す。
+    bucket.failingKeys.clear();
+    const second = await run(database, bucket);
+
+    expect(second.deletedFailed).toBe(1);
+    expect(second.deferredObjectDeletions).toBe(0);
+    expect(bucket.deleted).toEqual([movieKey('orphanFailAA')]);
     expect(database.movies.size).toBe(0);
   });
 
@@ -427,8 +430,8 @@ describe('runRetention: サマリ', () => {
       deletedMovies: 1,
       strandedMovies: 0,
       deletedOrphans: 1,
-      strandedOrphanObjects: 0,
       deletedFailed: 1,
+      deferredObjectDeletions: 0,
       deletedCaptures: 1,
     });
     expect(database.movies.size).toBe(0);

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -4,7 +4,7 @@ import { captureKey, movieKey } from '../../src/lib/contracts/r2key';
 import {
   CAPTURE_KEY_PREFIX,
   MAX_CAPTURE_DELETIONS_PER_RUN,
-  MAX_MOVIE_DELETIONS_PER_RUN,
+  MAX_FAILED_DELETIONS_PER_RUN,
   runRetention,
   type RetentionBucket,
   type RetentionDatabase,
@@ -373,7 +373,7 @@ describe('runRetention: pending 孤児と failed', () => {
   it('上限を超える failed 行は上限分だけ処理し、残りは次回へ持ち越す', async () => {
     const overflow = 2;
     const database = new FakeRetentionDatabase(
-      Array.from({ length: MAX_MOVIE_DELETIONS_PER_RUN + overflow }, (_, index) =>
+      Array.from({ length: MAX_FAILED_DELETIONS_PER_RUN + overflow }, (_, index) =>
         movie({
           shortId: `failed${String(index).padStart(6, '0')}`,
           status: 'failed',
@@ -385,9 +385,9 @@ describe('runRetention: pending 孤児と failed', () => {
 
     const summary = await run(database, bucket);
 
-    expect(summary.deletedFailed).toBe(MAX_MOVIE_DELETIONS_PER_RUN);
+    expect(summary.deletedFailed).toBe(MAX_FAILED_DELETIONS_PER_RUN);
     expect(summary.sweepCapped).toBe(true);
-    expect(bucket.deleted).toHaveLength(MAX_MOVIE_DELETIONS_PER_RUN);
+    expect(bucket.deleted).toHaveLength(MAX_FAILED_DELETIONS_PER_RUN);
     expect(database.movies.size).toBe(overflow);
   });
 });

--- a/web/tests/services/uploads.test.ts
+++ b/web/tests/services/uploads.test.ts
@@ -38,7 +38,7 @@ class FakeUploadDatabase implements UploadDatabase {
     return {
       bind: (...values: unknown[]) => ({
         first: async <T>(): Promise<T | null> => this.first<T>(query, values),
-        run: async (): Promise<unknown> => this.run(query, values),
+        run: async () => ({ meta: { changes: this.run(query, values) } }),
       }),
     };
   }
@@ -64,7 +64,7 @@ class FakeUploadDatabase implements UploadDatabase {
     } as T;
   }
 
-  private run(query: string, values: unknown[]): void {
+  private run(query: string, values: unknown[]): number {
     if (query.startsWith('INSERT INTO movies')) {
       const [shortId, userId, filename, sizeBytes, expiresAt] = values as [
         string,
@@ -81,33 +81,39 @@ class FakeUploadDatabase implements UploadDatabase {
         status: 'pending',
         expiresAt,
       });
-      return;
+      return 1;
     }
 
     if (query.includes("status = 'ready'")) {
       const [sizeBytes, shortId, userId] = values as [number, string, number];
       const movie = this.movies.get(shortId);
-      if (movie && movie.userId === userId && movie.status === 'pending') {
-        movie.status = 'ready';
-        movie.sizeBytes = sizeBytes;
-      }
-      return;
+      if (!movie || movie.userId !== userId || movie.status !== 'pending') return 0;
+      movie.status = 'ready';
+      movie.sizeBytes = sizeBytes;
+      return 1;
     }
 
     if (query.includes("status = 'failed'")) {
       const [shortId, userId] = values as [string, number];
       const movie = this.movies.get(shortId);
-      if (movie && movie.userId === userId && movie.status === 'pending') movie.status = 'failed';
+      if (!movie || movie.userId !== userId || movie.status !== 'pending') return 0;
+      movie.status = 'failed';
+      return 1;
     }
+
+    return 0;
   }
 }
 
 class FakeUploadBucket implements UploadBucket {
   deletedKeys: string[] = [];
+  /** head の直後に走らせるフック（保持期間バッチの割り込みを再現する）。 */
+  onHead: (() => void) | undefined;
 
   constructor(private readonly objectSize: number | null) {}
 
   async head(): Promise<{ size: number } | null> {
+    this.onHead?.();
     return this.objectSize === null ? null : { size: this.objectSize };
   }
 
@@ -208,6 +214,47 @@ describe('commitUpload', () => {
         publicBaseUrl: PUBLIC_URL,
       })
     ).resolves.toMatchObject({ shortId: SHORT_ID, sizeBytes: 321 });
+  });
+
+  it('R2 確認中に保持期間バッチが行を回収したら 404 を返す', async () => {
+    const database = new FakeUploadDatabase([movie({ sizeBytes: 200 })]);
+    const bucket = new FakeUploadBucket(321);
+    // pending の掃除が先に行を確保した状況（実体はこの後バッチが消す）。
+    bucket.onHead = () => database.movies.delete(SHORT_ID);
+
+    await expect(
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_URL,
+      })
+    ).rejects.toMatchObject({ status: 404 });
+    expect(database.movies.size).toBe(0);
+  });
+
+  it('R2 確認中に別の commit が確定していたら同じ応答で成功する', async () => {
+    const database = new FakeUploadDatabase([movie({ sizeBytes: 200 })]);
+    const bucket = new FakeUploadBucket(321);
+    bucket.onHead = () => {
+      const target = database.movies.get(SHORT_ID);
+      if (target) {
+        target.status = 'ready';
+        target.sizeBytes = 321;
+      }
+    };
+
+    await expect(
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_URL,
+      })
+    ).resolves.toMatchObject({ shortId: SHORT_ID, sizeBytes: 321 });
+    expect(database.movies.get(SHORT_ID)?.status).toBe('ready');
   });
 
   it('他人の shortId は 404 を返す', async () => {

--- a/web/tests/services/uploads.test.ts
+++ b/web/tests/services/uploads.test.ts
@@ -234,6 +234,27 @@ describe('commitUpload', () => {
     expect(database.movies.size).toBe(0);
   });
 
+  it('R2 確認中に保持期間バッチが行を failed で確保したら 400 を返す', async () => {
+    const database = new FakeUploadDatabase([movie({ sizeBytes: 200 })]);
+    const bucket = new FakeUploadBucket(321);
+    // 掃除が pending → failed の確保に成功した状況（実体はこの後バッチが消す）。
+    bucket.onHead = () => {
+      const target = database.movies.get(SHORT_ID);
+      if (target) target.status = 'failed';
+    };
+
+    await expect(
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_URL,
+      })
+    ).rejects.toMatchObject({ status: 400 });
+    expect(database.movies.get(SHORT_ID)?.status).toBe('failed');
+  });
+
   it('R2 確認中に別の commit が確定していたら同じ応答で成功する', async () => {
     const database = new FakeUploadDatabase([movie({ sizeBytes: 200 })]);
     const bucket = new FakeUploadBucket(321);


### PR DESCRIPTION
## なぜこの変更が必要か

保持期間バッチの pending 掃除（24 時間放置された予約の回収）とアップロードの commit が競合すると、commit が成功した動画の R2 実体だけが消え、`ready` の行と公開 URL が残って「変換できたのに再生できない」状態になる（Issue #86、PR #87 のセキュリティレビューで指摘）。

## 変更内容

- 掃除側: R2 に触る前に `UPDATE ... SET status = 'failed' WHERE ... status = 'pending' AND 猶予超過` の 1 文で行を確保する。commit の UPDATE も `status = 'pending'` 条件なので勝者は一方だけ。R2 削除に成功した時だけ行を DELETE し、失敗したら `failed` のまま次回へ持ち越す
- `deleteFailedMovies` を「R2 → D1」の行単位に変え、持ち越された実体を回収できるようにする（キー配列でまとめて delete、行は 50 件ずつ `IN (...)` で削除）
- commit 側: ready 化の UPDATE が 0 件なら成功を返さない（行なし → 404 / 既に ready → 冪等成功 / それ以外 → 400）
- 1 回の実行で処理する上限を pending 200 件（1 行 4 subrequest）/ failed 500 件に分け、打ち切りを `sweepCapped` としてログに出す
- cron のログ: 持ち越し件数は warn、回収不能な `strandedMovies` だけ error

## 意思決定

### 採用アプローチ
- 確保に既存の `failed` 状態を使う。`status` は CHECK 制約で `pending / ready / failed` に固定されていて新しい状態は migration なしでは足せず、`failed` は既に「実体なし・猶予後に行を消す」意味で上限超過経路が使っている
- 「R2 → D1」の原則は維持し、pending の確保だけを例外にする理由を retention.ts の冒頭コメントに書いた

### 却下した代替案
- 行を先に DELETE して確保 → R2 削除が失敗すると実体が永久孤児になる（レビューゲートの指摘で撤回）
- `deleting` 状態の追加 → migration が要り、追加 → 切替 → 削除の 3 段階になる。今回の範囲を超える

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 346 pass / 0 fail
- [x] 再現テストは修正前に失敗することを確認（commit が成功を返す / `bucket.deleted` に ready 行のキーが入る）
- [x] 追加: 確保後に R2 delete が throw → 行が `failed` で残り、次回に実体 → 行の順で回収 / 上限を超える failed 行は上限分だけ処理して残りを持ち越す

## レビューゲート

codex `gpt-5.6-sol` 2 レーン + 再レビュー 1 回。ブロッキング 3 件（D1 先行 DELETE による永久孤児 / cron の severity / failed 回収の非有界処理）を修正。

Refs #86

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
