### PR TITLE
fix(web): 変換の各段に期限を入れ、中止ボタンで有限時間に戻れるようにする

### DIFF
--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -305,6 +305,27 @@ test.describe('ログイン済み', () => {
     await expect(page).toHaveURL(/\/Ab12Cd34Ef56\/$/, { timeout: 120_000 });
   });
 
+  test('撮影が返ってこなくても中止ボタンで初期表示へ戻せる', async ({ page }) => {
+    await signIn(page);
+    // 上流が詰まって応答を返さない状態。以前はここで「変換中」のまま操作不能になっていた。
+    await page.route('**/api/capture/', () => {});
+    await page.goto('/ja/');
+
+    const panel = page.locator('[data-convert-panel]');
+    await panel.locator('[data-url-input]').fill('https://example.com/');
+    await panel.locator('[data-url-form] button[type="submit"]').click();
+    await expect(panel).toHaveAttribute('data-phase', 'converting');
+
+    const abort = panel.locator('[data-abort-button]');
+    await expect(abort).toBeVisible();
+    await abort.click();
+
+    await expect(panel).toHaveAttribute('data-phase', 'idle');
+    // 中止したあとはそのまま次の変換を始められる。
+    await panel.locator('[data-url-form] button[type="submit"]').click();
+    await expect(panel).toHaveAttribute('data-phase', 'converting');
+  });
+
   test('アップロードに失敗したら予約した動画を実際に取り消す', async ({ page, context }) => {
     // presign を通った時点で pending の行が予約される。ここで失敗を放置すると
     // 誰も failed へ落とさないまま履歴に「処理中」として残り続けていた。

--- a/web/src/components/ConvertPanel.astro
+++ b/web/src/components/ConvertPanel.astro
@@ -26,6 +26,9 @@ const t = useTranslations(lang);
   data-msg-image-url-not-supported={t.convert.errorImageUrlNotSupported}
   data-msg-video-url-not-supported={t.convert.errorVideoUrlNotSupported}
   data-msg-non-web-page-url={t.convert.errorNonWebPageUrl}
+  data-msg-wasm-load-timeout={t.convert.errorWasmLoadTimeout}
+  data-msg-image-fetch-timeout={t.convert.errorImageFetchTimeout}
+  data-msg-upload-timeout={t.convert.errorUploadTimeout}
   data-label-capturing={t.convert.stageCapturing}
   data-label-preparing={t.convert.stagePreparing}
   data-label-encoding={t.convert.stageEncoding}
@@ -109,6 +112,14 @@ const t = useTranslations(lang);
       >
       </div>
     </div>
+    <button
+      type="button"
+      data-abort-button
+      class="mt-4 inline-flex items-center gap-2 rounded-md border border-slate-300 px-4 py-2 text-base font-semibold text-slate-700 hover:border-red-300 hover:bg-red-50 hover:text-red-700"
+    >
+      <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      <span>{t.convert.abort}</span>
+    </button>
   </div>
 
   <div class="mt-8 border-t border-slate-200 pt-6">

--- a/web/src/components/ConvertPanel.astro
+++ b/web/src/components/ConvertPanel.astro
@@ -29,6 +29,7 @@ const t = useTranslations(lang);
   data-msg-wasm-load-timeout={t.convert.errorWasmLoadTimeout}
   data-msg-image-fetch-timeout={t.convert.errorImageFetchTimeout}
   data-msg-upload-timeout={t.convert.errorUploadTimeout}
+  data-msg-api-timeout={t.convert.errorApiTimeout}
   data-label-capturing={t.convert.stageCapturing}
   data-label-preparing={t.convert.stagePreparing}
   data-label-encoding={t.convert.stageEncoding}

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -61,6 +61,7 @@
     "errorWasmLoadTimeout": "Loading the video encoder took too long. Check your connection and try again.",
     "errorImageFetchTimeout": "Downloading the captured images took too long. Please try again.",
     "errorUploadTimeout": "Uploading the video took too long. Check your connection and try again.",
+    "errorApiTimeout": "The server took too long to respond. Please try again in a little while.",
     "abort": "Cancel conversion",
     "batchNameSuffix": "+{count}"
   },

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -58,6 +58,10 @@
     "errorImageUrlNotSupported": "Image URLs can't be converted. Download the image, then upload the file.",
     "errorVideoUrlNotSupported": "Video files aren't supported. Use a web page, PDF, or image instead.",
     "errorNonWebPageUrl": "This URL isn't a web page. Enter a web page URL.",
+    "errorWasmLoadTimeout": "Loading the video encoder took too long. Check your connection and try again.",
+    "errorImageFetchTimeout": "Downloading the captured images took too long. Please try again.",
+    "errorUploadTimeout": "Uploading the video took too long. Check your connection and try again.",
+    "abort": "Cancel conversion",
     "batchNameSuffix": "+{count}"
   },
   "history": {

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -61,6 +61,7 @@
     "errorWasmLoadTimeout": "変換エンジンの読み込みに時間がかかりすぎました。通信環境を確認して、もう一度お試しください。",
     "errorImageFetchTimeout": "撮影した画像の取得に時間がかかりすぎました。もう一度お試しください。",
     "errorUploadTimeout": "動画のアップロードに時間がかかりすぎました。通信環境を確認して、もう一度お試しください。",
+    "errorApiTimeout": "サーバーの応答に時間がかかりすぎました。しばらくおいてからお試しください。",
     "abort": "変換を中止",
     "batchNameSuffix": "他{count}枚"
   },

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -58,6 +58,10 @@
     "errorImageUrlNotSupported": "画像のURLは変換できません。画像をダウンロードしてアップロードしてください。",
     "errorVideoUrlNotSupported": "動画ファイルには対応していません。Webページ、PDF、または画像をご利用ください。",
     "errorNonWebPageUrl": "このURLはWebページではありません。WebページのURLを入力してください。",
+    "errorWasmLoadTimeout": "変換エンジンの読み込みに時間がかかりすぎました。通信環境を確認して、もう一度お試しください。",
+    "errorImageFetchTimeout": "撮影した画像の取得に時間がかかりすぎました。もう一度お試しください。",
+    "errorUploadTimeout": "動画のアップロードに時間がかかりすぎました。通信環境を確認して、もう一度お試しください。",
+    "abort": "変換を中止",
     "batchNameSuffix": "他{count}枚"
   },
   "history": {

--- a/web/src/lib/convert/encode.ts
+++ b/web/src/lib/convert/encode.ts
@@ -1,6 +1,6 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
-import { toBlobURL } from '@ffmpeg/util';
 
+import { abortRejection, WASM_LOAD_TIMEOUT_MS, withStageTimeout } from './timeouts';
 import type { ConversionProgress, ProgressReporter, VideoFrame } from './types';
 
 const CORE_VERSION = '0.12.10';
@@ -73,15 +73,46 @@ export function encodePhaseRatio(phase: EncodePhase, done: number, total: number
   return start + (end - start) * within;
 }
 
-async function loadFfmpeg(): Promise<FFmpeg> {
+/**
+ * core アセットを同一オリジン Blob URL へ写す。
+ *
+ * @ffmpeg/util の toBlobURL を使わないのは AbortSignal を受け取らず、CDN が詰まった時に
+ * 期限も中止も効かないため。進捗コールバックは引き続き使わない（startLoadPseudoProgress 参照）。
+ */
+async function fetchCoreAsset(url: string, mimeType: string, signal: AbortSignal): Promise<string> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) throw new Error(`Could not fetch FFmpeg core asset: ${response.status}`);
+  return URL.createObjectURL(new Blob([await response.arrayBuffer()], { type: mimeType }));
+}
+
+/**
+ * Workers Assets に収まらない core/wasm を CDN から取得して Worker を立ち上げる。
+ *
+ * 取得 2 本と load() 全体で 1 本の期限にする（分けると合計の待ちが読めなくなる）。
+ * load() はシグナルを受け取らないので、期限切れ・中止のどちらでも terminate() で worker を畳んで待ちを解く。
+ */
+async function loadFfmpeg(userSignal?: AbortSignal): Promise<FFmpeg> {
   const ffmpeg = new FFmpeg();
-  // Workers Assets に収まらない core/wasm を CDN から取得し、同一オリジン Blob URL として Worker に渡す。
-  const [coreURL, wasmURL] = await Promise.all([
-    toBlobURL(CORE_JS_URL, 'text/javascript'),
-    toBlobURL(CORE_WASM_URL, 'application/wasm'),
-  ]);
-  await ffmpeg.load({ coreURL, wasmURL });
-  return ffmpeg;
+  try {
+    return await withStageTimeout('wasmLoadTimeout', WASM_LOAD_TIMEOUT_MS, userSignal, async (signal) => {
+      const [coreURL, wasmURL] = await Promise.all([
+        fetchCoreAsset(CORE_JS_URL, 'text/javascript', signal),
+        fetchCoreAsset(CORE_WASM_URL, 'application/wasm', signal),
+      ]);
+      // worker 生成の直前に中止されても抱え込まないよう、terminate() だけに頼らず race を添える。
+      const stop = (): void => ffmpeg.terminate();
+      signal.addEventListener('abort', stop, { once: true });
+      try {
+        await Promise.race([ffmpeg.load({ coreURL, wasmURL }), abortRejection(signal)]);
+      } finally {
+        signal.removeEventListener('abort', stop);
+      }
+      return ffmpeg;
+    });
+  } catch (error) {
+    ffmpeg.terminate();
+    throw error;
+  }
 }
 
 /**
@@ -105,10 +136,14 @@ export function startLoadPseudoProgress(total: number, report?: ProgressReporter
   return () => clearInterval(timer);
 }
 
-async function loadFfmpegWithProgress(total: number, report?: ProgressReporter): Promise<FFmpeg> {
+async function loadFfmpegWithProgress(
+  total: number,
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<FFmpeg> {
   const stopPseudoProgress = startLoadPseudoProgress(total, report);
   try {
-    return await loadFfmpeg();
+    return await loadFfmpeg(signal);
   } finally {
     stopPseudoProgress();
   }
@@ -143,24 +178,32 @@ export function runningProgress(progress: number, total: number): ConversionProg
 }
 
 /** PNG フレーム列を順序を保って VRChat 互換 MP4 にエンコードする。 */
-export async function encodeFramesToMp4(frames: readonly VideoFrame[], report?: ProgressReporter): Promise<Blob> {
+export async function encodeFramesToMp4(
+  frames: readonly VideoFrame[],
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<Blob> {
   if (frames.length === 0) throw new Error('At least one frame is required');
   const total = frames.length;
   // エンコードは「core 読み込み → フレーム書き出し → FFmpeg 実行」と進む。枚数は実行が
   // 始まるまで動かせない（書き出し枚数を出すと実行の開始で 0 に戻る）ため、枚数は据え置き、
   // バーだけを工程ごとの部分帯域で進める。
   report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('loading', 0, 1) });
-  const ffmpeg = await loadFfmpegWithProgress(total, report);
+  const ffmpeg = await loadFfmpegWithProgress(total, report, signal);
+  // 書き出しと実行はシグナルを受け取らないため、中止は worker を畳んで止める。
+  const stop = (): void => ffmpeg.terminate();
+  signal?.addEventListener('abort', stop, { once: true });
   try {
     for (const [index, frame] of frames.entries()) {
       await ffmpeg.writeFile(frameFileName(index), new Uint8Array(frame.data));
       report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('writing', index + 1, total) });
     }
     ffmpeg.on('progress', ({ progress }) => report?.(runningProgress(progress, total)));
-    const status = await ffmpeg.exec(buildFrameEncodeArgs());
+    const status = await Promise.race([ffmpeg.exec(buildFrameEncodeArgs()), abortRejection(signal)]);
     if (status !== 0) throw new Error(`FFmpeg exited with ${status}`);
     return await readMp4(ffmpeg, 'output.mp4');
   } finally {
+    signal?.removeEventListener('abort', stop);
     ffmpeg.terminate();
   }
 }

--- a/web/src/lib/convert/encode.ts
+++ b/web/src/lib/convert/encode.ts
@@ -1,6 +1,6 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 
-import { abortRejection, WASM_LOAD_TIMEOUT_MS, withStageTimeout } from './timeouts';
+import { onAbort, raceAbort, WASM_LOAD_TIMEOUT_MS, withStageTimeout } from './timeouts';
 import type { ConversionProgress, ProgressReporter, VideoFrame } from './types';
 
 const CORE_VERSION = '0.12.10';
@@ -95,19 +95,32 @@ async function loadFfmpeg(userSignal?: AbortSignal): Promise<FFmpeg> {
   const ffmpeg = new FFmpeg();
   try {
     return await withStageTimeout('wasmLoadTimeout', WASM_LOAD_TIMEOUT_MS, userSignal, async (signal) => {
-      const [coreURL, wasmURL] = await Promise.all([
+      // allSettled で待つのは、片方だけ成功したときに作られた Blob URL を取り逃さないため
+      // （Promise.all は先に落ちた方で抜けるので、後から解決した URL が解放されずに残る）。
+      const assets = await Promise.allSettled([
         fetchCoreAsset(CORE_JS_URL, 'text/javascript', signal),
         fetchCoreAsset(CORE_WASM_URL, 'application/wasm', signal),
       ]);
-      // worker 生成の直前に中止されても抱え込まないよう、terminate() だけに頼らず race を添える。
-      const stop = (): void => ffmpeg.terminate();
-      signal.addEventListener('abort', stop, { once: true });
+      const objectUrls = assets.flatMap((asset) => (asset.status === 'fulfilled' ? [asset.value] : []));
       try {
-        await Promise.race([ffmpeg.load({ coreURL, wasmURL }), abortRejection(signal)]);
+        const failed = assets.find((asset) => asset.status === 'rejected');
+        if (failed) throw failed.reason;
+
+        const [coreURL, wasmURL] = objectUrls;
+        if (coreURL === undefined || wasmURL === undefined) throw new Error('FFmpeg core assets are missing');
+
+        // worker 生成の直前に中止されても抱え込まないよう、terminate() だけに頼らず race を添える。
+        const releaseStop = onAbort(signal, () => ffmpeg.terminate());
+        try {
+          await raceAbort(ffmpeg.load({ coreURL, wasmURL }), signal);
+        } finally {
+          releaseStop();
+        }
+        return ffmpeg;
       } finally {
-        signal.removeEventListener('abort', stop);
+        // load が終われば core は worker 側へ読み込み済み。成功・失敗・中止のいずれでも解放する。
+        for (const objectUrl of objectUrls) URL.revokeObjectURL(objectUrl);
       }
-      return ffmpeg;
     });
   } catch (error) {
     ffmpeg.terminate();
@@ -191,19 +204,18 @@ export async function encodeFramesToMp4(
   report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('loading', 0, 1) });
   const ffmpeg = await loadFfmpegWithProgress(total, report, signal);
   // 書き出しと実行はシグナルを受け取らないため、中止は worker を畳んで止める。
-  const stop = (): void => ffmpeg.terminate();
-  signal?.addEventListener('abort', stop, { once: true });
+  const releaseStop = onAbort(signal, () => ffmpeg.terminate());
   try {
     for (const [index, frame] of frames.entries()) {
       await ffmpeg.writeFile(frameFileName(index), new Uint8Array(frame.data));
       report?.({ stage: 'encoding', current: 0, total, ratio: encodePhaseRatio('writing', index + 1, total) });
     }
     ffmpeg.on('progress', ({ progress }) => report?.(runningProgress(progress, total)));
-    const status = await Promise.race([ffmpeg.exec(buildFrameEncodeArgs()), abortRejection(signal)]);
+    const status = await raceAbort(ffmpeg.exec(buildFrameEncodeArgs()), signal);
     if (status !== 0) throw new Error(`FFmpeg exited with ${status}`);
     return await readMp4(ffmpeg, 'output.mp4');
   } finally {
-    signal?.removeEventListener('abort', stop);
+    releaseStop();
     ffmpeg.terminate();
   }
 }

--- a/web/src/lib/convert/image.ts
+++ b/web/src/lib/convert/image.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CAPTURE_HEIGHT, DEFAULT_CAPTURE_WIDTH } from '../contracts/api';
+import { raceAbort } from './timeouts';
 import type { ProgressReporter, VideoFrame } from './types';
 
 /** 出力フレームを VRChat 向けの一定解像度へ揃える。 */
@@ -25,13 +26,23 @@ function canvasToPng(canvas: HTMLCanvasElement): Promise<Blob> {
   });
 }
 
-/** 画像をレターボックス付きの偶数ピクセル PNG フレームへ正規化する。 */
+/**
+ * 画像をレターボックス付きの偶数ピクセル PNG フレームへ正規化する。
+ *
+ * 復号（createImageBitmap）と PNG 化はシグナルを受け取らないので、待つのをやめる形で中止する。
+ * 見捨てた ImageBitmap は後から解決したところで閉じる（GPU 側の領域を持つため放置しない）。
+ */
 export async function normalizeImageBlob(
   image: Blob,
+  signal?: AbortSignal,
   width = FRAME_WIDTH,
   height = FRAME_HEIGHT
 ): Promise<VideoFrame> {
-  const bitmap = await createImageBitmap(image);
+  const decoding = createImageBitmap(image);
+  const bitmap = await raceAbort(decoding, signal).catch((error: unknown) => {
+    void decoding.then((late) => late.close()).catch(() => undefined);
+    throw error;
+  });
   try {
     const targetWidth = even(width);
     const targetHeight = even(height);
@@ -47,8 +58,12 @@ export async function normalizeImageBlob(
     const drawHeight = even(bitmap.height * scale);
     context.drawImage(bitmap, (targetWidth - drawWidth) / 2, (targetHeight - drawHeight) / 2, drawWidth, drawHeight);
 
-    const png = await canvasToPng(canvas);
-    return { data: new Uint8Array(await png.arrayBuffer()), width: targetWidth, height: targetHeight };
+    const png = await raceAbort(canvasToPng(canvas), signal);
+    return {
+      data: new Uint8Array(await raceAbort(png.arrayBuffer(), signal)),
+      width: targetWidth,
+      height: targetHeight,
+    };
   } finally {
     bitmap.close();
   }
@@ -64,7 +79,7 @@ export async function imageFilesToFrames(
   for (const [index, file] of files.entries()) {
     // 1 枚ごとに中止を確認する。枚数が多いほど中止から実際に止まるまでが延びるため。
     signal?.throwIfAborted();
-    frames.push(await normalizeImageBlob(file));
+    frames.push(await normalizeImageBlob(file, signal));
     report?.({ stage: 'preparing', current: index + 1, total: files.length });
   }
   return frames;

--- a/web/src/lib/convert/image.ts
+++ b/web/src/lib/convert/image.ts
@@ -55,9 +55,15 @@ export async function normalizeImageBlob(
 }
 
 /** 画像ファイル群を選択順どおりのフレーム列へ変換する。 */
-export async function imageFilesToFrames(files: readonly File[], report?: ProgressReporter): Promise<VideoFrame[]> {
+export async function imageFilesToFrames(
+  files: readonly File[],
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<VideoFrame[]> {
   const frames: VideoFrame[] = [];
   for (const [index, file] of files.entries()) {
+    // 1 枚ごとに中止を確認する。枚数が多いほど中止から実際に止まるまでが延びるため。
+    signal?.throwIfAborted();
     frames.push(await normalizeImageBlob(file));
     report?.({ stage: 'preparing', current: index + 1, total: files.length });
   }

--- a/web/src/lib/convert/imageUrls.ts
+++ b/web/src/lib/convert/imageUrls.ts
@@ -1,30 +1,48 @@
 import { normalizeImageBlob } from './image';
+import { IMAGE_FETCH_TIMEOUT_MS, withStageTimeout } from './timeouts';
 import type { ProgressReporter, VideoFrame } from './types';
 
-type ImageFetcher = (url: string) => Promise<Response>;
+type ImageFetcher = (url: string, init: RequestInit) => Promise<Response>;
 
-/** URL を渡された順に取得し、取得完了順で並べ替わらないようにする。 */
+/**
+ * URL を渡された順に取得し、取得完了順で並べ替わらないようにする。
+ *
+ * 期限は 1 枚ごとに切り直す。本文の読み取り（blob()）も同じ期限に含めるのは、
+ * ヘッダだけ届いて本文が止まる詰まり方があるため。
+ */
 export async function fetchImagesInOrder(
   urls: readonly string[],
-  fetcher: ImageFetcher = fetch
+  fetcher: ImageFetcher = fetch,
+  userSignal?: AbortSignal,
+  timeoutMs: number = IMAGE_FETCH_TIMEOUT_MS
 ): Promise<Blob[]> {
   const images: Blob[] = [];
   for (const url of urls) {
-    const response = await fetcher(url);
-    if (!response.ok) throw new Error(`Could not fetch capture image: ${response.status}`);
-    images.push(await response.blob());
+    images.push(
+      await withStageTimeout('imageFetchTimeout', timeoutMs, userSignal, async (signal) => {
+        const response = await fetcher(url, { signal });
+        if (!response.ok) throw new Error(`Could not fetch capture image: ${response.status}`);
+        return response.blob();
+      })
+    );
   }
   return images;
 }
 
 /** CaptureResponse.images の撮影順を保ったまま正規化フレームへ変換する。 */
-export async function imageUrlsToFrames(urls: readonly string[], report?: ProgressReporter): Promise<VideoFrame[]> {
+export async function imageUrlsToFrames(
+  urls: readonly string[],
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<VideoFrame[]> {
   // 取得（枚数分の fetch）は正規化より前に時間を使うため、段階の切り替わりを先に知らせる。
   // 撮影完了の表示のまま数十秒止まって見えるのを避ける。
   report?.({ stage: 'preparing', current: 0, total: urls.length });
-  const images = await fetchImagesInOrder(urls);
+  const images = await fetchImagesInOrder(urls, fetch, signal);
   const frames: VideoFrame[] = [];
   for (const [index, image] of images.entries()) {
+    // 正規化は 1 枚ずつ CPU を使うだけなので、中止はここで打ち切る。
+    signal?.throwIfAborted();
     frames.push(await normalizeImageBlob(image));
     report?.({ stage: 'preparing', current: index + 1, total: images.length });
   }

--- a/web/src/lib/convert/imageUrls.ts
+++ b/web/src/lib/convert/imageUrls.ts
@@ -43,7 +43,7 @@ export async function imageUrlsToFrames(
   for (const [index, image] of images.entries()) {
     // 正規化は 1 枚ずつ CPU を使うだけなので、中止はここで打ち切る。
     signal?.throwIfAborted();
-    frames.push(await normalizeImageBlob(image));
+    frames.push(await normalizeImageBlob(image, signal));
     report?.({ stage: 'preparing', current: index + 1, total: images.length });
   }
   return frames;

--- a/web/src/lib/convert/index.ts
+++ b/web/src/lib/convert/index.ts
@@ -9,16 +9,29 @@ import type { ProgressReporter } from './types';
 export async function convertFilesToMp4(
   files: readonly File[],
   kind: Exclude<UploadKind, 'web'>,
-  report?: ProgressReporter
+  report?: ProgressReporter,
+  signal?: AbortSignal
 ): Promise<Blob> {
   if (files.length === 0) throw new Error('At least one file is required');
   const frames = kind === 'pdf' ? await pdfToFrames(files[0]!, report) : await imageFilesToFrames(files, report);
-  return encodeFramesToMp4(frames, report);
+  return encodeFramesToMp4(frames, report, signal);
 }
 
 /** 撮影順で返された URL 画像群を VRChat 互換 MP4 にする。 */
-export async function convertImageUrlsToMp4(urls: readonly string[], report?: ProgressReporter): Promise<Blob> {
-  return encodeFramesToMp4(await imageUrlsToFrames(urls, report), report);
+export async function convertImageUrlsToMp4(
+  urls: readonly string[],
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<Blob> {
+  return encodeFramesToMp4(await imageUrlsToFrames(urls, report, signal), report, signal);
 }
 
 export { ConversionError, type ConversionProgress, type ConversionStage, type VideoFrame } from './types';
+export {
+  isUserAborted,
+  StageTimeoutError,
+  STAGE_TIMEOUT_CODES,
+  UPLOAD_PUT_TIMEOUT_MS,
+  withStageTimeout,
+  type StageTimeoutCode,
+} from './timeouts';

--- a/web/src/lib/convert/index.ts
+++ b/web/src/lib/convert/index.ts
@@ -13,7 +13,10 @@ export async function convertFilesToMp4(
   signal?: AbortSignal
 ): Promise<Blob> {
   if (files.length === 0) throw new Error('At least one file is required');
-  const frames = kind === 'pdf' ? await pdfToFrames(files[0]!, report) : await imageFilesToFrames(files, report);
+  const frames =
+    kind === 'pdf'
+      ? await pdfToFrames(files[0]!, report, signal)
+      : await imageFilesToFrames(files, report, signal);
   return encodeFramesToMp4(frames, report, signal);
 }
 
@@ -28,6 +31,7 @@ export async function convertImageUrlsToMp4(
 
 export { ConversionError, type ConversionProgress, type ConversionStage, type VideoFrame } from './types';
 export {
+  API_REQUEST_TIMEOUT_MS,
   isUserAborted,
   StageTimeoutError,
   STAGE_TIMEOUT_CODES,

--- a/web/src/lib/convert/pdf.ts
+++ b/web/src/lib/convert/pdf.ts
@@ -1,5 +1,7 @@
+import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
+
 import { DEFAULT_CAPTURE_HEIGHT, DEFAULT_CAPTURE_WIDTH } from '../contracts/api';
-import { onAbort } from './timeouts';
+import { onAbort, raceAbort } from './timeouts';
 import type { ProgressReporter, VideoFrame } from './types';
 import { ConversionError } from './types';
 
@@ -37,10 +39,28 @@ export async function pdfToFrames(
   const worker = new Worker(new URL('pdfjs-dist/build/pdf.worker.mjs', import.meta.url), { type: 'module' });
   pdfjs.GlobalWorkerOptions.workerPort = worker;
 
-  try {
-    return await renderPdfFrames(pdfjs, pdfFile, report, signal);
-  } finally {
+  let stopped = false;
+  const stopWorker = (): void => {
+    if (stopped) return;
+    stopped = true;
     worker.terminate();
+  };
+  // 解析（getDocument / getPage / render）はシグナルを受け取らない。中止したら worker ごと
+  // 落として保留中の待ちを reject させる。これが無いと 1 ページの解析が終わるまで止まらない。
+  const session: { document: PDFDocumentProxy | null } = { document: null };
+  const releaseAbort = onAbort(signal, () => {
+    void session.document?.destroy().catch(() => undefined);
+    stopWorker();
+  });
+
+  try {
+    return await renderPdfFrames(pdfjs, pdfFile, session, report, signal);
+  } finally {
+    releaseAbort();
+    // 中止時は worker を畳んだ後なので destroy の応答は返らない。待つと止まらなくなる。
+    const closing = session.document?.destroy().catch(() => undefined);
+    if (!signal?.aborted) await closing;
+    stopWorker();
     pdfjs.GlobalWorkerOptions.workerPort = null;
   }
 }
@@ -48,53 +68,61 @@ export async function pdfToFrames(
 async function renderPdfFrames(
   pdfjs: typeof import('pdfjs-dist'),
   pdfFile: File,
+  session: { document: PDFDocumentProxy | null },
   report?: ProgressReporter,
   signal?: AbortSignal
 ): Promise<VideoFrame[]> {
-  const pdfDocument = await pdfjs.getDocument({ data: await pdfFile.arrayBuffer() }).promise;
-  try {
-    assertPdfPageCount(pdfDocument.numPages);
-    const frames: VideoFrame[] = [];
-    for (let index = 1; index <= pdfDocument.numPages; index += 1) {
-      // 1 ページごとに中止を確認する。長い PDF ほど中止から実際に止まるまでが延びるため。
-      signal?.throwIfAborted();
-      const page = await pdfDocument.getPage(index);
-      const sourceViewport = page.getViewport({ scale: 1 });
-      const scale = Math.min(
-        DEFAULT_CAPTURE_WIDTH / sourceViewport.width,
-        DEFAULT_CAPTURE_HEIGHT / sourceViewport.height
-      );
-      const viewport = page.getViewport({ scale });
-      const canvas = document.createElement('canvas');
-      canvas.width = DEFAULT_CAPTURE_WIDTH;
-      canvas.height = DEFAULT_CAPTURE_HEIGHT;
-      const context = canvas.getContext('2d');
-      if (!context) throw new Error('Canvas 2D context is unavailable');
-      context.fillStyle = '#ffffff';
-      context.fillRect(0, 0, canvas.width, canvas.height);
-      const renderTask = page.render({
-        canvas: null,
-        canvasContext: context,
-        viewport,
-        transform: [1, 0, 0, 1, (canvas.width - viewport.width) / 2, (canvas.height - viewport.height) / 2],
-      });
-      // 描画は数秒かかることがある。中止したら進行中のページも打ち切る。
-      const releaseCancel = onAbort(signal, () => renderTask.cancel());
-      try {
-        await renderTask.promise;
-      } finally {
-        releaseCancel();
-      }
-      const png = await canvasToPng(canvas);
-      frames.push({
-        data: new Uint8Array(await png.arrayBuffer()),
-        width: canvas.width,
-        height: canvas.height,
-      });
-      report?.({ stage: 'preparing', current: index, total: pdfDocument.numPages });
-    }
-    return frames;
-  } finally {
-    await pdfDocument.destroy();
+  const data = await raceAbort(pdfFile.arrayBuffer(), signal);
+  const pdfDocument = await raceAbort(pdfjs.getDocument({ data }).promise, signal);
+  // 破棄は呼び出し側（worker を畳む側）に任せる。ここで待つと中止時に返らなくなる。
+  session.document = pdfDocument;
+
+  assertPdfPageCount(pdfDocument.numPages);
+  const frames: VideoFrame[] = [];
+  for (let index = 1; index <= pdfDocument.numPages; index += 1) {
+    // 1 ページごとに中止を確認する。長い PDF ほど中止から実際に止まるまでが延びるため。
+    signal?.throwIfAborted();
+    const page = await raceAbort(pdfDocument.getPage(index), signal);
+    frames.push(await renderPdfPage(page, signal));
+    report?.({ stage: 'preparing', current: index, total: pdfDocument.numPages });
   }
+  return frames;
+}
+
+/** 1 ページを 1920x1080 の中央寄せ PNG フレームへ描画する。 */
+async function renderPdfPage(page: PDFPageProxy, signal?: AbortSignal): Promise<VideoFrame> {
+  const sourceViewport = page.getViewport({ scale: 1 });
+  const scale = Math.min(
+    DEFAULT_CAPTURE_WIDTH / sourceViewport.width,
+    DEFAULT_CAPTURE_HEIGHT / sourceViewport.height
+  );
+  const viewport = page.getViewport({ scale });
+  const canvas = document.createElement('canvas');
+  canvas.width = DEFAULT_CAPTURE_WIDTH;
+  canvas.height = DEFAULT_CAPTURE_HEIGHT;
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('Canvas 2D context is unavailable');
+  context.fillStyle = '#ffffff';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  const renderTask = page.render({
+    canvas: null,
+    canvasContext: context,
+    viewport,
+    transform: [1, 0, 0, 1, (canvas.width - viewport.width) / 2, (canvas.height - viewport.height) / 2],
+  });
+  // 描画は数秒かかることがある。中止したら進行中のページも打ち切る。
+  const releaseCancel = onAbort(signal, () => renderTask.cancel());
+  try {
+    await raceAbort(renderTask.promise, signal);
+  } finally {
+    releaseCancel();
+  }
+
+  const png = await raceAbort(canvasToPng(canvas), signal);
+  return {
+    data: new Uint8Array(await raceAbort(png.arrayBuffer(), signal)),
+    width: canvas.width,
+    height: canvas.height,
+  };
 }

--- a/web/src/lib/convert/pdf.ts
+++ b/web/src/lib/convert/pdf.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CAPTURE_HEIGHT, DEFAULT_CAPTURE_WIDTH } from '../contracts/api';
+import { onAbort } from './timeouts';
 import type { ProgressReporter, VideoFrame } from './types';
 import { ConversionError } from './types';
 
@@ -21,19 +22,42 @@ function canvasToPng(canvas: HTMLCanvasElement): Promise<Blob> {
   });
 }
 
-/** PDF の各ページを順番どおり 1920x1080 の PNG フレームへ描画する。 */
-export async function pdfToFrames(pdfFile: File, report?: ProgressReporter): Promise<VideoFrame[]> {
+/**
+ * PDF の各ページを順番どおり 1920x1080 の PNG フレームへ描画する。
+ *
+ * worker は自前で作って GlobalWorkerOptions へ渡しているため、pdfjs は破棄してくれない。
+ * 中止・失敗も含めて必ず terminate し、次の変換が新しい worker を張れる状態へ戻す。
+ */
+export async function pdfToFrames(
+  pdfFile: File,
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<VideoFrame[]> {
   const pdfjs = await import('pdfjs-dist');
-  pdfjs.GlobalWorkerOptions.workerPort = new Worker(
-    new URL('pdfjs-dist/build/pdf.worker.mjs', import.meta.url),
-    { type: 'module' }
-  );
+  const worker = new Worker(new URL('pdfjs-dist/build/pdf.worker.mjs', import.meta.url), { type: 'module' });
+  pdfjs.GlobalWorkerOptions.workerPort = worker;
 
+  try {
+    return await renderPdfFrames(pdfjs, pdfFile, report, signal);
+  } finally {
+    worker.terminate();
+    pdfjs.GlobalWorkerOptions.workerPort = null;
+  }
+}
+
+async function renderPdfFrames(
+  pdfjs: typeof import('pdfjs-dist'),
+  pdfFile: File,
+  report?: ProgressReporter,
+  signal?: AbortSignal
+): Promise<VideoFrame[]> {
   const pdfDocument = await pdfjs.getDocument({ data: await pdfFile.arrayBuffer() }).promise;
   try {
     assertPdfPageCount(pdfDocument.numPages);
     const frames: VideoFrame[] = [];
     for (let index = 1; index <= pdfDocument.numPages; index += 1) {
+      // 1 ページごとに中止を確認する。長い PDF ほど中止から実際に止まるまでが延びるため。
+      signal?.throwIfAborted();
       const page = await pdfDocument.getPage(index);
       const sourceViewport = page.getViewport({ scale: 1 });
       const scale = Math.min(
@@ -48,12 +72,19 @@ export async function pdfToFrames(pdfFile: File, report?: ProgressReporter): Pro
       if (!context) throw new Error('Canvas 2D context is unavailable');
       context.fillStyle = '#ffffff';
       context.fillRect(0, 0, canvas.width, canvas.height);
-      await page.render({
+      const renderTask = page.render({
         canvas: null,
         canvasContext: context,
         viewport,
         transform: [1, 0, 0, 1, (canvas.width - viewport.width) / 2, (canvas.height - viewport.height) / 2],
-      }).promise;
+      });
+      // 描画は数秒かかることがある。中止したら進行中のページも打ち切る。
+      const releaseCancel = onAbort(signal, () => renderTask.cancel());
+      try {
+        await renderTask.promise;
+      } finally {
+        releaseCancel();
+      }
       const png = await canvasToPng(canvas);
       frames.push({
         data: new Uint8Array(await png.arrayBuffer()),

--- a/web/src/lib/convert/timeouts.ts
+++ b/web/src/lib/convert/timeouts.ts
@@ -1,0 +1,76 @@
+/**
+ * クライアント側の長い待ちに期限と中止を与える。
+ *
+ * ブラウザ内変換は「変換エンジンの取得 → 画像の取得 → R2 への PUT」と待ちが続き、
+ * どれか 1 つでも詰まると進捗バーが止まったまま永久に返らない。段ごとに期限を切り、
+ * 期限切れは段の分かる表示コード（StageTimeoutError.code）で投げる。
+ *
+ * 利用者による中止は失敗ではないので期限切れと区別し、そのまま伝播させる
+ * （呼び出し側が idle へ戻す）。
+ */
+
+/**
+ * 変換エンジン（ffmpeg core / wasm、数十 MB）の取得と初期化の上限。
+ * CDN が詰まった時の待ちであり、細い回線でも数十 MB を引き切れる幅を残す。
+ */
+export const WASM_LOAD_TIMEOUT_MS = 60_000;
+/**
+ * 撮影済み画像 1 枚あたりの取得上限。枚数分だけ直列に積み上がるため 1 枚は短く切る。
+ * note: 逐次取得のままなので長いページほど総待ち時間が伸びる。並列化は Issue #71。
+ */
+export const IMAGE_FETCH_TIMEOUT_MS = 30_000;
+/** R2 への PUT の上限。上限 50 MB を細い回線で送り切る余地を残す。 */
+export const UPLOAD_PUT_TIMEOUT_MS = 120_000;
+
+/** 期限切れの段。UI の表示コードとしてそのまま辞書を引く。 */
+export const STAGE_TIMEOUT_CODES = ['wasmLoadTimeout', 'imageFetchTimeout', 'uploadTimeout'] as const;
+export type StageTimeoutCode = (typeof STAGE_TIMEOUT_CODES)[number];
+
+/** 段ごとの期限切れ。原因の分かる文言を出すため、段を code として持ち回る。 */
+export class StageTimeoutError extends Error {
+  constructor(readonly code: StageTimeoutCode) {
+    super(`Stage timed out: ${code}`);
+    this.name = 'StageTimeoutError';
+  }
+}
+
+/** 利用者の中止で落ちたかどうか。失敗表示とリセットの分岐に使う。 */
+export function isUserAborted(userSignal?: AbortSignal): boolean {
+  return userSignal?.aborted === true;
+}
+
+/** シグナルが落ちた時に、その理由で reject するだけの promise。 */
+export function abortRejection(signal?: AbortSignal): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    if (!signal) return;
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+}
+
+/**
+ * 期限と利用者の中止を束ねたシグナルを run へ渡す。
+ *
+ * 失敗の分類はエラーの名前ではなくシグナルの状態で行う。ffmpeg の worker を
+ * terminate() して待ちを解いた場合、reject されるのは AbortError ではなく
+ * ライブラリ独自のエラーになるため、名前で見ると中止が「変換失敗」に化ける。
+ */
+export async function withStageTimeout<T>(
+  code: StageTimeoutCode,
+  timeoutMs: number,
+  userSignal: AbortSignal | undefined,
+  run: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  const signal = userSignal ? AbortSignal.any([timeout, userSignal]) : timeout;
+  try {
+    return await run(signal);
+  } catch (error) {
+    if (isUserAborted(userSignal)) throw error;
+    if (timeout.aborted) throw new StageTimeoutError(code);
+    throw error;
+  }
+}

--- a/web/src/lib/convert/timeouts.ts
+++ b/web/src/lib/convert/timeouts.ts
@@ -28,8 +28,18 @@ export const UPLOAD_PUT_TIMEOUT_MS = 120_000;
  */
 export const API_REQUEST_TIMEOUT_MS = 30_000;
 
-/** 期限切れの段。UI の表示コードとしてそのまま辞書を引く。 */
-export const STAGE_TIMEOUT_CODES = ['wasmLoadTimeout', 'imageFetchTimeout', 'uploadTimeout'] as const;
+/**
+ * 期限切れの段。UI の表示コードとしてそのまま辞書を引く。
+ *
+ * apiTimeout（予約・確定の要求）と uploadTimeout（本体の送信）は分ける。前者はまだ 1 バイトも
+ * 送っていないので、利用者に伝えるべきことが違う。
+ */
+export const STAGE_TIMEOUT_CODES = [
+  'wasmLoadTimeout',
+  'imageFetchTimeout',
+  'uploadTimeout',
+  'apiTimeout',
+] as const;
 export type StageTimeoutCode = (typeof STAGE_TIMEOUT_CODES)[number];
 
 /** 段ごとの期限切れ。原因の分かる文言を出すため、段を code として持ち回る。 */
@@ -70,7 +80,7 @@ export function onAbort(signal: AbortSignal | undefined, stop: () => void): () =
 export async function raceAbort<T>(task: Promise<T>, signal?: AbortSignal): Promise<T> {
   if (!signal) return task;
 
-  let onAbort: (() => void) | undefined;
+  let removeAbortListener: (() => void) | undefined;
   try {
     return await Promise.race([
       task,
@@ -79,12 +89,13 @@ export async function raceAbort<T>(task: Promise<T>, signal?: AbortSignal): Prom
           reject(signal.reason);
           return;
         }
-        onAbort = (): void => reject(signal.reason);
-        signal.addEventListener('abort', onAbort, { once: true });
+        const rejectOnAbort = (): void => reject(signal.reason);
+        removeAbortListener = (): void => signal.removeEventListener('abort', rejectOnAbort);
+        signal.addEventListener('abort', rejectOnAbort, { once: true });
       }),
     ]);
   } finally {
-    if (onAbort) signal.removeEventListener('abort', onAbort);
+    removeAbortListener?.();
   }
 }
 

--- a/web/src/lib/convert/timeouts.ts
+++ b/web/src/lib/convert/timeouts.ts
@@ -21,6 +21,12 @@ export const WASM_LOAD_TIMEOUT_MS = 60_000;
 export const IMAGE_FETCH_TIMEOUT_MS = 30_000;
 /** R2 への PUT の上限。上限 50 MB を細い回線で送り切る余地を残す。 */
 export const UPLOAD_PUT_TIMEOUT_MS = 120_000;
+/**
+ * presign / commit のような短い JSON 要求の上限。
+ * これらは利用者の中止では打ち切らない（予約済みの行を宙に浮かせないため）ので、
+ * 詰まったときに抜ける手段は期限だけになる。
+ */
+export const API_REQUEST_TIMEOUT_MS = 30_000;
 
 /** 期限切れの段。UI の表示コードとしてそのまま辞書を引く。 */
 export const STAGE_TIMEOUT_CODES = ['wasmLoadTimeout', 'imageFetchTimeout', 'uploadTimeout'] as const;
@@ -39,16 +45,47 @@ export function isUserAborted(userSignal?: AbortSignal): boolean {
   return userSignal?.aborted === true;
 }
 
-/** シグナルが落ちた時に、その理由で reject するだけの promise。 */
-export function abortRejection(signal?: AbortSignal): Promise<never> {
-  return new Promise<never>((_resolve, reject) => {
-    if (!signal) return;
-    if (signal.aborted) {
-      reject(signal.reason);
-      return;
-    }
-    signal.addEventListener('abort', () => reject(signal.reason), { once: true });
-  });
+/**
+ * 中止時に stop を呼ぶ。戻り値は解除関数。
+ *
+ * 既に落ちているシグナルへ addEventListener しても 'abort' は二度と発火しないため、
+ * その場合はその場で stop を呼ぶ。ここを取り違えると「中止済みなのに止まらない」になる。
+ */
+export function onAbort(signal: AbortSignal | undefined, stop: () => void): () => void {
+  if (!signal) return () => {};
+  if (signal.aborted) {
+    stop();
+    return () => {};
+  }
+  signal.addEventListener('abort', stop, { once: true });
+  return () => signal.removeEventListener('abort', stop);
+}
+
+/**
+ * シグナルを受け取れない処理（ffmpeg の load / exec）を中止と競わせる。
+ *
+ * 決着したら abort リスナーを必ず外す。外さないと、同じシグナルを使い回す
+ * 呼び出しのぶんだけ listener が積み上がる。
+ */
+export async function raceAbort<T>(task: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return task;
+
+  let onAbort: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<never>((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        onAbort = (): void => reject(signal.reason);
+        signal.addEventListener('abort', onAbort, { once: true });
+      }),
+    ]);
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
 }
 
 /**

--- a/web/src/lib/ui/convert-panel-view.ts
+++ b/web/src/lib/ui/convert-panel-view.ts
@@ -18,6 +18,9 @@ function errorMessage(panel: HTMLElement, code: UploadErrorCode): string {
     imageUrlNotSupported: panel.dataset['msgImageUrlNotSupported'],
     videoUrlNotSupported: panel.dataset['msgVideoUrlNotSupported'],
     nonWebPageUrl: panel.dataset['msgNonWebPageUrl'],
+    wasmLoadTimeout: panel.dataset['msgWasmLoadTimeout'],
+    imageFetchTimeout: panel.dataset['msgImageFetchTimeout'],
+    uploadTimeout: panel.dataset['msgUploadTimeout'],
   };
   return messages[code] ?? '';
 }

--- a/web/src/lib/ui/convert-panel-view.ts
+++ b/web/src/lib/ui/convert-panel-view.ts
@@ -21,6 +21,7 @@ function errorMessage(panel: HTMLElement, code: UploadErrorCode): string {
     wasmLoadTimeout: panel.dataset['msgWasmLoadTimeout'],
     imageFetchTimeout: panel.dataset['msgImageFetchTimeout'],
     uploadTimeout: panel.dataset['msgUploadTimeout'],
+    apiTimeout: panel.dataset['msgApiTimeout'],
   };
   return messages[code] ?? '';
 }

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -19,6 +19,7 @@ import { isShortId } from '../contracts/r2key';
 import { collectCaptures } from './capture-pages';
 import { movieEndpoint } from './history-view';
 import {
+  API_REQUEST_TIMEOUT_MS,
   ConversionError,
   convertFilesToMp4,
   convertImageUrlsToMp4,
@@ -150,7 +151,25 @@ export async function putMp4(
   if (!response.ok) throw new Error(`Upload failed: ${response.status}`);
 }
 
-async function uploadMp4(
+/**
+ * presign / commit を送る。利用者の中止シグナルは渡さない。
+ *
+ * 予約と確定は「送ったのに結果を知らない」状態を作ってはいけない。中止で打ち切ると
+ * pending の行が誰にも回収されないまま残るため、短い要求として応答を必ず待ち、
+ * 抜ける手段は期限だけにする。
+ */
+function requestUploadApi(path: string, body: unknown): Promise<unknown> {
+  return withStageTimeout('uploadTimeout', API_REQUEST_TIMEOUT_MS, undefined, (signal) =>
+    requestJson(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal,
+    })
+  );
+}
+
+export async function uploadMp4(
   mp4: Blob,
   filename: string,
   kind: UploadKind,
@@ -164,13 +183,13 @@ async function uploadMp4(
   }
   dispatch({ type: 'converted' }, runGeneration);
   const presign = asPresignResponse(
-    await requestJson('/api/uploads/presign/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ filename, sizeBytes: mp4.size, kind }),
-      signal,
-    })
+    await requestUploadApi('/api/uploads/presign/', { filename, sizeBytes: mp4.size, kind })
   );
+  // 応答を待っている間に中止された場合。予約だけ残るので、抜ける前に取り消す。
+  if (signal?.aborted) {
+    abandonUpload(presign.shortId);
+    signal.throwIfAborted();
+  }
   dispatch({ type: 'stageRatio', stage: 'uploading', ratio: UPLOAD_PRESIGNED_RATIO }, runGeneration);
 
   // presign を通った時点で pending の行が予約されている。ここから先で失敗すると
@@ -187,13 +206,9 @@ async function uploadMp4(
   dispatch({ type: 'stageRatio', stage: 'uploading', ratio: UPLOAD_STORED_RATIO }, runGeneration);
 
   try {
+    // commit は中止でも最後まで送り切る。届いた後の中止は「完了」として扱ってよい。
     const committed = asCommitResponse(
-      await requestJson('/api/uploads/commit/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ shortId: presign.shortId }),
-        signal,
-      })
+      await requestUploadApi('/api/uploads/commit/', { shortId: presign.shortId })
     );
     dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
   } catch (error) {

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -159,7 +159,7 @@ export async function putMp4(
  * 抜ける手段は期限だけにする。
  */
 function requestUploadApi(path: string, body: unknown): Promise<unknown> {
-  return withStageTimeout('uploadTimeout', API_REQUEST_TIMEOUT_MS, undefined, (signal) =>
+  return withStageTimeout('apiTimeout', API_REQUEST_TIMEOUT_MS, undefined, (signal) =>
     requestJson(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -18,7 +18,14 @@ import {
 import { isShortId } from '../contracts/r2key';
 import { collectCaptures } from './capture-pages';
 import { movieEndpoint } from './history-view';
-import { ConversionError, convertFilesToMp4, convertImageUrlsToMp4 } from '../convert';
+import {
+  ConversionError,
+  convertFilesToMp4,
+  convertImageUrlsToMp4,
+  StageTimeoutError,
+  UPLOAD_PUT_TIMEOUT_MS,
+  withStageTimeout,
+} from '../convert';
 import {
   INITIAL_UPLOAD_STATE,
   preflightInputFiles,
@@ -121,12 +128,35 @@ function abandonUpload(shortId: string): void {
   }
 }
 
+/**
+ * R2 へ本体を送る。期限を切らないと、詰まったときに「アップロード中 95%」のまま返らない。
+ *
+ * timeoutMs を引数に出しているのは短い期限でテストできるようにするため（既定値が正本）。
+ */
+export async function putMp4(
+  uploadUrl: string,
+  mp4: Blob,
+  userSignal?: AbortSignal,
+  timeoutMs: number = UPLOAD_PUT_TIMEOUT_MS
+): Promise<void> {
+  const response = await withStageTimeout('uploadTimeout', timeoutMs, userSignal, (signal) =>
+    fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'video/mp4' },
+      body: mp4,
+      signal,
+    })
+  );
+  if (!response.ok) throw new Error(`Upload failed: ${response.status}`);
+}
+
 async function uploadMp4(
   mp4: Blob,
   filename: string,
   kind: UploadKind,
   dispatch: Dispatch,
-  runGeneration: number
+  runGeneration: number,
+  signal?: AbortSignal
 ): Promise<void> {
   if (mp4.size > MAX_UPLOAD_BYTES) {
     dispatch({ type: 'failed', errorCode: 'tooLarge' }, runGeneration);
@@ -138,6 +168,7 @@ async function uploadMp4(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ filename, sizeBytes: mp4.size, kind }),
+      signal,
     })
   );
   dispatch({ type: 'stageRatio', stage: 'uploading', ratio: UPLOAD_PRESIGNED_RATIO }, runGeneration);
@@ -146,12 +177,7 @@ async function uploadMp4(
   // 誰も failed へ落とさないまま残り、cron が回収するまで容量を占め続ける。
   // ただし取り消してよいのは「まだ ready になっていないと確信できる」失敗だけ。
   try {
-    const upload = await fetch(presign.uploadUrl, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'video/mp4' },
-      body: mp4,
-    });
-    if (!upload.ok) throw new Error(`Upload failed: ${upload.status}`);
+    await putMp4(presign.uploadUrl, mp4, signal);
   } catch (error) {
     // R2 への PUT 段階の失敗。commit を送っていないので確実に pending のまま。
     abandonUpload(presign.shortId);
@@ -166,6 +192,7 @@ async function uploadMp4(
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ shortId: presign.shortId }),
+        signal,
       })
     );
     dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
@@ -193,6 +220,8 @@ const API_ERROR_TO_UPLOAD_ERROR: Readonly<Partial<Record<ErrorCode, UploadErrorC
 
 /** API とブラウザ内変換の失敗を、辞書で表示できるエラーコードへ正規化する。 */
 export function uploadErrorCode(error: unknown): UploadErrorCode {
+  // 段ごとの期限切れは、どこで詰まったかがそのまま表示コードになる。
+  if (error instanceof StageTimeoutError) return error.code;
   if (error instanceof ConversionError) {
     return error.code === 'tooManyPages' ? 'tooManyPages' : 'failed';
   }
@@ -225,12 +254,37 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     }
   };
 
-  // BFCache で復元すると完了状態のままになるため、古い非同期処理も無効化して初期表示に戻す。
-  window.addEventListener('pageshow', (event) => {
-    if (!event.persisted) return;
+  let activeRun: AbortController | null = null;
+
+  /** 新しい変換の世代と中止シグナルを起こす。前の変換が残っていれば道連れに止める。 */
+  const startRun = (): { generation: number; signal: AbortSignal } => {
+    activeRun?.abort();
+    activeRun = new AbortController();
+    return { generation: ++generation, signal: activeRun.signal };
+  };
+
+  /** 進行中の変換を捨てて初期表示へ戻す。世代を進めるので遅れて届く報告も無視される。 */
+  const cancelRun = (): void => {
+    if (state.phase !== 'converting' && state.phase !== 'uploading') return;
+    activeRun?.abort();
+    activeRun = null;
     generation += 1;
     state = INITIAL_UPLOAD_STATE;
     renderConvertPanel(panel, state);
+  };
+
+  // BFCache で復元すると完了状態のままになるため、古い非同期処理も無効化して初期表示に戻す。
+  window.addEventListener('pageshow', (event) => {
+    if (!event.persisted) return;
+    activeRun?.abort();
+    activeRun = null;
+    generation += 1;
+    state = INITIAL_UPLOAD_STATE;
+    renderConvertPanel(panel, state);
+  });
+
+  element(panel, '[data-abort-button]')?.addEventListener('click', () => {
+    cancelRun();
   });
 
   const fileInput = element<HTMLInputElement>(panel, '[data-file-input]');
@@ -238,8 +292,17 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     if (files.length === 0) return;
     if (state.phase === 'converting' || state.phase === 'uploading') return;
     // 署名読み取り中に別の入力へ切り替わった場合、古い検証結果で状態を上書きしない。
-    const current = ++generation;
-    const preflight = await preflightInputFiles(files);
+    const { generation: current, signal } = startRun();
+    let preflight;
+    try {
+      preflight = await preflightInputFiles(files);
+    } catch (error) {
+      // 選択後にファイルが読めなくなった等。握り潰すと unhandled rejection のまま
+      // 画面が idle で固まるので、失敗として見せる。
+      console.error('preflight failed', error);
+      dispatch({ type: 'failed', errorCode: 'failed' }, current);
+      return;
+    }
     if (current !== generation) return;
     if (!preflight.ok) {
       dispatch({ type: 'failed', errorCode: 'unsupported' }, current);
@@ -253,9 +316,14 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     dispatch(event, current);
     if (next.phase !== 'converting' || next.kind === null || next.kind === 'web' || next.kind !== preflight.kind) return;
     const kind = next.kind;
-    void convertFilesToMp4(files, kind, (progress) => {
-      dispatch({ type: 'stageProgress', ...progress }, current);
-    })
+    void convertFilesToMp4(
+      files,
+      kind,
+      (progress) => {
+        dispatch({ type: 'stageProgress', ...progress }, current);
+      },
+      signal
+    )
       .then((mp4) =>
         uploadMp4(
           mp4,
@@ -265,10 +333,13 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
           ),
           kind,
           dispatch,
-          current
+          current,
+          signal
         )
       )
       .catch((error: unknown) => {
+        // 中止は失敗ではない。cancelRun が既に初期表示へ戻している。
+        if (signal.aborted) return;
         console.error('conversion failed', error);
         dispatch({ type: 'failed', errorCode: uploadErrorCode(error) }, current);
       });
@@ -305,7 +376,7 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     const url = input?.value.trim();
     if (!url) return;
     if (state.phase === 'converting' || state.phase === 'uploading') return;
-    const current = ++generation;
+    const { generation: current, signal } = startRun();
     dispatch({ type: 'selectUrl', url }, current);
 
     let pseudoRatio = 0;
@@ -323,6 +394,7 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ url, startIndex }),
+          signal,
         }).then(asCaptureResponse),
       onProgress: (collected, total) => {
         // 実進捗が来たら疑似進捗は用済み。天井へ届く前の tick が後から入ると戻るので止める。
@@ -336,9 +408,11 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
       })
       .then((images) => convertImageUrlsToMp4(images, (progress) => {
         dispatch({ type: 'stageProgress', ...progress }, current);
-      }))
-      .then((mp4) => uploadMp4(mp4, movieNameForUrl(url), 'web', dispatch, current))
+      }, signal))
+      .then((mp4) => uploadMp4(mp4, movieNameForUrl(url), 'web', dispatch, current, signal))
       .catch((error: unknown) => {
+        // 中止は失敗ではない。cancelRun が既に初期表示へ戻している。
+        if (signal.aborted) return;
         console.error('conversion failed', error);
         dispatch({ type: 'failed', errorCode: uploadErrorCode(error), target: 'url' }, current);
       });

--- a/web/src/lib/ui/upload-flow.ts
+++ b/web/src/lib/ui/upload-flow.ts
@@ -9,6 +9,7 @@
  */
 
 import { MAX_UPLOAD_BYTES, type UploadKind } from '../contracts/api';
+import { STAGE_TIMEOUT_CODES } from '../convert/timeouts';
 import type { ConversionStage } from '../convert/types';
 import { ACCEPT_ATTRIBUTE, detectInputKind } from './input-formats';
 
@@ -63,6 +64,7 @@ export function stageBands(kind: UploadKind | null): Readonly<Record<ProgressSta
   return kind === 'web' ? URL_STAGE_BANDS : FILE_STAGE_BANDS;
 }
 
+// 段ごとの期限切れコードは convert 側が正本。並べ直すと文言と実装がずれるので展開して取り込む。
 export const UPLOAD_ERROR_CODES = [
   'tooLarge',
   'unsupported',
@@ -75,6 +77,7 @@ export const UPLOAD_ERROR_CODES = [
   'imageUrlNotSupported',
   'videoUrlNotSupported',
   'nonWebPageUrl',
+  ...STAGE_TIMEOUT_CODES,
 ] as const;
 export type UploadErrorCode = (typeof UPLOAD_ERROR_CODES)[number];
 export type UploadErrorTarget = 'file' | 'url';

--- a/web/tests/convert/abort-propagation.test.ts
+++ b/web/tests/convert/abort-propagation.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { imageFilesToFrames } from '../../src/lib/convert/image';
+import { pdfToFrames } from '../../src/lib/convert/pdf';
+
+/** canvas を使う変換のために、描画まわりの最小限の代役を置く。 */
+function installCanvasFakes(): () => void {
+  const original = { document: globalThis.document, createImageBitmap: globalThis.createImageBitmap };
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ({ fillStyle: '', fillRect: () => {}, drawImage: () => {} }),
+    toBlob: (callback: (blob: Blob) => void) => callback(new Blob([new Uint8Array([1, 2, 3])])),
+  };
+  Object.assign(globalThis, { document: { createElement: () => canvas } });
+  return () => Object.assign(globalThis, original);
+}
+
+const restores: (() => void)[] = [];
+
+afterEach(() => {
+  while (restores.length > 0) restores.pop()?.();
+});
+
+describe('imageFilesToFrames', () => {
+  test('中止したら残りの画像を処理しない', async () => {
+    restores.push(installCanvasFakes());
+    const controller = new AbortController();
+    let started = 0;
+    Object.assign(globalThis, {
+      createImageBitmap: async () => {
+        started += 1;
+        // 1 枚目の処理中に中止された状況。
+        controller.abort();
+        return { width: 2, height: 2, close: () => {} };
+      },
+    });
+
+    const failure = await imageFilesToFrames(
+      [new File(['a'], 'a.png'), new File(['b'], 'b.png'), new File(['c'], 'c.png')],
+      undefined,
+      controller.signal
+    ).catch((error: unknown) => error);
+
+    expect(started).toBe(1);
+    expect(failure).toBeInstanceOf(Error);
+  });
+});
+
+describe('pdfToFrames', () => {
+  test('中止したら残りのページを描画せず、進行中の描画も打ち切る', async () => {
+    restores.push(installCanvasFakes());
+    const controller = new AbortController();
+    let renders = 0;
+    let cancels = 0;
+    let terminated = 0;
+
+    const page = {
+      getViewport: () => ({ width: 100, height: 100 }),
+      render: () => {
+        renders += 1;
+        // 1 ページ目の描画中に中止された状況。
+        controller.abort();
+        return {
+          promise: Promise.resolve(),
+          cancel: () => {
+            cancels += 1;
+          },
+        };
+      },
+    };
+    const workerPortHolder = { workerPort: null as unknown };
+    mock.module('pdfjs-dist', () => ({
+      GlobalWorkerOptions: workerPortHolder,
+      getDocument: () => ({
+        promise: Promise.resolve({
+          numPages: 3,
+          getPage: async () => page,
+          destroy: async () => {},
+        }),
+      }),
+    }));
+    Object.assign(globalThis, {
+      Worker: class {
+        terminate(): void {
+          terminated += 1;
+        }
+      },
+    });
+
+    const failure = await pdfToFrames(new File(['pdf'], 'a.pdf'), undefined, controller.signal).catch(
+      (error: unknown) => error
+    );
+
+    expect(renders).toBe(1);
+    expect(cancels).toBe(1);
+    expect(failure).toBeInstanceOf(Error);
+    // 自前の worker は pdfjs が畳んでくれないので、中止でも必ず終了させる。
+    expect(terminated).toBe(1);
+    expect(workerPortHolder.workerPort).toBeNull();
+  });
+});

--- a/web/tests/convert/abort-propagation.test.ts
+++ b/web/tests/convert/abort-propagation.test.ts
@@ -3,6 +3,31 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { imageFilesToFrames } from '../../src/lib/convert/image';
 import { pdfToFrames } from '../../src/lib/convert/pdf';
 
+/** worker は自前生成なので、terminate の回数を数えられる代役に差し替える。 */
+function installWorkerFake(onTerminate: () => void): () => void {
+  const original = { Worker: globalThis.Worker };
+  Object.assign(globalThis, {
+    Worker: class {
+      terminate(): void {
+        onTerminate();
+      }
+    },
+  });
+  return () => Object.assign(globalThis, original);
+}
+
+/** 解決しない promise。解析や復号が返ってこない状態を再現する。 */
+function neverSettles<T>(): Promise<T> {
+  return new Promise<T>(() => {});
+}
+
+/** run が settle するまでの実測ミリ秒。中止が「効いた」ことを時間で見るために使う。 */
+async function millisUntilSettled(run: Promise<unknown>): Promise<number> {
+  const startedAt = performance.now();
+  await run.catch(() => undefined);
+  return performance.now() - startedAt;
+}
+
 /** canvas を使う変換のために、描画まわりの最小限の代役を置く。 */
 function installCanvasFakes(): () => void {
   const original = { document: globalThis.document, createImageBitmap: globalThis.createImageBitmap };
@@ -80,13 +105,9 @@ describe('pdfToFrames', () => {
         }),
       }),
     }));
-    Object.assign(globalThis, {
-      Worker: class {
-        terminate(): void {
-          terminated += 1;
-        }
-      },
-    });
+    restores.push(installWorkerFake(() => {
+      terminated += 1;
+    }));
 
     const failure = await pdfToFrames(new File(['pdf'], 'a.pdf'), undefined, controller.signal).catch(
       (error: unknown) => error
@@ -98,5 +119,59 @@ describe('pdfToFrames', () => {
     // 自前の worker は pdfjs が畳んでくれないので、中止でも必ず終了させる。
     expect(terminated).toBe(1);
     expect(workerPortHolder.workerPort).toBeNull();
+  });
+});
+
+describe('返ってこない前処理', () => {
+  const SETTLE_BUDGET_MS = 50;
+
+  test('PDF の解析が返らなくても、中止したら worker を畳んで抜ける', async () => {
+    restores.push(installCanvasFakes());
+    const controller = new AbortController();
+    let terminated = 0;
+    const workerPortHolder = { workerPort: null as unknown };
+    mock.module('pdfjs-dist', () => ({
+      GlobalWorkerOptions: workerPortHolder,
+      // 解析が始まったきり返ってこない上流。
+      getDocument: () => ({ promise: neverSettles() }),
+    }));
+    restores.push(installWorkerFake(() => {
+      terminated += 1;
+    }));
+
+    const running = pdfToFrames(new File(['pdf'], 'a.pdf'), undefined, controller.signal);
+    controller.abort();
+
+    expect(await millisUntilSettled(running)).toBeLessThan(SETTLE_BUDGET_MS);
+    expect(terminated).toBe(1);
+    expect(workerPortHolder.workerPort).toBeNull();
+  });
+
+  test('画像の復号が返らなくても、中止したら抜けて後から解決した bitmap を閉じる', async () => {
+    restores.push(installCanvasFakes());
+    const controller = new AbortController();
+    let closed = 0;
+    let release: ((bitmap: { close: () => void }) => void) | undefined;
+    Object.assign(globalThis, {
+      // 復号が始まったきり返ってこない状態。あとから解決させて後始末を確かめる。
+      createImageBitmap: () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    });
+
+    const running = imageFilesToFrames([new File(['a'], 'a.png')], undefined, controller.signal);
+    controller.abort();
+
+    expect(await millisUntilSettled(running)).toBeLessThan(SETTLE_BUDGET_MS);
+
+    release?.({
+      close: () => {
+        closed += 1;
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(closed).toBe(1);
   });
 });

--- a/web/tests/convert/encode-abort.test.ts
+++ b/web/tests/convert/encode-abort.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { encodeFramesToMp4 } from '../../src/lib/convert/encode';
+import { StageTimeoutError } from '../../src/lib/convert/timeouts';
+
+const FRAMES = [{ data: new Uint8Array([1, 2, 3]), width: 2, height: 2 }];
+
+interface FfmpegFakeOptions {
+  /** load() が返らない（core は取れたのに worker が立ち上がらない状況）。 */
+  loadHangs?: boolean;
+  /** writeFile() が返らない（フレーム書き出しで詰まる状況）。 */
+  writeHangs?: boolean;
+  /** writeFile() に入った瞬間に呼ぶ。中止のタイミングを確定させるために使う。 */
+  onWriteFile?: () => void;
+}
+
+/**
+ * FFmpeg の代役。terminate() が保留中の待ちを reject するのは実物と同じ挙動で、
+ * 「シグナルを受け取れない処理を worker ごと畳んで止める」という設計の前提そのもの。
+ */
+function installFfmpegFake(options: FfmpegFakeOptions = {}): () => number {
+  let terminations = 0;
+  let terminated = false;
+  const pending = new Set<(reason: unknown) => void>();
+  // 実物は worker へ送った時点で待ちが登録され、terminate() で一括 reject される。
+  // 畳んだ後の呼び出しも待たずに落ちるので、代役も同じ順序にしておく。
+  const hang = <T>(): Promise<T> =>
+    new Promise<T>((_resolve, reject) => {
+      if (terminated) {
+        reject(new Error('FFmpeg terminated'));
+        return;
+      }
+      pending.add(reject);
+    });
+
+  mock.module('@ffmpeg/ffmpeg', () => ({
+    FFmpeg: class {
+      load = async (): Promise<void> => (options.loadHangs ? hang<void>() : undefined);
+      writeFile = async (): Promise<void> => {
+        if (!options.writeHangs) {
+          options.onWriteFile?.();
+          return;
+        }
+        // 待ちを登録してから中止させる（実物も送信後に中止が届く）。
+        const waiting = hang<void>();
+        options.onWriteFile?.();
+        return waiting;
+      };
+      on = (): void => {};
+      exec = async (): Promise<number> => 0;
+      readFile = async (): Promise<Uint8Array> => new Uint8Array([0, 0, 0, 1]);
+      terminate = (): void => {
+        terminations += 1;
+        terminated = true;
+        for (const reject of pending) reject(new Error('FFmpeg terminated'));
+        pending.clear();
+      };
+    },
+  }));
+
+  return () => terminations;
+}
+
+/** core/wasm の取得と Blob URL を差し替え、解放された URL を数える。 */
+function installCoreAssetFakes(options: { failWasm?: boolean } = {}): {
+  revoked: () => readonly string[];
+  restore: () => void;
+} {
+  const originalFetch = globalThis.fetch;
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  const revoked: string[] = [];
+  let issued = 0;
+
+  Object.assign(globalThis, {
+    fetch: async (url: string) => {
+      if (options.failWasm && url.endsWith('.wasm')) throw new Error('core asset unavailable');
+      return new Response(new Uint8Array([1, 2, 3]));
+    },
+  });
+  URL.createObjectURL = (): string => `blob:core-${(issued += 1)}`;
+  URL.revokeObjectURL = (url: string): void => {
+    revoked.push(url);
+  };
+
+  return {
+    revoked: () => revoked,
+    restore: () => {
+      Object.assign(globalThis, { fetch: originalFetch });
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+    },
+  };
+}
+
+/** 期限の時計だけ縮める。製品コードの定数（60 秒）はそのままに、待たずに期限切れを観測する。 */
+function installFastTimeouts(afterMs = 5): () => void {
+  const original = AbortSignal.timeout;
+  AbortSignal.timeout = (): AbortSignal => original.call(AbortSignal, afterMs);
+  return () => {
+    AbortSignal.timeout = original;
+  };
+}
+
+const restores: (() => void)[] = [];
+
+afterEach(() => {
+  while (restores.length > 0) restores.pop()?.();
+});
+
+async function caught(run: Promise<unknown>): Promise<unknown> {
+  try {
+    await run;
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+describe('encodeFramesToMp4 の中止', () => {
+  test('変換エンジンの起動が返らなくても、中止したら worker を畳んで Blob URL を解放する', async () => {
+    const assets = installCoreAssetFakes();
+    restores.push(assets.restore);
+    const terminations = installFfmpegFake({ loadHangs: true });
+    const controller = new AbortController();
+
+    const running = encodeFramesToMp4(FRAMES, undefined, controller.signal);
+    await Promise.resolve();
+    controller.abort();
+
+    expect(await caught(running)).not.toBeNull();
+    expect(terminations()).toBeGreaterThan(0);
+    // core と wasm の 2 本。解放しないと変換のたびに数十 MB 分が残る。
+    expect(assets.revoked()).toHaveLength(2);
+  });
+
+  test('フレーム書き出し中に中止しても、worker を畳んで待ちが解ける', async () => {
+    const assets = installCoreAssetFakes();
+    restores.push(assets.restore);
+    const controller = new AbortController();
+    const terminations = installFfmpegFake({
+      writeHangs: true,
+      onWriteFile: () => controller.abort(),
+    });
+
+    const failure = await caught(encodeFramesToMp4(FRAMES, undefined, controller.signal));
+
+    expect(failure).not.toBeNull();
+    expect(terminations()).toBeGreaterThan(0);
+  });
+});
+
+describe('encodeFramesToMp4 の期限切れ', () => {
+  test('変換エンジンの起動が返らないまま期限を過ぎたら wasmLoadTimeout になる', async () => {
+    restores.push(installFastTimeouts());
+    const assets = installCoreAssetFakes();
+    restores.push(assets.restore);
+    installFfmpegFake({ loadHangs: true });
+
+    const failure = await caught(encodeFramesToMp4(FRAMES));
+
+    expect(failure).toBeInstanceOf(StageTimeoutError);
+    expect((failure as StageTimeoutError).code).toBe('wasmLoadTimeout');
+    expect(assets.revoked()).toHaveLength(2);
+  });
+
+  test('core と wasm の片方だけ取れた場合も、成功した側の Blob URL を解放する', async () => {
+    const assets = installCoreAssetFakes({ failWasm: true });
+    restores.push(assets.restore);
+    installFfmpegFake();
+
+    expect(await caught(encodeFramesToMp4(FRAMES))).not.toBeNull();
+    expect(assets.revoked()).toHaveLength(1);
+  });
+});

--- a/web/tests/convert/timeouts.test.ts
+++ b/web/tests/convert/timeouts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { fetchImagesInOrder } from '../../src/lib/convert/imageUrls';
-import { StageTimeoutError, withStageTimeout } from '../../src/lib/convert/timeouts';
+import { onAbort, raceAbort, StageTimeoutError, withStageTimeout } from '../../src/lib/convert/timeouts';
 
 /** 中止されるまで返らない通信。CDN や R2 が詰まった状態を再現する。 */
 function neverResolvingFetch(): (url: string, init: RequestInit) => Promise<Response> {
@@ -66,5 +66,45 @@ describe('fetchImagesInOrder', () => {
     const images = await fetchImagesInOrder(['a', 'b', 'c'], fetcher, undefined, 20);
 
     expect(images).toHaveLength(3);
+  });
+});
+
+describe('raceAbort', () => {
+  test('中止されなければ結果をそのまま返す', async () => {
+    expect(await raceAbort(Promise.resolve('done'), new AbortController().signal)).toBe('done');
+  });
+
+  test('シグナルを受け取れない処理でも中止で抜けられる', async () => {
+    const controller = new AbortController();
+    const running = raceAbort(new Promise<string>(() => {}), controller.signal);
+    controller.abort();
+
+    expect(await caught(running)).not.toBeNull();
+  });
+});
+
+describe('onAbort', () => {
+  test('既に中止済みのシグナルでも停止処理を呼ぶ', () => {
+    const controller = new AbortController();
+    controller.abort();
+    let stopped = 0;
+
+    onAbort(controller.signal, () => {
+      stopped += 1;
+    });
+
+    expect(stopped).toBe(1);
+  });
+
+  test('解除したあとの中止では停止処理を呼ばない', () => {
+    const controller = new AbortController();
+    let stopped = 0;
+
+    onAbort(controller.signal, () => {
+      stopped += 1;
+    })();
+    controller.abort();
+
+    expect(stopped).toBe(0);
   });
 });

--- a/web/tests/convert/timeouts.test.ts
+++ b/web/tests/convert/timeouts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+
+import { fetchImagesInOrder } from '../../src/lib/convert/imageUrls';
+import { StageTimeoutError, withStageTimeout } from '../../src/lib/convert/timeouts';
+
+/** 中止されるまで返らない通信。CDN や R2 が詰まった状態を再現する。 */
+function neverResolvingFetch(): (url: string, init: RequestInit) => Promise<Response> {
+  return (_url, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      const signal = init.signal;
+      if (!signal) return;
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+}
+
+async function caught(run: Promise<unknown>): Promise<unknown> {
+  try {
+    await run;
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+describe('withStageTimeout', () => {
+  test('返らない通信は段の分かる期限切れとして失敗する', async () => {
+    const error = await caught(
+      withStageTimeout('wasmLoadTimeout', 5, undefined, (signal) => neverResolvingFetch()('https://cdn', { signal }))
+    );
+
+    expect(error).toBeInstanceOf(StageTimeoutError);
+    expect((error as StageTimeoutError).code).toBe('wasmLoadTimeout');
+  });
+
+  test('利用者の中止は期限切れに化けない', async () => {
+    const user = new AbortController();
+    const running = withStageTimeout('uploadTimeout', 60_000, user.signal, (signal) =>
+      neverResolvingFetch()('https://r2', { signal })
+    );
+    user.abort();
+
+    expect(await caught(running)).not.toBeInstanceOf(StageTimeoutError);
+  });
+
+  test('期限内に終われば結果をそのまま返す', async () => {
+    expect(await withStageTimeout('imageFetchTimeout', 1_000, undefined, async () => 'done')).toBe('done');
+  });
+});
+
+describe('fetchImagesInOrder', () => {
+  test('返らない画像取得は imageFetchTimeout になる', async () => {
+    const error = await caught(
+      fetchImagesInOrder(['https://example.com/a.png'], neverResolvingFetch(), undefined, 5)
+    );
+
+    expect(error).toBeInstanceOf(StageTimeoutError);
+    expect((error as StageTimeoutError).code).toBe('imageFetchTimeout');
+  });
+
+  test('期限は 1 枚ごとに切り直す（合計が上限を超えても落ちない）', async () => {
+    const fetcher = async (url: string): Promise<Response> => {
+      await new Promise((resolve) => setTimeout(resolve, 6));
+      return new Response(url);
+    };
+
+    const images = await fetchImagesInOrder(['a', 'b', 'c'], fetcher, undefined, 20);
+
+    expect(images).toHaveLength(3);
+  });
+});

--- a/web/tests/ui/convert-panel-view.test.ts
+++ b/web/tests/ui/convert-panel-view.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
+import { readFileSync } from 'node:fs';
+
 import ja from '../../src/i18n/ja.json';
 import { renderConvertPanel } from '../../src/lib/ui/convert-panel-view';
-import { INITIAL_UPLOAD_STATE, reduceUpload, type UploadState } from '../../src/lib/ui/upload-flow';
+import {
+  INITIAL_UPLOAD_STATE,
+  reduceUpload,
+  UPLOAD_ERROR_CODES,
+  type UploadErrorCode,
+  type UploadState,
+} from '../../src/lib/ui/upload-flow';
 
 class FakeNode {
   textContent = '';
@@ -24,6 +32,20 @@ class FakePanel {
     labelUploading: ja.convert.stageUploading,
     labelSelectedFile: ja.convert.selectedFile,
     labelSourceUrl: ja.convert.sourceUrl,
+    msgTooLarge: ja.convert.errorTooLarge,
+    msgUnsupported: ja.convert.errorUnsupported,
+    msgTooManyPages: ja.convert.errorTooManyPages,
+    msgPageTooLong: ja.convert.errorPageTooLong,
+    msgCaptureTimeout: ja.convert.errorCaptureTimeout,
+    msgSessionExpired: ja.actions.sessionExpired,
+    msgFailed: ja.convert.errorFailed,
+    msgPdfUrlNotSupported: ja.convert.errorPdfUrlNotSupported,
+    msgImageUrlNotSupported: ja.convert.errorImageUrlNotSupported,
+    msgVideoUrlNotSupported: ja.convert.errorVideoUrlNotSupported,
+    msgNonWebPageUrl: ja.convert.errorNonWebPageUrl,
+    msgWasmLoadTimeout: ja.convert.errorWasmLoadTimeout,
+    msgImageFetchTimeout: ja.convert.errorImageFetchTimeout,
+    msgUploadTimeout: ja.convert.errorUploadTimeout,
   };
   readonly nodes = new Map<string, FakeNode>();
 
@@ -35,6 +57,10 @@ class FakePanel {
 
   text(selector: string): string {
     return this.nodes.get(selector)?.textContent ?? '';
+  }
+
+  node(selector: string): FakeNode {
+    return this.nodes.get(selector) ?? new FakeNode();
   }
 }
 
@@ -73,5 +99,37 @@ describe('進捗表示', () => {
 
   test('段階が決まっていなければ段階名を出さない', () => {
     expect(render(INITIAL_UPLOAD_STATE).text('[data-stage-label]')).toBe('');
+  });
+});
+
+describe('エラー表示', () => {
+  // 画面は data-* 属性でしか文言を受け取らない。属性名が 1 つでも欠けると文言が空になり、
+  // エラー欄ごと隠れて「無反応」に見える（この Issue が潰したい症状そのもの）。
+  test.each([...UPLOAD_ERROR_CODES])('%s は文言と一緒にエラー欄を出す', (code: UploadErrorCode) => {
+    const panel = render({
+      ...INITIAL_UPLOAD_STATE,
+      phase: 'error',
+      errorCode: code,
+      errorTarget: 'file',
+    });
+
+    expect(panel.text('[data-file-error-message]').length).toBeGreaterThan(0);
+    expect(panel.node('[data-file-error]').hidden).toBe(false);
+  });
+});
+
+describe('画面テンプレート', () => {
+  // dataset は kebab-case の属性から作られる。属性名の綴りは tsc が見ないため、
+  // 表示コードの一覧とテンプレートの突合をここで固定する。
+  const template = readFileSync(new URL('../../src/components/ConvertPanel.astro', import.meta.url), 'utf8');
+
+  test.each([...UPLOAD_ERROR_CODES])('%s の文言を渡す data 属性がある', (code: UploadErrorCode) => {
+    const attribute = `data-msg-${code.replace(/[A-Z]/g, (letter: string) => `-${letter.toLowerCase()}`)}=`;
+
+    expect(template).toContain(attribute);
+  });
+
+  test('中止ボタンを置いている', () => {
+    expect(template).toContain('data-abort-button');
   });
 });

--- a/web/tests/ui/convert-panel-view.test.ts
+++ b/web/tests/ui/convert-panel-view.test.ts
@@ -46,6 +46,7 @@ class FakePanel {
     msgWasmLoadTimeout: ja.convert.errorWasmLoadTimeout,
     msgImageFetchTimeout: ja.convert.errorImageFetchTimeout,
     msgUploadTimeout: ja.convert.errorUploadTimeout,
+    msgApiTimeout: ja.convert.errorApiTimeout,
   };
   readonly nodes = new Map<string, FakeNode>();
 

--- a/web/tests/ui/convert-panel.test.ts
+++ b/web/tests/ui/convert-panel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { ConversionError, StageTimeoutError } from '../../src/lib/convert';
-import { mountConvertPanel, putMp4, uploadErrorCode } from '../../src/lib/ui/convert-panel';
+import { mountConvertPanel, putMp4, uploadErrorCode, uploadMp4 } from '../../src/lib/ui/convert-panel';
 import { JsonRequestError } from '../../src/lib/ui/request-json';
 
 type Listener = (event: Event) => void;
@@ -253,6 +253,50 @@ describe('putMp4', () => {
 
       expect(failure).toBeInstanceOf(StageTimeoutError);
       expect((failure as StageTimeoutError).code).toBe('uploadTimeout');
+    } finally {
+      Object.assign(globalThis, { fetch: originalFetch });
+    }
+  });
+});
+
+describe('uploadMp4', () => {
+  test('presign の応答を待つ間に中止されたら、予約した動画を取り消してから抜ける', async () => {
+    const controller = new AbortController();
+    const requests: { url: string; method: string | undefined }[] = [];
+    const originalFetch = globalThis.fetch;
+    Object.assign(globalThis, {
+      fetch: async (url: string, init: RequestInit = {}) => {
+        requests.push({ url, method: init.method });
+        if (url === '/api/uploads/presign/') {
+          // 予約は成立しているが、応答が届くまでの間に利用者が中止した状況。
+          controller.abort();
+          return new Response(
+            JSON.stringify({
+              shortId: 'Ab12Cd34Ef56',
+              uploadUrl: 'https://upload.test/r2-upload',
+              publicUrl: 'https://cdn.test/movies/Ab12Cd34Ef56.mp4',
+            }),
+            { headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    try {
+      const failure = await uploadMp4(
+        new Blob(['mp4']),
+        'a.mp4',
+        'image',
+        () => {},
+        0,
+        controller.signal
+      ).catch((error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(requests).toContainEqual({ url: '/api/movies/Ab12Cd34Ef56/', method: 'DELETE' });
+      // 中止済みなので R2 へは送らない。
+      expect(requests.some((request) => request.url === 'https://upload.test/r2-upload')).toBe(false);
     } finally {
       Object.assign(globalThis, { fetch: originalFetch });
     }

--- a/web/tests/ui/convert-panel.test.ts
+++ b/web/tests/ui/convert-panel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
-import { ConversionError } from '../../src/lib/convert';
-import { mountConvertPanel, uploadErrorCode } from '../../src/lib/ui/convert-panel';
+import { ConversionError, StageTimeoutError } from '../../src/lib/convert';
+import { mountConvertPanel, putMp4, uploadErrorCode } from '../../src/lib/ui/convert-panel';
 import { JsonRequestError } from '../../src/lib/ui/request-json';
 
 type Listener = (event: Event) => void;
@@ -27,6 +27,7 @@ class FakePanel {
   readonly dataset: DOMStringMap = {};
   readonly sourceName = { textContent: '' };
   readonly urlForm = new FakeEventTarget();
+  readonly abortButton = new FakeEventTarget();
   readonly urlInput: { value: string };
 
   constructor(private readonly fileInput: FakeFileInput, url = '') {
@@ -38,6 +39,7 @@ class FakePanel {
       '[data-file-input]': this.fileInput,
       '[data-url-form]': this.urlForm,
       '[data-url-input]': this.urlInput,
+      '[data-abort-button]': this.abortButton,
     };
     return (elements[selector] ?? null) as T | null;
   }
@@ -67,6 +69,20 @@ function controlledPng(
     }),
   } as unknown as File;
   return { file, release };
+}
+
+/** 選択後に読めなくなったファイル。事前検査そのものが例外で落ちる状態を再現する。 */
+function unreadablePng(): File {
+  return {
+    name: 'vanished.png',
+    type: 'image/png',
+    size: 8,
+    slice: () => ({
+      arrayBuffer: async (): Promise<ArrayBuffer> => {
+        throw new Error('NotReadableError');
+      },
+    }),
+  } as unknown as File;
 }
 
 function installBrowserFakes(): { conversionStarts: () => number; restore: () => void } {
@@ -160,6 +176,89 @@ describe('mountConvertPanel', () => {
   });
 });
 
+describe('中止', () => {
+  test('変換中に中止すると初期表示へ戻り、もう一度変換できる', async () => {
+    const browser = installBrowserFakes();
+
+    try {
+      const panel = new FakePanel(new FakeFileInput(), 'https://example.com/articles/latest');
+      mountConvertPanel(panel as unknown as HTMLElement);
+
+      panel.urlForm.dispatch('submit');
+      await flushPromises();
+      expect(panel.dataset['phase']).toBe('converting');
+
+      panel.abortButton.dispatch('click');
+      await flushPromises();
+      expect(panel.dataset['phase']).toBe('idle');
+
+      panel.urlForm.dispatch('submit');
+      await flushPromises();
+      expect(panel.dataset['phase']).toBe('converting');
+    } finally {
+      browser.restore();
+    }
+  });
+
+  test('変換していないときの中止は何も起こさない', () => {
+    const browser = installBrowserFakes();
+
+    try {
+      const panel = new FakePanel(new FakeFileInput());
+      mountConvertPanel(panel as unknown as HTMLElement);
+
+      panel.abortButton.dispatch('click');
+
+      expect(panel.dataset['phase']).toBe('idle');
+    } finally {
+      browser.restore();
+    }
+  });
+});
+
+describe('入力の事前検査', () => {
+  test('検査そのものが失敗したらエラー表示にする', async () => {
+    const browser = installBrowserFakes();
+
+    try {
+      const input = new FakeFileInput();
+      const panel = new FakePanel(input);
+      mountConvertPanel(panel as unknown as HTMLElement);
+
+      input.files = [unreadablePng()];
+      input.dispatch('change');
+      await flushPromises();
+
+      expect(panel.dataset['phase']).toBe('error');
+    } finally {
+      browser.restore();
+    }
+  });
+});
+
+describe('putMp4', () => {
+  test('返らないアップロードは uploadTimeout になる', async () => {
+    const originalFetch = globalThis.fetch;
+    Object.assign(globalThis, {
+      fetch: (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+        }),
+    });
+
+    try {
+      const failure = await putMp4('https://r2.example/put', new Blob(['mp4']), undefined, 5).catch(
+        (error: unknown) => error
+      );
+
+      expect(failure).toBeInstanceOf(StageTimeoutError);
+      expect((failure as StageTimeoutError).code).toBe('uploadTimeout');
+    } finally {
+      Object.assign(globalThis, { fetch: originalFetch });
+    }
+  });
+});
+
 describe('uploadErrorCode', () => {
   test.each([
     ['PAGE_TOO_LONG', 400, 'pageTooLong'],
@@ -175,4 +274,13 @@ describe('uploadErrorCode', () => {
   test('ブラウザ内のページ数上限は同じ経路で変換する', () => {
     expect(uploadErrorCode(new ConversionError('tooManyPages', 'too many pages'))).toBe('tooManyPages');
   });
+
+  test.each(['wasmLoadTimeout', 'imageFetchTimeout', 'uploadTimeout'])(
+    '%s の期限切れは詰まった段のコードのまま表示へ渡す',
+    (code) => {
+      expect(uploadErrorCode(new StageTimeoutError(code as 'wasmLoadTimeout'))).toBe(
+        code as ReturnType<typeof uploadErrorCode>
+      );
+    }
+  );
 });


### PR DESCRIPTION
## なぜこの変更が必要か

クライアント側の長時間処理（FFmpeg core / wasm の CDN 取得、撮影画像の取得、R2 への PUT）にタイムアウトも中止導線もなく、どこかが詰まると「変換中 0%」のまま永久に固まっていた。`preflightInputFiles` の失敗は unhandled rejection になり画面が無反応だった（Issue #68 の WebScreen 側。web-capture 側の `acquire()` タイムアウトは #72 の PR 群で扱う）。

## 変更内容

- 期限を 1 箇所（`web/src/lib/convert/timeouts.ts`）に定義: wasm ロード 60s / 画像 1 枚 30s / R2 PUT 120s / API（presign・commit）30s。期限切れは段の分かる表示コード（`wasmLoadTimeout` / `imageFetchTimeout` / `uploadTimeout` / `apiTimeout`）で画面に出す
- 変換中の「変換を中止」ボタン。`AbortController` を capture / 画像取得 / wasm ロード / エンコード / PUT に通し、中止後は idle に戻って再変換できる
- 中止を PDF・画像の前処理まで伝播: 進行中の `getDocument` / `getPage` / `render` は PDF worker を terminate して打ち切り、`createImageBitmap` / `toBlob` / `arrayBuffer` は `raceAbort` で待つのをやめる
- presign / commit にはユーザー中止を渡さない（短い要求なので完了を待つ）。presign 応答時点で中止済みなら `abandonUpload` で予約を解放
- リソース解放: core / wasm の Blob URL を `allSettled` 後に revoke、擬似進捗タイマーは上限到達と `finally` で停止、`raceAbort` のリスナーは決着時に解除。「中止済みシグナルへの `addEventListener` は発火しない」穴を `onAbort()` に集約
- `preflightInputFiles` の失敗を catch してエラー表示。`@ffmpeg/util` の `toBlobURL` は AbortSignal を受け取れないため自前 fetch に置き換え（取得元は固定定数）
- 「全表示コード × テンプレートの `data-msg-*` 属性」の突合テストを追加（文言が空になってエラー欄ごと消える = 本 Issue の症状の再生産を防ぐ）

## 意思決定

### 採用アプローチ
- 期限値は Issue の決定値をそのまま採用（実回線での妥当性は未計測。定数 1 箇所なので変えやすい）
- 期限切れと利用者中止の判別はエラー名ではなくシグナルの状態で行う（ffmpeg worker を terminate すると reject が AbortError にならない）

### 却下・対象外
- `/api/capture/` へのクライアント期限 → 長いページの分割取得を切らないため付けない（サーバー側 504 と中止ボタンで代替）
- 中止した PUT と即時 DELETE の競合で R2 だけ残る件、presign の応答を受け取れなかった時の pending 残留 → 本 PR 以前からの構造（Issue #108 / 保持期間バッチが回収）
- PUT 完了後〜commit 応答の間の中止で行が ready になる → 意図どおり（データを失うより良い）

## テスト

- [x] `cd web && bun run typecheck` / `bun run build`
- [x] `bun test` 434 pass / 0 fail（各段のタイムアウト、中止で idle に戻る、preflight 失敗の表示、PDF / 画像 / encode の中止伝播とリソース解放、presign 応答前の中止で `abandonUpload`）
- [x] E2E `e2e/top.spec.ts` 22 pass（上流が返らない時に中止で初期表示へ戻れることを含む。実 CDN 経由の変換 3 件も緑）

## Screenshot

| 変換中（中止ボタン） | 中止後（idle） |
|--------|-------|
| ![01-converting-abort-button-20260831](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/58e98c47fa6a-01-converting-abort-button-20260831.avif) | ![02-idle-after-abort-20260831](https://agent-toolbox-assets.kaisha3.com/uploads/2026/08/ac54fb395bd6-02-idle-after-abort-20260831.avif) |

## レビューゲート

codex `gpt-5.6-sol` 2 レーン + 再レビュー 1 回 → Opus `code-reviewer`（codex ハングのためフォールバック）。ブロッキング計 7 件を修正（詳細は対応表コメント）。

Refs #68

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
