### PR TITLE
feat(web): cron の最終成功時刻を D1 に記録し、止まったら Discord へ通知する（dead-man's switch）

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -8,7 +8,7 @@
 | リクエスト / レスポンス型、エラーコード、上限値、バリデータ | `web/src/lib/contracts/api.ts` |
 | セッション Cookie（名前・署名形式・TTL） | `web/src/lib/contracts/session.ts` |
 | R2 オブジェクトキー、shortId 生成 | `web/src/lib/contracts/r2key.ts` |
-| DB スキーマ | `web/migrations/0001_init.sql` |
+| DB スキーマ | `web/migrations/`（連番の全ファイル。適用は `wrangler d1 migrations apply`） |
 | mp4 のエンコード条件 | [encode-contract.md](encode-contract.md) |
 
 URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッシュなしは 404 になる。
@@ -17,7 +17,7 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 
 | メソッド / パス | 用途 | 認証 | 型 |
 |---|---|---|---|
-| `GET /api/health/` | 疎通確認 | 不要 | — |
+| `GET /api/health/` | 疎通確認 + 保持期間バッチの鮮度（`cron`。読めない時は `{ error: true }`） | 不要 | `CronHealthSection`（`services/cron-health.ts`） |
 | `GET /api/auth/login/` | Discord OAuth 開始（state Cookie を発行してリダイレクト） | 不要 | `session.ts` |
 | `GET /api/auth/callback/` | OAuth コールバック（state 検証 → users upsert → セッション Cookie 発行） | 不要 | `session.ts` |
 | `POST /api/auth/logout/` | セッション Cookie の破棄（form の `lang` のトップへ 303 リダイレクト。不正・欠落は `ja`） | 本人 | — |

--- a/web/.dev.vars.example
+++ b/web/.dev.vars.example
@@ -7,3 +7,8 @@ SESSION_SIGNING_KEY=replace_with_a_long_random_value
 
 # web-capture サービスの Bearer token
 WEBCAPTURE_TOKEN=replace_with_webcapture_token
+
+# 保持期間バッチの死活監視が使う Discord Incoming Webhook（cron Worker 専用の secret）。
+# 本体 Worker は使わない。本番は `bunx wrangler secret put DISCORD_ALERT_WEBHOOK_URL -c cron/wrangler.jsonc` で投入し、
+# ローカルは wrangler dev の --var でダミーを渡す（実 Discord に送らないため）。
+DISCORD_ALERT_WEBHOOK_URL=

--- a/web/cron/src/alert.ts
+++ b/web/cron/src/alert.ts
@@ -1,0 +1,72 @@
+/**
+ * 死活監視の cron（保持期間バッチが止まっていないかを見る側）。
+ *
+ * entry 層なので責務は 3 つだけ: binding をサービスの型に渡す・実行時刻を注入する・
+ * 結果を構造化ログにする。判定は services/cron-health.ts が持つ。
+ */
+
+import {
+  createDiscordNotifier,
+  runRetentionAlert,
+  type CronRunDatabase,
+} from '../../src/lib/services/cron-health';
+
+const SOURCE = 'webscreen-beta-cron';
+
+export interface AlertEnv {
+  DB: CronRunDatabase;
+  /** Discord の Incoming Webhook URL（secret）。未設定なら通知せず warn を残す。 */
+  DISCORD_ALERT_WEBHOOK_URL?: string;
+}
+
+/** 保持期間バッチの鮮度を確認し、閾値を超えていれば通知する。 */
+export async function runAlertCron(
+  env: AlertEnv,
+  scheduledTime: number,
+  cron: string
+): Promise<void> {
+  const timestamp = new Date(scheduledTime).toISOString();
+  const webhookUrl = env.DISCORD_ALERT_WEBHOOK_URL;
+
+  const result = await runRetentionAlert({
+    database: env.DB,
+    now: new Date(scheduledTime),
+    notify: async (message) => {
+      if (webhookUrl === undefined || webhookUrl === '') {
+        // 通知先が無いのに「送った」と記録すると連投防止が働いて次回以降も黙るため、
+        // 未送信（false）として返す。設定漏れ自体はログで気づけるようにする。
+        console.warn(
+          JSON.stringify({
+            timestamp,
+            source: SOURCE,
+            severity: 'warn',
+            kind: 'event',
+            cron,
+            event: 'cron_alert_webhook_unconfigured',
+            summary: 'DISCORD_ALERT_WEBHOOK_URL is not set; the alert was not delivered.',
+          })
+        );
+        return false;
+      }
+      return createDiscordNotifier(webhookUrl)(message);
+    },
+  });
+
+  // 通知すべきなのに送れなかった時だけ error（監視が機能していない印）。
+  // 停止している間は連投防止で黙る回も warn にする（decision で切り替えると、
+  // 止まったままの実行が info で流れて、ログだけ見た人が正常と誤読する）。
+  const severity = result.notifyFailed ? 'error' : result.freshness.stale ? 'warn' : 'info';
+  const log = severity === 'error' ? console.error : severity === 'warn' ? console.warn : console.log;
+
+  log(
+    JSON.stringify({
+      timestamp,
+      source: SOURCE,
+      severity,
+      kind: 'event',
+      cron,
+      summary: `retention freshness check: ${result.decision} (stale=${result.freshness.stale}, ageSeconds=${result.freshness.ageSeconds ?? 'unknown'}).`,
+      detail: result,
+    })
+  );
+}

--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -41,41 +41,51 @@ const SOURCE = 'webscreen-beta-cron';
 
 /**
  * 受け付けるスケジュール式。web/cron/wrangler.jsonc の triggers.crons と一致させること
- * （wrangler の設定と TS で二重化は避けられないため、片方だけ変えると下の default に落ちる）。
- *
- * 両方を明示マッチさせ、知らない式は error にする。「alert 以外は retention」と書くと、
- * 式を変えた時に監視側が黙って動かなくなり、dead-man's switch 自身が静かに死ぬ。
+ * （wrangler の設定と TS で二重化は避けられないため）。
  */
 const RETENTION_CRON = '17 * * * *';
 const ALERT_CRON = '47 * * * *';
 
+/**
+ * 式の表記ゆれ（前後の空白・フィールド間の連続空白）を吸収する。workerd が渡す文字列は
+ * 設定の書き方に依存するので、素の === だけで振り分けると空白 1 つで分岐が変わる。
+ */
+function normalizeCron(expression: string): string {
+  return expression.trim().replace(/\s+/g, ' ');
+}
+
 export default {
   async scheduled(event: ScheduledEvent, env: Env): Promise<void> {
-    if (event.cron === ALERT_CRON) {
-      await runAlertCron(env, event.scheduledTime, event.cron);
-      return;
-    }
-    if (event.cron === RETENTION_CRON) {
-      await runRetentionCron(env, event);
+    const cron = normalizeCron(event.cron);
+
+    // 監視だけを厳密一致にする。残りは retention へ倒す（fail-open）。式を変えた時に
+    // 掃除が止まる方が、監視が 1 回鳴らないより高くつくため。知らない式は error に出して
+    // 気づけるようにする（黙って握り潰さない）。
+    if (cron === ALERT_CRON) {
+      await runAlertCron(env, event.scheduledTime, cron);
       return;
     }
 
-    console.error(
-      JSON.stringify({
-        timestamp: new Date(event.scheduledTime).toISOString(),
-        source: SOURCE,
-        severity: 'error',
-        kind: 'event',
-        cron: event.cron,
-        event: 'cron_trigger_unknown',
-        summary: 'No handler is registered for this cron expression.',
-      })
-    );
+    if (cron !== RETENTION_CRON) {
+      console.error(
+        JSON.stringify({
+          timestamp: new Date(event.scheduledTime).toISOString(),
+          source: SOURCE,
+          severity: 'error',
+          kind: 'event',
+          cron,
+          event: 'cron_trigger_unknown',
+          summary:
+            'No handler is registered for this cron expression; running retention as a fallback.',
+        })
+      );
+    }
+    await runRetentionCron(env, event, cron);
   },
 };
 
 /** 保持期間バッチ本体。成功したら実行記録を残し、件数を 1 行 JSON で出す。 */
-async function runRetentionCron(env: Env, event: ScheduledEvent): Promise<void> {
+async function runRetentionCron(env: Env, event: ScheduledEvent, cron: string): Promise<void> {
   // Date.now を呼んでよいのはこの層だけ。サービスへは値として渡す。
   const startedAt = Date.now();
 
@@ -125,7 +135,7 @@ async function runRetentionCron(env: Env, event: ScheduledEvent): Promise<void> 
         source: SOURCE,
         severity,
         kind: 'event',
-        cron: event.cron,
+        cron,
         summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures; audited ${summary.checkedReadyRows} ready rows (${summary.missingObjectRows} missing objects).${deferred}${capped}${skipped}${auditErrors}`,
         detail: summary,
         durationMs: Date.now() - startedAt,
@@ -138,7 +148,7 @@ async function runRetentionCron(env: Env, event: ScheduledEvent): Promise<void> 
         source: SOURCE,
         severity: 'error',
         kind: 'event',
-        cron: event.cron,
+        cron,
         summary: 'retention run failed.',
         error_message: error instanceof Error ? error.message : String(error),
         stack_trace: error instanceof Error ? error.stack : undefined,

--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -1,8 +1,12 @@
 /**
- * 保持期間バッチの Worker（cron トリガー専用）。
+ * cron トリガー専用の Worker。
+ *
+ * 2 本のスケジュールを 1 つの Worker で受ける（web/cron/wrangler.jsonc の triggers.crons）:
+ *   - 保持期間バッチ本体（期限切れの掃除）
+ *   - その死活監視（バッチが止まっていないかを見て通知する）
  *
  * entry 層なので責務は 3 つだけ: bindings をサービスの型に渡す・実行時刻を注入する・
- * 結果を構造化ログにする。判定ロジックは services/retention.ts が持つ。
+ * 結果を構造化ログにする。判定ロジックは services/retention.ts と services/cron-health.ts が持つ。
  * fetch ハンドラは持たない（HTTP からは叩けない）。
  */
 
@@ -11,13 +15,19 @@ import {
   type RetentionBucket,
   type RetentionDatabase,
 } from '../../src/lib/services/retention';
+import {
+  recordCronRun,
+  RETENTION_RUN_NAME,
+  type CronRunDatabase,
+} from '../../src/lib/services/cron-health';
+import { runAlertCron, type AlertEnv } from './alert';
 
 /**
  * 使う binding だけを宣言する。@cloudflare/workers-types を入れず、サービス側の
  * 最小インターフェースをそのまま契約にする（実 binding は構造的に適合する）。
  */
-interface Env {
-  DB: RetentionDatabase;
+interface Env extends AlertEnv {
+  DB: RetentionDatabase & CronRunDatabase;
   BUCKET: RetentionBucket;
 }
 
@@ -29,71 +39,114 @@ interface ScheduledEvent {
 
 const SOURCE = 'webscreen-beta-cron';
 
+/**
+ * 受け付けるスケジュール式。web/cron/wrangler.jsonc の triggers.crons と一致させること
+ * （wrangler の設定と TS で二重化は避けられないため、片方だけ変えると下の default に落ちる）。
+ *
+ * 両方を明示マッチさせ、知らない式は error にする。「alert 以外は retention」と書くと、
+ * 式を変えた時に監視側が黙って動かなくなり、dead-man's switch 自身が静かに死ぬ。
+ */
+const RETENTION_CRON = '17 * * * *';
+const ALERT_CRON = '47 * * * *';
+
 export default {
   async scheduled(event: ScheduledEvent, env: Env): Promise<void> {
-    // Date.now を呼んでよいのはこの層だけ。サービスへは値として渡す。
-    const startedAt = Date.now();
-
-    try {
-      const summary = await runRetention({
-        database: env.DB,
-        bucket: env.BUCKET,
-        now: new Date(event.scheduledTime),
-      });
-
-      // error は回収不能な異常だけに使う。実体だけ消えた行（stranded / missing）は
-      // 壊れた URL が残り続けるので error、R2 の削除失敗（deferred）・打ち切り（capped）・
-      // 監査の失敗（auditErrors = 検出が働いていない）は次回に回せるので warn。
-      // 競合で何もしなかった行（skipped）は正常なので info。
-      const severity =
-        summary.strandedMovies > 0 || summary.missingObjectRows > 0
-          ? 'error'
-          : summary.deferredObjectDeletions > 0 || summary.sweepCapped || summary.auditErrors > 0
-            ? 'warn'
-            : 'info';
-      const log =
-        severity === 'error' ? console.error : severity === 'warn' ? console.warn : console.log;
-      const deferred =
-        summary.deferredObjectDeletions > 0
-          ? ` ${summary.deferredObjectDeletions} object deletions deferred to the next run.`
-          : '';
-      const capped = summary.sweepCapped
-        ? ' A sweep hit a per-run cap; the rest waits for the next run.'
-        : '';
-      const skipped =
-        summary.skippedRows > 0 ? ` ${summary.skippedRows} rows skipped this run.` : '';
-      const auditErrors =
-        summary.auditErrors > 0 ? ` ${summary.auditErrors} audit checks failed.` : '';
-
-      log(
-        JSON.stringify({
-          timestamp: new Date(event.scheduledTime).toISOString(),
-          source: SOURCE,
-          severity,
-          kind: 'event',
-          cron: event.cron,
-          summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures; audited ${summary.checkedReadyRows} ready rows (${summary.missingObjectRows} missing objects).${deferred}${capped}${skipped}${auditErrors}`,
-          detail: summary,
-          durationMs: Date.now() - startedAt,
-        })
-      );
-    } catch (error) {
-      console.error(
-        JSON.stringify({
-          timestamp: new Date(event.scheduledTime).toISOString(),
-          source: SOURCE,
-          severity: 'error',
-          kind: 'event',
-          cron: event.cron,
-          summary: 'retention run failed.',
-          error_message: error instanceof Error ? error.message : String(error),
-          stack_trace: error instanceof Error ? error.stack : undefined,
-          durationMs: Date.now() - startedAt,
-        })
-      );
-      // 実行を失敗として記録させるため握りつぶさない（Cloudflare 側の
-      // cron 実行履歴と observability で異常が見えるようにする）。
-      throw error;
+    if (event.cron === ALERT_CRON) {
+      await runAlertCron(env, event.scheduledTime, event.cron);
+      return;
     }
+    if (event.cron === RETENTION_CRON) {
+      await runRetentionCron(env, event);
+      return;
+    }
+
+    console.error(
+      JSON.stringify({
+        timestamp: new Date(event.scheduledTime).toISOString(),
+        source: SOURCE,
+        severity: 'error',
+        kind: 'event',
+        cron: event.cron,
+        event: 'cron_trigger_unknown',
+        summary: 'No handler is registered for this cron expression.',
+      })
+    );
   },
 };
+
+/** 保持期間バッチ本体。成功したら実行記録を残し、件数を 1 行 JSON で出す。 */
+async function runRetentionCron(env: Env, event: ScheduledEvent): Promise<void> {
+  // Date.now を呼んでよいのはこの層だけ。サービスへは値として渡す。
+  const startedAt = Date.now();
+
+  try {
+    const summary = await runRetention({
+      database: env.DB,
+      bucket: env.BUCKET,
+      now: new Date(event.scheduledTime),
+    });
+
+    // 死活監視の根拠になる記録。ここが失敗したら成功として扱わない（rethrow に任せる）。
+    // 記録が無いまま「成功」にすると、監視側からは止まって見えるのに誰も直さない状態になる。
+    await recordCronRun({
+      database: env.DB,
+      name: RETENTION_RUN_NAME,
+      at: new Date(event.scheduledTime),
+      summary,
+    });
+
+    // error は回収不能な異常だけに使う。実体だけ消えた行（stranded / missing）は
+    // 壊れた URL が残り続けるので error、R2 の削除失敗（deferred）・打ち切り（capped）・
+    // 監査の失敗（auditErrors = 検出が働いていない）は次回に回せるので warn。
+    // 競合で何もしなかった行（skipped）は正常なので info。
+    const severity =
+      summary.strandedMovies > 0 || summary.missingObjectRows > 0
+        ? 'error'
+        : summary.deferredObjectDeletions > 0 || summary.sweepCapped || summary.auditErrors > 0
+          ? 'warn'
+          : 'info';
+    const log =
+      severity === 'error' ? console.error : severity === 'warn' ? console.warn : console.log;
+    const deferred =
+      summary.deferredObjectDeletions > 0
+        ? ` ${summary.deferredObjectDeletions} object deletions deferred to the next run.`
+        : '';
+    const capped = summary.sweepCapped
+      ? ' A sweep hit a per-run cap; the rest waits for the next run.'
+      : '';
+    const skipped =
+      summary.skippedRows > 0 ? ` ${summary.skippedRows} rows skipped this run.` : '';
+    const auditErrors =
+      summary.auditErrors > 0 ? ` ${summary.auditErrors} audit checks failed.` : '';
+
+    log(
+      JSON.stringify({
+        timestamp: new Date(event.scheduledTime).toISOString(),
+        source: SOURCE,
+        severity,
+        kind: 'event',
+        cron: event.cron,
+        summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures; audited ${summary.checkedReadyRows} ready rows (${summary.missingObjectRows} missing objects).${deferred}${capped}${skipped}${auditErrors}`,
+        detail: summary,
+        durationMs: Date.now() - startedAt,
+      })
+    );
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        timestamp: new Date(event.scheduledTime).toISOString(),
+        source: SOURCE,
+        severity: 'error',
+        kind: 'event',
+        cron: event.cron,
+        summary: 'retention run failed.',
+        error_message: error instanceof Error ? error.message : String(error),
+        stack_trace: error instanceof Error ? error.stack : undefined,
+        durationMs: Date.now() - startedAt,
+      })
+    );
+    // 実行を失敗として記録させるため握りつぶさない（Cloudflare 側の
+    // cron 実行履歴と observability で異常が見えるようにする）。
+    throw error;
+  }
+}

--- a/web/cron/wrangler.jsonc
+++ b/web/cron/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   // 保持期間バッチ専用の独立 Worker。Astro のビルドを通さない素の TS で、
   // wrangler が esbuild して単体デプロイする:
-  //   bunx wrangler deploy -c web/cron/wrangler.jsonc
+  //   bunx wrangler deploy -c cron/wrangler.jsonc
   // 本体（webscreen-beta）と分けるのは、cron の失敗・実行時間が
   // リクエスト処理側の可観測性に混ざらないようにするため。
   "$schema": "../node_modules/wrangler/config-schema.json",

--- a/web/cron/wrangler.jsonc
+++ b/web/cron/wrangler.jsonc
@@ -10,9 +10,16 @@
   // 本体（web/wrangler.jsonc）と揃える。片方だけ上げると同じ D1 / R2 を
   // 別挙動の runtime で触ることになるため、上げる時は両方同時に上げる。
   "compatibility_date": "2026-08-18",
-  // 毎時 17 分。0 分ちょうどは Cloudflare 全体のスケジュール集中で遅延しやすい。
+  // 式は cron/src/index.ts の RETENTION_CRON / ALERT_CRON と一致させること
+  // （知らない式は index.ts が error ログにして何もしない）。
+  //   17 分 … 保持期間バッチ本体。0 分ちょうどは Cloudflare 全体のスケジュール集中で
+  //           遅延しやすいので外している。
+  //   47 分 … 本体の死活監視（dead-man's switch）。本体の 30 分後に置き、
+  //           同じ時刻に走らせない（監視が本体の実行中に「まだ止まっている」と誤読しないため）。
+  //           通知先は secret DISCORD_ALERT_WEBHOOK_URL（wrangler.jsonc には書けない）:
+  //             bunx wrangler secret put DISCORD_ALERT_WEBHOOK_URL -c cron/wrangler.jsonc
   "triggers": {
-    "crons": ["17 * * * *"]
+    "crons": ["17 * * * *", "47 * * * *"]
   },
   "observability": {
     "enabled": true

--- a/web/e2e/fixtures/seed.sql
+++ b/web/e2e/fixtures/seed.sql
@@ -63,3 +63,14 @@ VALUES
     datetime('now', '-1 days'),
     strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+29 days')
   );
+
+-- 保持期間バッチの実行記録。e2e ではバッチが走らないので、直前に成功した状態を作って
+-- /api/health/ が stale: false を返すことを確認する（0002 の適用漏れもここで落ちる）。
+DELETE FROM cron_runs;
+
+INSERT INTO cron_runs (name, last_success_at, last_summary)
+VALUES (
+  'retention',
+  strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-13 minutes'),
+  '{"deletedMovies":0,"deletedCaptures":0}'
+);

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -19,6 +19,18 @@ test('英語トップページが表示される', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 });
 
+test('health が保持期間バッチの鮮度を返す', async ({ request }) => {
+  // Cloudflare のダッシュボードを見に行かなくても、バッチが動いているかを外から確認できること。
+  // stale まで見るのは、migration の適用漏れ（cron が読めず error になる）を検出するため。
+  const response = await request.get('/api/health/');
+  const body = await response.json();
+
+  expect(body.status).toBe('ok');
+  expect(body.cron.stale).toBe(false);
+  expect(typeof body.cron.lastSuccessAt).toBe('string');
+  expect(body.cron.ageSeconds).toBeGreaterThanOrEqual(0);
+});
+
 test.describe('cross-origin isolation', () => {
   // 静的アセット（public/_headers）と Worker レスポンス（middleware）は
   // ヘッダーの供給元が別なので、両方を確認しないと片方の欠落に気づけない。

--- a/web/migrations/0002_cron_runs.sql
+++ b/web/migrations/0002_cron_runs.sql
@@ -1,0 +1,17 @@
+-- Migration number: 0002 	 2026-08-31T00:00:00.000Z
+-- cron の死活監視（dead-man's switch）用のテーブル。追加のみで、既存のテーブルには触らない。
+--
+-- 追加のみにするのは、デプロイが「migration 適用 → Worker 反映」の順で走り、ロールバックは
+-- Worker のコードしか戻さないため。旧コードがこのテーブルを知らなくても動き続ける形にする。
+
+-- 1 行 1 ジョブ。行の意味は name ごとに決まる:
+--   'retention'       … 保持期間バッチ本体。last_success_at = 最後に成功した実行の基準時刻、
+--                       last_summary = その実行の件数 JSON（RetentionSummary）。
+--   'retention-alert' … 上の鮮度を見張る通知側。last_success_at = 最後に通知を送った時刻、
+--                       last_summary = 通知の状態 JSON（{"state":"alerting"|"recovered"}）。
+-- 時刻は ISO8601（UTC, Z 付き）で書く。読み書きは services/cron-health.ts が正本。
+CREATE TABLE IF NOT EXISTS cron_runs (
+  name TEXT PRIMARY KEY,
+  last_success_at TEXT NOT NULL,
+  last_summary TEXT
+);

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -41,6 +41,8 @@ const seedCommand = [
   `rm -rf ${STATE_DIR}`,
   'bun run build',
   `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=migrations/0001_init.sql`,
+  // migrations/ に追加したら必ずここにも足す（seed.sql と /api/health/ の cron が先に落ちる）。
+  `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=migrations/0002_cron_runs.sql`,
   `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/seed.sql`,
   // ダウンロード経路は R2 の実体を読むため、seed した行に対応するオブジェクトも置く。
   `bunx wrangler r2 object put webscreen-beta/movies/${E2E_FIXTURES.readyShortId}.mp4 --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/sample.mp4 --content-type=video/mp4`,

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -40,9 +40,8 @@ const seedCommand = [
   // 毎回まっさらな D1 から作り直す（前回の pin 解除・削除が残っていると結果が変わるため）。
   `rm -rf ${STATE_DIR}`,
   'bun run build',
-  `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=migrations/0001_init.sql`,
-  // migrations/ に追加したら必ずここにも足す（seed.sql と /api/health/ の cron が先に落ちる）。
-  `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=migrations/0002_cron_runs.sql`,
+  // migrations/ を全部当てる（ファイル名を列挙すると新しい migration の追従漏れが起きる）。
+  `bunx wrangler d1 migrations apply webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR}`,
   `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/seed.sql`,
   // ダウンロード経路は R2 の実体を読むため、seed した行に対応するオブジェクトも置く。
   `bunx wrangler r2 object put webscreen-beta/movies/${E2E_FIXTURES.readyShortId}.mp4 --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/sample.mp4 --content-type=video/mp4`,

--- a/web/src/lib/infra/discord-webhook.ts
+++ b/web/src/lib/infra/discord-webhook.ts
@@ -1,0 +1,71 @@
+/**
+ * Discord の Incoming Webhook へ運用通知を送る境界。
+ *
+ * 既存の infra/discord.ts は OAuth（ログイン）専用なので分けている。こちらは
+ * 認証に関与せず、URL 自体が資格情報である webhook だけを扱う。
+ *
+ * 例外を投げないのが契約。通知は監視の付帯機能であり、送信の失敗で本体のジョブを
+ * 落とすと「掃除は動いていたのに通知の失敗で異常終了」という逆転が起きる。
+ */
+
+const SOURCE = 'webscreen-beta-cron';
+
+/** Discord のメッセージ本文の上限（超えると 400 で落ちるので手前で切る）。 */
+const MAX_CONTENT_LENGTH = 2000;
+
+/** fetch の注入境界（テストで実ネットワークを使わないため）。 */
+export type WebhookFetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const defaultFetch: WebhookFetcher = (input, init) => globalThis.fetch(input, init);
+
+/**
+ * 失敗を 1 行 JSON で残す。
+ *
+ * webhook URL は資格情報そのものなので、URL も例外の message も出さない
+ * （fetch の失敗メッセージには URL が混ざることがある）。ログに出すのは固定の
+ * イベント名と HTTP ステータスだけで、Cloudflare observability での絞り込みには足りる。
+ */
+function logFailure(reason: 'request_failed' | 'rejected', status?: number): void {
+  console.error(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source: SOURCE,
+      severity: 'error',
+      kind: 'event',
+      event: 'cron_alert_webhook_failed',
+      reason,
+      status,
+      summary: `Discord webhook delivery failed (${reason}).`,
+    })
+  );
+}
+
+/**
+ * 通知を 1 通送る。送れたら true、送れなければ false（例外は投げない）。
+ *
+ * 呼び出し側は false を「未送信」として扱い、送信済みの記録を残さないこと
+ * （残すと連投防止の間隔に入り、本当は届いていないのに次が抑止される）。
+ */
+export async function postDiscordWebhook(
+  webhookUrl: string,
+  content: string,
+  fetcher: WebhookFetcher = defaultFetch
+): Promise<boolean> {
+  let response: Response;
+  try {
+    response = await fetcher(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: content.slice(0, MAX_CONTENT_LENGTH) }),
+    });
+  } catch {
+    logFailure('request_failed');
+    return false;
+  }
+
+  if (!response.ok) {
+    logFailure('rejected', response.status);
+    return false;
+  }
+  return true;
+}

--- a/web/src/lib/infra/discord-webhook.ts
+++ b/web/src/lib/infra/discord-webhook.ts
@@ -13,6 +13,12 @@ const SOURCE = 'webscreen-beta-cron';
 /** Discord のメッセージ本文の上限（超えると 400 で落ちるので手前で切る）。 */
 const MAX_CONTENT_LENGTH = 2000;
 
+/**
+ * 送信を諦めるまでの時間。Discord が応答しない時に cron の実行時間を食い潰さないため
+ * （通知は付帯機能であり、待ち続けて本体の掃除の枠を削る価値はない）。
+ */
+const REQUEST_TIMEOUT_MS = 5000;
+
 /** fetch の注入境界（テストで実ネットワークを使わないため）。 */
 export type WebhookFetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -57,8 +63,10 @@ export async function postDiscordWebhook(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content: content.slice(0, MAX_CONTENT_LENGTH) }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
   } catch {
+    // タイムアウト（AbortError）もここに来る。理由で分けず、送れなかった事実だけを残す。
     logFailure('request_failed');
     return false;
   }

--- a/web/src/lib/infra/worker-log.ts
+++ b/web/src/lib/infra/worker-log.ts
@@ -20,6 +20,7 @@ const WORKER_FAILURE_EVENTS = [
   'capture_upstream_request_failed',
   'capture_upstream_rejected',
   'capture_upstream_error_unmapped',
+  'health_cron_read_failed',
 ] as const;
 type WorkerFailureEvent = (typeof WORKER_FAILURE_EVENTS)[number];
 

--- a/web/src/lib/services/cron-health.ts
+++ b/web/src/lib/services/cron-health.ts
@@ -10,7 +10,9 @@
  * workerd なしで全分岐をテストできる。
  */
 
+import { ERROR_CODES } from '../contracts/api';
 import { postDiscordWebhook } from '../infra/discord-webhook';
+import { logWorkerFailure } from '../infra/worker-log';
 
 /** D1 の最小操作面。この監視が必要とするのは all / run だけ。 */
 export interface CronRunDatabase {
@@ -143,13 +145,76 @@ export function evaluateFreshness(now: Date, lastSuccessAt: string | null): Cron
   };
 }
 
-/** /api/health/ 用に、保持期間バッチの鮮度を読む。 */
+/** 保持期間バッチの鮮度を読む。D1 が失敗したらそのまま throw する。 */
 export async function readRetentionFreshness(
   database: CronRunDatabase,
   now: Date
 ): Promise<CronFreshness> {
   const row = await readRow(database, RETENTION_RUN_NAME);
   return evaluateFreshness(now, row?.last_success_at ?? null);
+}
+
+/** /api/health/ の cron セクション。鮮度が取れなければ取れなかったことだけを伝える。 */
+export type CronHealthSection = CronFreshness | { error: true };
+
+/**
+ * health の cron セクションを使い回す時間。
+ *
+ * /api/health/ は無認証で誰でも叩けるため、素通しだとリクエストごとに D1 read が発生する。
+ * バッチは毎時なので秒単位の鮮度は要らず、この程度の古さは判定に影響しない。
+ */
+export const CRON_HEALTH_CACHE_MS = 60_000;
+
+/**
+ * /api/health/ 用の読み取りを作る。D1 の失敗と binding の欠落は { error: true } に畳み、
+ * 結果を ttlMs の間だけ使い回す（呼び出し側が module スコープで 1 つ作れば isolate 単位のキャッシュになる）。
+ *
+ * health は 200 のまま返す。この応答はデプロイの疎通確認にも使われるため、監視の付帯情報が
+ * 取れないことを理由に 500 を返すと正常なデプロイをロールバックさせてしまう。握り潰さず、
+ * 失敗そのものは worker-log に残して observability から追えるようにする。
+ *
+ * 失敗もキャッシュする（D1 障害時にリクエストごとの read とログを増やさないため。
+ * 復旧の反映は最大 ttlMs 遅れるが、毎時のバッチの監視では問題にならない）。
+ */
+export function createCronHealthReader(
+  ttlMs: number = CRON_HEALTH_CACHE_MS
+): (database: CronRunDatabase | undefined, now: Date) => Promise<CronHealthSection> {
+  let cached: { atMs: number; section: CronHealthSection } | null = null;
+
+  return async (database, now) => {
+    if (cached !== null && now.getTime() - cached.atMs < ttlMs) return cached.section;
+
+    const section = await readSection(database, now);
+    cached = { atMs: now.getTime(), section };
+    return section;
+  };
+}
+
+async function readSection(
+  database: CronRunDatabase | undefined,
+  now: Date
+): Promise<CronHealthSection> {
+  if (database !== undefined) {
+    try {
+      return await readRetentionFreshness(database, now);
+    } catch {
+      logHealthReadFailure();
+      return { error: true };
+    }
+  }
+
+  // binding が無いのは設定の誤り。静かに「鮮度不明」で流さず記録する。
+  logHealthReadFailure();
+  return { error: true };
+}
+
+function logHealthReadFailure(): void {
+  logWorkerFailure({
+    event: 'health_cron_read_failed',
+    errorCode: ERROR_CODES.internalError,
+    // 応答は 200 のまま返すので status も 200。ログ上で「落ちていないが欠けている」と読める。
+    status: 200,
+  });
 }
 
 /**

--- a/web/src/lib/services/cron-health.ts
+++ b/web/src/lib/services/cron-health.ts
@@ -1,0 +1,268 @@
+/**
+ * cron の死活監視（dead-man's switch）。
+ *
+ * 保持期間バッチは失敗しても「そもそも発火しなくなっても」誰も気づけなかった。
+ * 成功のたびに D1 へ時刻と件数を残し、別の cron がその鮮度を見て通知する。
+ * 「実行されたか」ではなく「結果が残ったか」で検証できる形にするのが目的。
+ *
+ * D1 も通知の送信もインターフェースで注入し、現在時刻は引数で受け取る
+ * （Date.now を呼ぶのは cron の entry 層だけ）。判定は純関数に切り出してあるので、
+ * workerd なしで全分岐をテストできる。
+ */
+
+import { postDiscordWebhook } from '../infra/discord-webhook';
+
+/** D1 の最小操作面。この監視が必要とするのは all / run だけ。 */
+export interface CronRunDatabase {
+  prepare(query: string): {
+    bind(...values: unknown[]): {
+      all<T>(): Promise<{ results: T[] }>;
+      run(): Promise<{ meta: { changes: number } }>;
+    };
+  };
+}
+
+/** 保持期間バッチ本体の実行記録を持つ行。 */
+export const RETENTION_RUN_NAME = 'retention';
+
+/** 保持期間バッチの通知状態を持つ行（連投防止と回復通知に使う）。 */
+export const RETENTION_ALERT_NAME = 'retention-alert';
+
+/**
+ * 最終成功からこれを超えたら停止とみなす。
+ *
+ * バッチは毎時 1 回なので「2 回連続で発火しなかった」= 2 時間空く。Cloudflare 側の
+ * スケジュール遅延を 15 分見込んで足し、1 回落ちただけでは鳴らないようにしている
+ * （毎時のジョブで閾値を 2 時間ちょうどにすると、遅延だけで誤報が出る）。
+ */
+export const CRON_STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000 + 15 * 60 * 1000;
+
+/**
+ * 同じ停止状態で再通知するまでの間隔。復旧できない障害でチャンネルを毎時
+ * 埋めないための連投防止。回復通知はこの間隔に関係なく 1 回だけ出す。
+ */
+export const CRON_REALERT_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** cron_runs の 1 行（列名は D1 のまま）。 */
+interface CronRunRow {
+  last_success_at: string;
+  last_summary: string | null;
+}
+
+/** 通知側の行が持つ状態。 */
+export type CronAlertState = 'alerting' | 'recovered';
+
+/** 直近の通知（送った時刻とその時の状態）。 */
+export interface CronAlertRecord {
+  at: Date;
+  state: CronAlertState;
+}
+
+/** 通知するかどうかの判定結果。 */
+export type CronAlertDecision = 'none' | 'alert' | 'recovered';
+
+/** /api/health/ がそのまま載せる鮮度。 */
+export interface CronFreshness {
+  /** 最後に成功した実行の基準時刻（ISO8601）。記録が無い・壊れていれば null。 */
+  lastSuccessAt: string | null;
+  ageSeconds: number | null;
+  stale: boolean;
+}
+
+/** 通知の送信境界。送れたかどうかだけを返し、例外は出さない（通知の失敗で cron を落とさない）。 */
+export type CronAlertNotifier = (message: string) => Promise<boolean>;
+
+/**
+ * 既定の通知先（Discord の webhook）。
+ *
+ * cron の entry 層は infra を直接叩けない（docs/architecture-contract.toml）ため、
+ * 送信先の組み立てはここで行い、entry へは CronAlertNotifier だけを渡す。
+ */
+export function createDiscordNotifier(webhookUrl: string): CronAlertNotifier {
+  return (message) => postDiscordWebhook(webhookUrl, message);
+}
+
+/**
+ * D1 に混在しうる 2 つの時刻形式（ISO8601 と `YYYY-MM-DD HH:MM:SS`）を UTC として解く。
+ * 後者をそのまま Date.parse に渡すと実行環境のローカル時刻として解釈され、UTC で動く
+ * workerd と手元の bun test で結果がずれる。
+ */
+function parseUtc(value: string): number {
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+  return Date.parse(/[Z+]|-\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`);
+}
+
+/** cron_runs の 1 行を取る。行が無ければ null。 */
+async function readRow(database: CronRunDatabase, name: string): Promise<CronRunRow | null> {
+  const { results } = await database
+    .prepare('SELECT last_success_at, last_summary FROM cron_runs WHERE name = ?')
+    .bind(name)
+    .all<CronRunRow>();
+  return results[0] ?? null;
+}
+
+/**
+ * ジョブの成功を記録する。同じ name の行を上書きするので履歴は残らない
+ * （履歴が要る用途は Cloudflare 側の実行ログが持つ。ここは「最後に成功したのはいつか」だけ）。
+ */
+export async function recordCronRun(input: {
+  database: CronRunDatabase;
+  name: string;
+  at: Date;
+  summary: unknown;
+}): Promise<void> {
+  await input.database
+    .prepare(
+      `INSERT INTO cron_runs (name, last_success_at, last_summary) VALUES (?, ?, ?)
+       ON CONFLICT(name) DO UPDATE SET
+         last_success_at = excluded.last_success_at,
+         last_summary = excluded.last_summary`
+    )
+    .bind(input.name, input.at.toISOString(), JSON.stringify(input.summary))
+    .run();
+}
+
+/**
+ * 記録されている時刻から鮮度を出す。
+ *
+ * 記録が無い（初回デプロイ直後・テーブルを作った直後）場合と、値が壊れている場合は
+ * どちらも stale にする。「読めないので分からない」を正常扱いにすると、監視自体が
+ * 静かに死ぬため。
+ */
+export function evaluateFreshness(now: Date, lastSuccessAt: string | null): CronFreshness {
+  if (lastSuccessAt === null) return { lastSuccessAt: null, ageSeconds: null, stale: true };
+
+  const parsed = parseUtc(lastSuccessAt);
+  if (Number.isNaN(parsed)) return { lastSuccessAt: null, ageSeconds: null, stale: true };
+
+  const ageMs = now.getTime() - parsed;
+  return {
+    lastSuccessAt: new Date(parsed).toISOString(),
+    ageSeconds: Math.floor(ageMs / 1000),
+    stale: ageMs > CRON_STALE_THRESHOLD_MS,
+  };
+}
+
+/** /api/health/ 用に、保持期間バッチの鮮度を読む。 */
+export async function readRetentionFreshness(
+  database: CronRunDatabase,
+  now: Date
+): Promise<CronFreshness> {
+  const row = await readRow(database, RETENTION_RUN_NAME);
+  return evaluateFreshness(now, row?.last_success_at ?? null);
+}
+
+/**
+ * 通知するかを決める（純関数）。
+ *
+ * - 停止中: 前回が通知済みで再通知の間隔内なら黙る。それ以外は通知する
+ * - 正常時: 直前が停止通知だった時だけ「回復」を 1 回出す
+ */
+export function decideCronAlert(input: {
+  now: Date;
+  stale: boolean;
+  lastAlert: CronAlertRecord | null;
+}): CronAlertDecision {
+  const { now, stale, lastAlert } = input;
+
+  if (!stale) return lastAlert?.state === 'alerting' ? 'recovered' : 'none';
+
+  if (lastAlert?.state === 'alerting') {
+    const sinceLast = now.getTime() - lastAlert.at.getTime();
+    return sinceLast < CRON_REALERT_INTERVAL_MS ? 'none' : 'alert';
+  }
+  return 'alert';
+}
+
+/** 通知側の行を CronAlertRecord に直す。読めない行は「通知していない」として扱う。 */
+function parseAlertRecord(row: CronRunRow | null): CronAlertRecord | null {
+  if (row === null) return null;
+
+  const at = parseUtc(row.last_success_at);
+  if (Number.isNaN(at)) return null;
+
+  const state = row.last_summary === null ? null : readState(row.last_summary);
+  if (state === null) return null;
+
+  return { at: new Date(at), state };
+}
+
+function readState(summary: string): CronAlertState | null {
+  try {
+    const parsed: unknown = JSON.parse(summary);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const state = (parsed as { state?: unknown }).state;
+    return state === 'alerting' || state === 'recovered' ? state : null;
+  } catch {
+    // 壊れた JSON は「状態不明」= 未通知として扱う（次の判定で改めて通知する）。
+    return null;
+  }
+}
+
+/** 経過時間を日本語 1 語にする（通知文面用）。 */
+function formatAge(ageSeconds: number | null): string {
+  if (ageSeconds === null) return '不明';
+
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) return `${minutes} 分`;
+  return `${Math.floor(minutes / 60)} 時間 ${minutes % 60} 分`;
+}
+
+/** 通知の本文。値そのものは載せず、いつ・どれだけ止まっているかだけを日本語で書く。 */
+export function buildAlertMessage(input: {
+  decision: 'alert' | 'recovered';
+  freshness: CronFreshness;
+}): string {
+  const { decision, freshness } = input;
+  const last =
+    freshness.lastSuccessAt === null
+      ? '最終成功: 記録なし'
+      : `最終成功: ${freshness.lastSuccessAt}（${formatAge(freshness.ageSeconds)}前）`;
+
+  if (decision === 'recovered') {
+    return `[回復] WebScreen の保持期間バッチ（webscreen-beta-cron）が再び成功しました。\n${last}`;
+  }
+  return `[警告] WebScreen の保持期間バッチ（webscreen-beta-cron）が停止している可能性があります。期限切れの動画・キャプチャが消えずに溜まり続けます。\n${last}`;
+}
+
+/** 監視 cron の実行結果（entry 層の構造化ログにそのまま載せる）。 */
+export interface CronAlertResult {
+  decision: CronAlertDecision;
+  freshness: CronFreshness;
+  /** 通知を送ろうとして送れなかったか。true なら状態を記録せず次回に再送する。 */
+  notifyFailed: boolean;
+}
+
+/**
+ * 保持期間バッチの鮮度を見て、必要なら通知する。
+ *
+ * 送信に失敗した時は状態を記録しない。記録してしまうと「送ったつもり」で
+ * 再通知の間隔に入り、次の 6 時間が無音になる。
+ */
+export async function runRetentionAlert(input: {
+  database: CronRunDatabase;
+  now: Date;
+  notify: CronAlertNotifier;
+}): Promise<CronAlertResult> {
+  const { database, now, notify } = input;
+
+  const freshness = evaluateFreshness(
+    now,
+    (await readRow(database, RETENTION_RUN_NAME))?.last_success_at ?? null
+  );
+  const lastAlert = parseAlertRecord(await readRow(database, RETENTION_ALERT_NAME));
+  const decision = decideCronAlert({ now, stale: freshness.stale, lastAlert });
+
+  if (decision === 'none') return { decision, freshness, notifyFailed: false };
+
+  const delivered = await notify(buildAlertMessage({ decision, freshness }));
+  if (!delivered) return { decision, freshness, notifyFailed: true };
+
+  await recordCronRun({
+    database,
+    name: RETENTION_ALERT_NAME,
+    at: now,
+    summary: { state: decision === 'alert' ? 'alerting' : 'recovered' },
+  });
+  return { decision, freshness, notifyFailed: false };
+}

--- a/web/src/pages/api/health.ts
+++ b/web/src/pages/api/health.ts
@@ -2,8 +2,7 @@ import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 
 import {
-  readRetentionFreshness,
-  type CronFreshness,
+  createCronHealthReader,
   type CronRunDatabase,
 } from '../../lib/services/cron-health';
 
@@ -21,34 +20,11 @@ interface HealthBindings {
   DB?: CronRunDatabase;
 }
 
-/** cron の鮮度。D1 を読めなかった時は健全性の判断材料が無いことだけを伝える。 */
-type CronSection = CronFreshness | { error: true };
-
 /**
- * 保持期間バッチの鮮度を読む。失敗しても health 全体は落とさない。
- *
- * この応答はデプロイの疎通確認にも使われるため、監視の付帯情報が取れないことを
- * 理由に 500 を返すと、正常なデプロイをロールバックさせてしまう。握り潰さずログには残す。
+ * module スコープで作ることで isolate 単位のキャッシュになる。この経路は無認証なので、
+ * 素通しだとリクエストごとに D1 read が走る（バッチは毎時なので秒単位の鮮度は要らない）。
  */
-async function readCronSection(database: CronRunDatabase | undefined): Promise<CronSection> {
-  if (database === undefined) return { error: true };
-
-  try {
-    return await readRetentionFreshness(database, new Date());
-  } catch {
-    console.error(
-      JSON.stringify({
-        timestamp: new Date().toISOString(),
-        source: 'webscreen-beta-worker',
-        severity: 'error',
-        kind: 'event',
-        event: 'health_cron_read_failed',
-        summary: 'Failed to read cron_runs for the health response.',
-      })
-    );
-    return { error: true };
-  }
-}
+const readCronSection = createCronHealthReader();
 
 /**
  * 応答に自分のバージョンと cron の鮮度を含める。
@@ -64,7 +40,7 @@ async function readCronSection(database: CronRunDatabase | undefined): Promise<C
 export const GET: APIRoute = async () => {
   const bindings = env as unknown as HealthBindings;
   const version = bindings.CF_VERSION_METADATA?.id ?? null;
-  const cron = await readCronSection(bindings.DB);
+  const cron = await readCronSection(bindings.DB, new Date());
 
   return new Response(JSON.stringify({ status: 'ok', version, cron }), {
     status: 200,

--- a/web/src/pages/api/health.ts
+++ b/web/src/pages/api/health.ts
@@ -1,6 +1,12 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 
+import {
+  readRetentionFreshness,
+  type CronFreshness,
+  type CronRunDatabase,
+} from '../../lib/services/cron-health';
+
 // SSR 経路の疎通確認用。middleware が付ける COOP/COEP の実測点も兼ねる
 // （prerender=true だと静的化され Worker を通らないため false 固定）。
 export const prerender = false;
@@ -12,20 +18,55 @@ interface VersionMetadata {
 
 interface HealthBindings {
   CF_VERSION_METADATA?: VersionMetadata;
+  DB?: CronRunDatabase;
+}
+
+/** cron の鮮度。D1 を読めなかった時は健全性の判断材料が無いことだけを伝える。 */
+type CronSection = CronFreshness | { error: true };
+
+/**
+ * 保持期間バッチの鮮度を読む。失敗しても health 全体は落とさない。
+ *
+ * この応答はデプロイの疎通確認にも使われるため、監視の付帯情報が取れないことを
+ * 理由に 500 を返すと、正常なデプロイをロールバックさせてしまう。握り潰さずログには残す。
+ */
+async function readCronSection(database: CronRunDatabase | undefined): Promise<CronSection> {
+  if (database === undefined) return { error: true };
+
+  try {
+    return await readRetentionFreshness(database, new Date());
+  } catch {
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        source: 'webscreen-beta-worker',
+        severity: 'error',
+        kind: 'event',
+        event: 'health_cron_read_failed',
+        summary: 'Failed to read cron_runs for the health response.',
+      })
+    );
+    return { error: true };
+  }
 }
 
 /**
- * 応答に自分のバージョンを含める。
+ * 応答に自分のバージョンと cron の鮮度を含める。
  *
  * デプロイ直後の疎通確認は、200 が返るだけでは「新しい版が配信されている」ことの
  * 証明にならない（旧版が生きていても 200 を返す）。CI はこの id とデプロイ結果の
  * バージョン ID を突き合わせて反映を判定する。
+ *
+ * cron は保持期間バッチの最終成功からの経過。Cloudflare のダッシュボードを人が
+ * 見に行かなくても、この 1 本で「バッチが動いているか」を外から確認できる。
+ * status / version の形は CI の疎通確認が文字列で見ているので変えない。
  */
-export const GET: APIRoute = () => {
+export const GET: APIRoute = async () => {
   const bindings = env as unknown as HealthBindings;
   const version = bindings.CF_VERSION_METADATA?.id ?? null;
+  const cron = await readCronSection(bindings.DB);
 
-  return new Response(JSON.stringify({ status: 'ok', version }), {
+  return new Response(JSON.stringify({ status: 'ok', version, cron }), {
     status: 200,
     headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
   });

--- a/web/tests/cron/alert-worker.test.ts
+++ b/web/tests/cron/alert-worker.test.ts
@@ -33,7 +33,8 @@ class FakeCronRunsDatabase implements CronRunDatabase {
           return { results: row === undefined ? [] : ([row] as T[]) };
         },
         run: async (): Promise<{ meta: { changes: number } }> => {
-          if (!query.includes('INSERT INTO cron_runs')) throw new Error(`unexpected: ${query}`);
+          // cron_runs 以外（保持期間バッチの UPDATE / DELETE）は「対象 0 件」で素通しする。
+          if (!query.includes('INSERT INTO cron_runs')) return { meta: { changes: 0 } };
           this.rows.set(values[0] as string, {
             last_success_at: values[1] as string,
             last_summary: values[2] as string | null,
@@ -46,7 +47,10 @@ class FakeCronRunsDatabase implements CronRunDatabase {
 }
 
 interface ScheduledRun {
-  logs: { level: 'log' | 'warn' | 'error'; entry: { severity: string; summary: string } }[];
+  logs: {
+    level: 'log' | 'warn' | 'error';
+    entry: { severity: string; summary: string; cron: string };
+  }[];
   posts: { url: string; content: string }[];
 }
 
@@ -74,10 +78,17 @@ async function runScheduled(
     return new Response(null, { status: 204 });
   }) as typeof globalThis.fetch;
 
+  // 掃除対象が無い R2（fail-open で retention 側へ落ちる分岐でも動くようにする）。
+  const bucket = {
+    head: async () => null,
+    delete: async () => {},
+    list: async () => ({ objects: [], truncated: false }),
+  };
+
   try {
     await worker.scheduled({ scheduledTime: SCHEDULED_TIME, cron }, {
       DB: database,
-      BUCKET: {} as never,
+      BUCKET: bucket,
       DISCORD_ALERT_WEBHOOK_URL: env.webhookUrl,
     } as never);
   } finally {
@@ -161,15 +172,30 @@ describe('監視 cron（47 分）', () => {
   });
 });
 
-describe('未知の cron 式', () => {
-  test('どちらのハンドラも呼ばず error を残す', async () => {
+describe('cron 式の振り分け', () => {
+  test('空白がゆれていても監視 cron として扱う', async () => {
+    const database = new FakeCronRunsDatabase({
+      [RETENTION_RUN_NAME]: {
+        last_success_at: new Date(SCHEDULED_TIME - 3 * HOUR_MS).toISOString(),
+        last_summary: '{}',
+      },
+    });
+
+    const run = await runScheduled('  47   *  *  *  * ', database);
+
+    expect(run.posts).toHaveLength(1);
+    expect(run.logs[0]!.entry.cron).toBe('47 * * * *');
+  });
+
+  test('未知の式は error を残しつつ保持期間バッチを実行する（掃除を止めない）', async () => {
     const database = new FakeCronRunsDatabase();
 
     const run = await runScheduled('0 3 * * *', database);
 
     expect(run.posts).toHaveLength(0);
-    expect(database.rows.size).toBe(0);
     expect(run.logs[0]!.level).toBe('error');
     expect(run.logs[0]!.entry.summary).toContain('No handler is registered');
+    // fail-open: 掃除は走り、実行記録も残る。
+    expect(database.rows.has(RETENTION_RUN_NAME)).toBe(true);
   });
 });

--- a/web/tests/cron/alert-worker.test.ts
+++ b/web/tests/cron/alert-worker.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test';
+
+import worker from '../../cron/src/index';
+import {
+  RETENTION_ALERT_NAME,
+  RETENTION_RUN_NAME,
+  type CronRunDatabase,
+} from '../../src/lib/services/cron-health';
+
+const SCHEDULED_TIME = Date.parse('2026-08-31T12:47:00.000Z');
+const HOUR_MS = 60 * 60 * 1000;
+const ALERT_CRON = '47 * * * *';
+const WEBHOOK_URL = 'https://discord.example/api/webhooks/1/token-placeholder';
+
+interface StoredRow {
+  last_success_at: string;
+  last_summary: string | null;
+}
+
+/** cron_runs だけを持つ D1 のフェイク（監視 cron は他のテーブルを触らない）。 */
+class FakeCronRunsDatabase implements CronRunDatabase {
+  readonly rows = new Map<string, StoredRow>();
+
+  constructor(rows: Record<string, StoredRow> = {}) {
+    for (const [name, row] of Object.entries(rows)) this.rows.set(name, row);
+  }
+
+  prepare(query: string) {
+    return {
+      bind: (...values: unknown[]) => ({
+        all: async <T>(): Promise<{ results: T[] }> => {
+          const row = this.rows.get(values[0] as string);
+          return { results: row === undefined ? [] : ([row] as T[]) };
+        },
+        run: async (): Promise<{ meta: { changes: number } }> => {
+          if (!query.includes('INSERT INTO cron_runs')) throw new Error(`unexpected: ${query}`);
+          this.rows.set(values[0] as string, {
+            last_success_at: values[1] as string,
+            last_summary: values[2] as string | null,
+          });
+          return { meta: { changes: 1 } };
+        },
+      }),
+    };
+  }
+}
+
+interface ScheduledRun {
+  logs: { level: 'log' | 'warn' | 'error'; entry: { severity: string; summary: string } }[];
+  posts: { url: string; content: string }[];
+}
+
+/**
+ * scheduled() を叩き、出た構造化ログと webhook への POST を取る。
+ *
+ * fetch を差し替えるのはプロセス外境界（Discord）なので、実ネットワークは使わない。
+ */
+async function runScheduled(
+  cron: string,
+  database: CronRunDatabase,
+  env: { webhookUrl?: string } = { webhookUrl: WEBHOOK_URL }
+): Promise<ScheduledRun> {
+  const logs: ScheduledRun['logs'] = [];
+  const posts: ScheduledRun['posts'] = [];
+  const originals = { log: console.log, warn: console.warn, error: console.error };
+  const originalFetch = globalThis.fetch;
+
+  console.log = (entry: unknown) => logs.push({ level: 'log', entry: JSON.parse(String(entry)) });
+  console.warn = (entry: unknown) => logs.push({ level: 'warn', entry: JSON.parse(String(entry)) });
+  console.error = (entry: unknown) =>
+    logs.push({ level: 'error', entry: JSON.parse(String(entry)) });
+  globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    posts.push({ url: String(url), content: JSON.parse(String(init?.body)).content });
+    return new Response(null, { status: 204 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    await worker.scheduled({ scheduledTime: SCHEDULED_TIME, cron }, {
+      DB: database,
+      BUCKET: {} as never,
+      DISCORD_ALERT_WEBHOOK_URL: env.webhookUrl,
+    } as never);
+  } finally {
+    console.log = originals.log;
+    console.warn = originals.warn;
+    console.error = originals.error;
+    globalThis.fetch = originalFetch;
+  }
+
+  return { logs, posts };
+}
+
+describe('監視 cron（47 分）', () => {
+  test('2 回連続で発火していなければ Discord へ 1 回通知する', async () => {
+    const database = new FakeCronRunsDatabase({
+      [RETENTION_RUN_NAME]: {
+        last_success_at: new Date(SCHEDULED_TIME - 3 * HOUR_MS).toISOString(),
+        last_summary: '{}',
+      },
+    });
+
+    const run = await runScheduled(ALERT_CRON, database);
+
+    expect(run.posts).toHaveLength(1);
+    expect(run.posts[0]!.url).toBe(WEBHOOK_URL);
+    expect(run.posts[0]!.content).toContain('[警告]');
+    expect(run.logs[0]!.level).toBe('warn');
+    expect(database.rows.get(RETENTION_ALERT_NAME)?.last_summary).toBe('{"state":"alerting"}');
+  });
+
+  test('停止したまま連投防止で黙る回も warn で残す（info だと正常に見える）', async () => {
+    const database = new FakeCronRunsDatabase({
+      [RETENTION_RUN_NAME]: {
+        last_success_at: new Date(SCHEDULED_TIME - 3 * HOUR_MS).toISOString(),
+        last_summary: '{}',
+      },
+      [RETENTION_ALERT_NAME]: {
+        last_success_at: new Date(SCHEDULED_TIME - HOUR_MS).toISOString(),
+        last_summary: '{"state":"alerting"}',
+      },
+    });
+
+    const run = await runScheduled(ALERT_CRON, database);
+
+    expect(run.posts).toHaveLength(0);
+    expect(run.logs[0]!.level).toBe('warn');
+  });
+
+  test('直前に成功していれば通知せず info を残す', async () => {
+    const database = new FakeCronRunsDatabase({
+      [RETENTION_RUN_NAME]: {
+        last_success_at: new Date(SCHEDULED_TIME - 30 * 60_000).toISOString(),
+        last_summary: '{}',
+      },
+    });
+
+    const run = await runScheduled(ALERT_CRON, database);
+
+    expect(run.posts).toHaveLength(0);
+    expect(run.logs[0]!.level).toBe('log');
+    expect(run.logs[0]!.entry.severity).toBe('info');
+  });
+
+  test('通知先が未設定なら送信せず、通知済みにもしない', async () => {
+    const database = new FakeCronRunsDatabase({
+      [RETENTION_RUN_NAME]: {
+        last_success_at: new Date(SCHEDULED_TIME - 3 * HOUR_MS).toISOString(),
+        last_summary: '{}',
+      },
+    });
+
+    const run = await runScheduled(ALERT_CRON, database, { webhookUrl: undefined });
+
+    expect(run.posts).toHaveLength(0);
+    expect(run.logs.some((entry) => entry.entry.summary.includes('DISCORD_ALERT_WEBHOOK_URL'))).toBe(
+      true
+    );
+    // 送れていないので記録も残さない（次の実行で送り直せる）。
+    expect(database.rows.has(RETENTION_ALERT_NAME)).toBe(false);
+    expect(run.logs.some((entry) => entry.level === 'error')).toBe(true);
+  });
+});
+
+describe('未知の cron 式', () => {
+  test('どちらのハンドラも呼ばず error を残す', async () => {
+    const database = new FakeCronRunsDatabase();
+
+    const run = await runScheduled('0 3 * * *', database);
+
+    expect(run.posts).toHaveLength(0);
+    expect(database.rows.size).toBe(0);
+    expect(run.logs[0]!.level).toBe('error');
+    expect(run.logs[0]!.entry.summary).toContain('No handler is registered');
+  });
+});

--- a/web/tests/cron/retention-worker.test.ts
+++ b/web/tests/cron/retention-worker.test.ts
@@ -16,6 +16,9 @@ const SCHEDULED_TIME = Date.parse('2026-08-25T12:00:00.000Z');
  * すべて空で返し、監査のサンプル抽出だけが行を返す形にする。
  */
 class FakeCronDatabase implements RetentionDatabase {
+  /** cron_runs へ書かれた実行記録（name, 時刻, 件数 JSON）。 */
+  readonly cronRuns: { name: string; at: string; summary: string }[] = [];
+
   constructor(private readonly readyRows: string[] = []) {}
 
   prepare(query: string) {
@@ -24,7 +27,16 @@ class FakeCronDatabase implements RetentionDatabase {
         all: async <T>(): Promise<{ results: T[] }> => ({
           results: this.select(query, values) as T[],
         }),
-        run: async (): Promise<{ meta: { changes: number } }> => ({ meta: { changes: 0 } }),
+        run: async (): Promise<{ meta: { changes: number } }> => {
+          if (query.includes('INSERT INTO cron_runs')) {
+            this.cronRuns.push({
+              name: values[0] as string,
+              at: values[1] as string,
+              summary: values[2] as string,
+            });
+          }
+          return { meta: { changes: 0 } };
+        },
       }),
     };
   }
@@ -78,6 +90,7 @@ async function runScheduled(
   database: RetentionDatabase,
   bucket: RetentionBucket = new FakeCronBucket()
 ): Promise<{ level: 'log' | 'warn' | 'error'; entry: CronLogEntry }> {
+  // cron 式は index.ts の RETENTION_CRON と一致させる（違う式は未知の式として弾かれる）。
   const original = { log: console.log, warn: console.warn, error: console.error };
   let captured: { level: 'log' | 'warn' | 'error'; entry: CronLogEntry } | undefined;
   const capture =
@@ -91,7 +104,7 @@ async function runScheduled(
 
   try {
     await worker.scheduled(
-      { scheduledTime: SCHEDULED_TIME, cron: '0 * * * *' },
+      { scheduledTime: SCHEDULED_TIME, cron: '17 * * * *' },
       { DB: database, BUCKET: bucket }
     );
   } finally {
@@ -134,5 +147,17 @@ describe('保持期間バッチの cron ログ', () => {
     expect(entry.summary).toContain('audited 0 ready rows (0 missing objects)');
     expect(entry.summary).not.toContain('rows skipped');
     expect(entry.detail.skippedRows).toBe(0);
+  });
+
+  it('成功したら最終成功時刻と直近の件数を cron_runs に残す', async () => {
+    // ここが残らないと死活監視（47 分の cron）からは止まって見える。
+    const database = new FakeCronDatabase();
+
+    await runScheduled(database);
+
+    expect(database.cronRuns).toHaveLength(1);
+    expect(database.cronRuns[0]!.name).toBe('retention');
+    expect(database.cronRuns[0]!.at).toBe(new Date(SCHEDULED_TIME).toISOString());
+    expect(JSON.parse(database.cronRuns[0]!.summary).checkedReadyRows).toBe(0);
   });
 });

--- a/web/tests/infra/discord-webhook.test.ts
+++ b/web/tests/infra/discord-webhook.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+
+import { postDiscordWebhook } from '../../src/lib/infra/discord-webhook';
+
+const WEBHOOK_URL = 'https://discord.example/api/webhooks/1/token-placeholder';
+
+/** console.error を差し替えて、出力された 1 行 JSON を取る。 */
+async function captureErrorLogs(run: () => Promise<void>): Promise<string[]> {
+  const original = console.error;
+  const entries: string[] = [];
+  console.error = (entry: unknown) => {
+    entries.push(String(entry));
+  };
+  try {
+    await run();
+  } finally {
+    console.error = original;
+  }
+  return entries;
+}
+
+describe('postDiscordWebhook', () => {
+  test('本文を JSON の content として POST し、成功なら true', async () => {
+    let seen: { url: string; init: RequestInit | undefined } | null = null;
+
+    const delivered = await postDiscordWebhook(WEBHOOK_URL, 'バッチが停止しています', (url, init) => {
+      seen = { url: String(url), init };
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    expect(delivered).toBe(true);
+    expect(seen!.url).toBe(WEBHOOK_URL);
+    expect(seen!.init?.method).toBe('POST');
+    expect(JSON.parse(String(seen!.init?.body))).toEqual({ content: 'バッチが停止しています' });
+  });
+
+  test('Discord が拒否したら false を返し、例外にしない', async () => {
+    let delivered = true;
+    const logs = await captureErrorLogs(async () => {
+      delivered = await postDiscordWebhook(WEBHOOK_URL, 'x', () =>
+        Promise.resolve(new Response('rate limited', { status: 429 }))
+      );
+    });
+
+    expect(delivered).toBe(false);
+    expect(JSON.parse(logs[0]!).status).toBe(429);
+  });
+
+  test('ネットワーク障害でも false を返し、通知の失敗で呼び出し側を落とさない', async () => {
+    let delivered = true;
+    const logs = await captureErrorLogs(async () => {
+      delivered = await postDiscordWebhook(WEBHOOK_URL, 'x', () =>
+        Promise.reject(new Error(`connect failed to ${WEBHOOK_URL}`))
+      );
+    });
+
+    expect(delivered).toBe(false);
+    expect(logs).toHaveLength(1);
+  });
+
+  test('ログに webhook URL と例外メッセージを出さない', async () => {
+    // URL 自体が資格情報なので、fetch の失敗メッセージ経由でも漏らさない。
+    const logs = await captureErrorLogs(async () => {
+      await postDiscordWebhook(WEBHOOK_URL, 'x', () =>
+        Promise.reject(new Error(`connect failed to ${WEBHOOK_URL}`))
+      );
+    });
+
+    expect(logs[0]).not.toContain('token-placeholder');
+    expect(logs[0]).not.toContain('discord.example');
+    expect(logs[0]).not.toContain('connect failed');
+  });
+
+  test('Discord の上限を超える本文は切り詰めて送る', async () => {
+    let body = '';
+    await postDiscordWebhook(WEBHOOK_URL, 'あ'.repeat(2500), (_url, init) => {
+      body = String(init?.body);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    expect(JSON.parse(body).content).toHaveLength(2000);
+  });
+});

--- a/web/tests/infra/discord-webhook.test.ts
+++ b/web/tests/infra/discord-webhook.test.ts
@@ -71,6 +71,18 @@ describe('postDiscordWebhook', () => {
     expect(logs[0]).not.toContain('connect failed');
   });
 
+  test('応答が無い時に待ち続けないようタイムアウトを渡す', async () => {
+    let signal: AbortSignal | null | undefined;
+
+    await postDiscordWebhook(WEBHOOK_URL, 'x', (_url, init) => {
+      signal = init?.signal;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal!.aborted).toBe(false);
+  });
+
   test('Discord の上限を超える本文は切り詰めて送る', async () => {
     let body = '';
     await postDiscordWebhook(WEBHOOK_URL, 'あ'.repeat(2500), (_url, init) => {

--- a/web/tests/services/cron-health.test.ts
+++ b/web/tests/services/cron-health.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  CRON_REALERT_INTERVAL_MS,
+  CRON_STALE_THRESHOLD_MS,
+  buildAlertMessage,
+  decideCronAlert,
+  evaluateFreshness,
+  readRetentionFreshness,
+  recordCronRun,
+  RETENTION_ALERT_NAME,
+  RETENTION_RUN_NAME,
+  runRetentionAlert,
+  type CronRunDatabase,
+} from '../../src/lib/services/cron-health';
+
+const NOW = new Date('2026-08-31T12:00:00.000Z');
+const HOUR_MS = 60 * 60 * 1000;
+
+interface StoredRow {
+  last_success_at: string;
+  last_summary: string | null;
+}
+
+/** cron_runs だけを持つ D1 のフェイク（UPSERT は Map の上書きで再現する）。 */
+class FakeCronDatabase implements CronRunDatabase {
+  readonly rows = new Map<string, StoredRow>();
+
+  constructor(rows: Record<string, StoredRow> = {}) {
+    for (const [name, row] of Object.entries(rows)) this.rows.set(name, row);
+  }
+
+  prepare(query: string) {
+    return {
+      bind: (...values: unknown[]) => ({
+        all: async <T>(): Promise<{ results: T[] }> => {
+          const row = this.rows.get(values[0] as string);
+          return { results: row === undefined ? [] : ([row] as T[]) };
+        },
+        run: async (): Promise<{ meta: { changes: number } }> => {
+          if (!query.includes('INSERT INTO cron_runs')) throw new Error(`unexpected: ${query}`);
+          this.rows.set(values[0] as string, {
+            last_success_at: values[1] as string,
+            last_summary: values[2] as string | null,
+          });
+          return { meta: { changes: 1 } };
+        },
+      }),
+    };
+  }
+}
+
+/** 送った本文を控える通知先。delivered=false で送信失敗を再現する。 */
+function fakeNotifier(delivered = true): {
+  notify: (message: string) => Promise<boolean>;
+  messages: string[];
+} {
+  const messages: string[] = [];
+  return {
+    messages,
+    notify: async (message) => {
+      messages.push(message);
+      return delivered;
+    },
+  };
+}
+
+describe('recordCronRun', () => {
+  test('成功した実行の時刻と件数を残し、次の実行で上書きする', async () => {
+    const database = new FakeCronDatabase();
+
+    await recordCronRun({
+      database,
+      name: RETENTION_RUN_NAME,
+      at: NOW,
+      summary: { deletedMovies: 3, deletedCaptures: 7 },
+    });
+    await recordCronRun({
+      database,
+      name: RETENTION_RUN_NAME,
+      at: new Date(NOW.getTime() + HOUR_MS),
+      summary: { deletedMovies: 0, deletedCaptures: 1 },
+    });
+
+    const row = database.rows.get(RETENTION_RUN_NAME);
+    expect(row?.last_success_at).toBe('2026-08-31T13:00:00.000Z');
+    expect(JSON.parse(row?.last_summary ?? '{}')).toEqual({ deletedMovies: 0, deletedCaptures: 1 });
+    expect(database.rows.size).toBe(1);
+  });
+});
+
+describe('evaluateFreshness', () => {
+  test('直前に成功していれば stale ではなく、経過秒を返す', () => {
+    const result = evaluateFreshness(NOW, '2026-08-31T11:43:00.000Z');
+    expect(result).toEqual({
+      lastSuccessAt: '2026-08-31T11:43:00.000Z',
+      ageSeconds: 17 * 60,
+      stale: false,
+    });
+  });
+
+  test('1 回の不発火（閾値内）では stale にしない', () => {
+    const lastSuccess = new Date(NOW.getTime() - CRON_STALE_THRESHOLD_MS + 60_000);
+    expect(evaluateFreshness(NOW, lastSuccess.toISOString()).stale).toBe(false);
+  });
+
+  test('閾値を超えたら stale', () => {
+    const lastSuccess = new Date(NOW.getTime() - CRON_STALE_THRESHOLD_MS - 60_000);
+    expect(evaluateFreshness(NOW, lastSuccess.toISOString()).stale).toBe(true);
+  });
+
+  test('記録が無ければ stale（監視が動き出す前を正常扱いにしない）', () => {
+    expect(evaluateFreshness(NOW, null)).toEqual({
+      lastSuccessAt: null,
+      ageSeconds: null,
+      stale: true,
+    });
+  });
+
+  test('読めない値も stale にする', () => {
+    expect(evaluateFreshness(NOW, 'not-a-timestamp').stale).toBe(true);
+  });
+
+  test('SQLite の datetime 形式（Z 無し）も UTC として解釈する', () => {
+    // ローカル時刻として解釈されると、JST の手元では 9 時間ずれて stale 判定が変わる。
+    expect(evaluateFreshness(NOW, '2026-08-31 11:43:00')).toEqual({
+      lastSuccessAt: '2026-08-31T11:43:00.000Z',
+      ageSeconds: 17 * 60,
+      stale: false,
+    });
+  });
+});
+
+describe('decideCronAlert', () => {
+  const alerting = (agoMs: number) =>
+    ({ at: new Date(NOW.getTime() - agoMs), state: 'alerting' }) as const;
+
+  test('停止していて未通知なら通知する', () => {
+    expect(decideCronAlert({ now: NOW, stale: true, lastAlert: null })).toBe('alert');
+  });
+
+  test('通知済みで再送間隔の内側なら黙る', () => {
+    const lastAlert = alerting(CRON_REALERT_INTERVAL_MS - 60_000);
+    expect(decideCronAlert({ now: NOW, stale: true, lastAlert })).toBe('none');
+  });
+
+  test('再送間隔を過ぎたら再通知する', () => {
+    const lastAlert = alerting(CRON_REALERT_INTERVAL_MS + 60_000);
+    expect(decideCronAlert({ now: NOW, stale: true, lastAlert })).toBe('alert');
+  });
+
+  test('正常に戻ったら回復を通知する', () => {
+    expect(decideCronAlert({ now: NOW, stale: false, lastAlert: alerting(HOUR_MS) })).toBe(
+      'recovered'
+    );
+  });
+
+  test('回復を通知した後の正常時は何もしない', () => {
+    const lastAlert = { at: new Date(NOW.getTime() - HOUR_MS), state: 'recovered' } as const;
+    expect(decideCronAlert({ now: NOW, stale: false, lastAlert })).toBe('none');
+  });
+
+  test('一度も通知していない正常時は何もしない', () => {
+    expect(decideCronAlert({ now: NOW, stale: false, lastAlert: null })).toBe('none');
+  });
+});
+
+describe('buildAlertMessage', () => {
+  test('停止の通知に最終成功と経過時間を載せる', () => {
+    const message = buildAlertMessage({
+      decision: 'alert',
+      freshness: { lastSuccessAt: '2026-08-31T08:17:00.000Z', ageSeconds: 3 * 3600 + 43 * 60, stale: true },
+    });
+    expect(message).toContain('[警告]');
+    expect(message).toContain('2026-08-31T08:17:00.000Z');
+    expect(message).toContain('3 時間 43 分前');
+  });
+
+  test('記録が無い時は経過時間を数値で書かない', () => {
+    const message = buildAlertMessage({
+      decision: 'alert',
+      freshness: { lastSuccessAt: null, ageSeconds: null, stale: true },
+    });
+    expect(message).toContain('記録なし');
+    expect(message).not.toContain('NaN');
+  });
+
+  test('回復の通知は警告と区別できる', () => {
+    const message = buildAlertMessage({
+      decision: 'recovered',
+      freshness: { lastSuccessAt: '2026-08-31T11:47:00.000Z', ageSeconds: 13 * 60, stale: false },
+    });
+    expect(message).toContain('[回復]');
+    expect(message).toContain('13 分前');
+  });
+});
+
+describe('runRetentionAlert', () => {
+  const staleRow = {
+    last_success_at: new Date(NOW.getTime() - 3 * HOUR_MS).toISOString(),
+    last_summary: '{}',
+  };
+  const freshRow = {
+    last_success_at: new Date(NOW.getTime() - 13 * 60_000).toISOString(),
+    last_summary: '{}',
+  };
+
+  test('2 回連続で発火していなければ 1 回通知し、通知済みとして記録する', async () => {
+    const database = new FakeCronDatabase({ [RETENTION_RUN_NAME]: staleRow });
+    const notifier = fakeNotifier();
+
+    const result = await runRetentionAlert({ database, now: NOW, notify: notifier.notify });
+
+    expect(result.decision).toBe('alert');
+    expect(notifier.messages).toHaveLength(1);
+    expect(notifier.messages[0]).toContain('[警告]');
+    expect(database.rows.get(RETENTION_ALERT_NAME)).toEqual({
+      last_success_at: NOW.toISOString(),
+      last_summary: '{"state":"alerting"}',
+    });
+  });
+
+  test('同じ停止状態のまま再送間隔の内側なら送らない', async () => {
+    const database = new FakeCronDatabase({
+      [RETENTION_RUN_NAME]: staleRow,
+      [RETENTION_ALERT_NAME]: {
+        last_success_at: new Date(NOW.getTime() - HOUR_MS).toISOString(),
+        last_summary: '{"state":"alerting"}',
+      },
+    });
+    const notifier = fakeNotifier();
+
+    const result = await runRetentionAlert({ database, now: NOW, notify: notifier.notify });
+
+    expect(result.decision).toBe('none');
+    expect(notifier.messages).toHaveLength(0);
+  });
+
+  test('回復したら 1 回だけ回復を通知する', async () => {
+    const database = new FakeCronDatabase({
+      [RETENTION_RUN_NAME]: freshRow,
+      [RETENTION_ALERT_NAME]: {
+        last_success_at: new Date(NOW.getTime() - HOUR_MS).toISOString(),
+        last_summary: '{"state":"alerting"}',
+      },
+    });
+    const notifier = fakeNotifier();
+
+    const first = await runRetentionAlert({ database, now: NOW, notify: notifier.notify });
+    const second = await runRetentionAlert({
+      database,
+      now: new Date(NOW.getTime() + HOUR_MS),
+      notify: notifier.notify,
+    });
+
+    expect(first.decision).toBe('recovered');
+    expect(second.decision).toBe('none');
+    expect(notifier.messages).toHaveLength(1);
+    expect(notifier.messages[0]).toContain('[回復]');
+  });
+
+  test('送信に失敗したら通知済みにせず、次の実行で送り直す', async () => {
+    const database = new FakeCronDatabase({ [RETENTION_RUN_NAME]: staleRow });
+    const failing = fakeNotifier(false);
+
+    const first = await runRetentionAlert({ database, now: NOW, notify: failing.notify });
+    expect(first.notifyFailed).toBe(true);
+    expect(database.rows.has(RETENTION_ALERT_NAME)).toBe(false);
+
+    const succeeding = fakeNotifier();
+    const second = await runRetentionAlert({
+      database,
+      now: new Date(NOW.getTime() + HOUR_MS),
+      notify: succeeding.notify,
+    });
+    expect(second.decision).toBe('alert');
+    expect(succeeding.messages).toHaveLength(1);
+  });
+
+  test('実行記録がまったく無ければ停止として通知する', async () => {
+    const database = new FakeCronDatabase();
+    const notifier = fakeNotifier();
+
+    const result = await runRetentionAlert({ database, now: NOW, notify: notifier.notify });
+
+    expect(result.decision).toBe('alert');
+    expect(result.freshness.stale).toBe(true);
+    expect(notifier.messages[0]).toContain('記録なし');
+  });
+});
+
+describe('readRetentionFreshness', () => {
+  test('記録した直後の実行は stale ではない', async () => {
+    const database = new FakeCronDatabase();
+    await recordCronRun({
+      database,
+      name: RETENTION_RUN_NAME,
+      at: new Date(NOW.getTime() - 13 * 60_000),
+      summary: { deletedMovies: 1 },
+    });
+
+    const freshness = await readRetentionFreshness(database, NOW);
+
+    expect(freshness.stale).toBe(false);
+    expect(freshness.ageSeconds).toBe(13 * 60);
+    expect(freshness.lastSuccessAt).toBe('2026-08-31T11:47:00.000Z');
+  });
+});

--- a/web/tests/services/cron-health.test.ts
+++ b/web/tests/services/cron-health.test.ts
@@ -4,6 +4,7 @@ import {
   CRON_REALERT_INTERVAL_MS,
   CRON_STALE_THRESHOLD_MS,
   buildAlertMessage,
+  createCronHealthReader,
   decideCronAlert,
   evaluateFreshness,
   readRetentionFreshness,
@@ -286,6 +287,81 @@ describe('runRetentionAlert', () => {
     expect(result.decision).toBe('alert');
     expect(result.freshness.stale).toBe(true);
     expect(notifier.messages[0]).toContain('記録なし');
+  });
+});
+
+describe('createCronHealthReader', () => {
+  /** D1 が落ちている状況（prepare の時点で失敗する）。 */
+  const brokenDatabase: CronRunDatabase = {
+    prepare() {
+      throw new Error('D1 unavailable');
+    },
+  };
+
+  /** worker-log が出す 1 行 JSON を捨てつつ件数だけ数える。 */
+  async function countFailureLogs(run: () => Promise<void>): Promise<number> {
+    const original = console.error;
+    let count = 0;
+    console.error = () => {
+      count += 1;
+    };
+    try {
+      await run();
+    } finally {
+      console.error = original;
+    }
+    return count;
+  }
+
+  test('D1 が失敗しても例外にせず error セクションを返し、失敗を記録する', async () => {
+    const read = createCronHealthReader(0);
+    let section: unknown;
+
+    const logs = await countFailureLogs(async () => {
+      section = await read(brokenDatabase, NOW);
+    });
+
+    expect(section).toEqual({ error: true });
+    expect(logs).toBe(1);
+  });
+
+  test('DB binding が無い時も error セクションを返す（設定漏れを静かに流さない）', async () => {
+    const read = createCronHealthReader(0);
+    let section: unknown;
+
+    const logs = await countFailureLogs(async () => {
+      section = await read(undefined, NOW);
+    });
+
+    expect(section).toEqual({ error: true });
+    expect(logs).toBe(1);
+  });
+
+  test('TTL の内側は D1 を読み直さない（無認証の経路で read を増やさない）', async () => {
+    let reads = 0;
+    const database: CronRunDatabase = {
+      prepare: () => ({
+        bind: () => ({
+          all: async <T>(): Promise<{ results: T[] }> => {
+            reads += 1;
+            return {
+              results: [
+                { last_success_at: new Date(NOW.getTime() - 60_000).toISOString(), last_summary: null },
+              ] as T[],
+            };
+          },
+          run: async () => ({ meta: { changes: 0 } }),
+        }),
+      }),
+    };
+    const read = createCronHealthReader(60_000);
+
+    await read(database, NOW);
+    await read(database, new Date(NOW.getTime() + 30_000));
+    expect(reads).toBe(1);
+
+    await read(database, new Date(NOW.getTime() + 61_000));
+    expect(reads).toBe(2);
   });
 });
 


### PR DESCRIPTION
## なぜこの変更が必要か

保持期間バッチ（cron）は失敗しても、そもそも発火しなくなっても誰にも通知されず、Cloudflare のダッシュボードを人が見に行くまで気づけなかった。止まると期限切れ動画・pending の残骸・古いキャプチャが溜まり続け、ストレージのコストとして現れるまで発覚しない（Issue #69）。

## 変更内容

- migration `0002_cron_runs.sql`（追加のみ）: `cron_runs(name, last_success_at, last_summary)`。保持期間バッチの成功ごとに `retention` 行を UPSERT し、`last_summary` に直近の件数 JSON を残す
- `GET /api/health/` に `cron: { lastSuccessAt, ageSeconds, stale }` を追加（`status` / `version` は不変。D1 失敗時は `cron: { error: true }` で 200 のまま。isolate グローバルで 60 秒メモ化）
- cron Worker に 2 本目の trigger `47 * * * *`（dead-man's switch）。`retention` の最終成功から 2 時間 15 分を超えていれば Discord webhook（secret `DISCORD_ALERT_WEBHOOK_URL`、cron Worker に投入済み）へ通知。再送は 6 時間に 1 回、回復時に 1 回。送信失敗は記録せず次回再送（無音化しない）
- `event.cron` は空白正規化のうえ ALERT のみ厳密一致。未知の式は error ログを出して retention を実行（fail-open。掃除が止まる方が高くつく）
- webhook 呼び出しは `infra/discord-webhook.ts`（5 秒タイムアウト。URL・例外 message はログに出さない）、判定は `services/cron-health.ts` の純関数
- E2E の seed を `wrangler d1 migrations apply --local` に置き換え（migration の手書き列挙をやめる）

## 意思決定

### 採用アプローチ
- 最終成功時刻を D1 に記録 → health で鮮度を出す + 別 cron が閾値超過を Discord へ通知（ユーザー選択 2026-08-30）
- `retention-alert` 行が `last_success_at` を「最終通知時刻」として再利用（migration のコメントに明記。列名の変更は 3 段階 migration が要るため今はしない）

### 意図的に残した挙動
- **マージ後の初回デプロイでは `cron_runs` が空 = 停止扱いなので、直後の :47 に `[警告] 最終成功: 記録なし` が 1 回飛び、次の :17 の実行後の :47 に `[回復]` が飛んで収束する**。本番での通知経路の実証を兼ねるため、ブートストラップ行は入れていない
- `wrangler rollback` は cron スケジュールを戻さないため、ロールバック後は旧コードが :17 と :47 の両方で retention を実行する（冪等・上限付きなので実害は薄い）

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 434 pass / 0 fail（状態遷移: alert → 6h 抑止 → alert / alert → recovered / 送信失敗時は記録しない / 壊れた state JSON / health の D1 失敗・binding 欠落・メモ化 / cron 式の正規化と未知式の fail-open）
- [x] `bunx wrangler d1 migrations apply --local` 通過
- [x] `wrangler dev --test-scheduled` でローカルのダミー webhook 相手に 6 パターン実測（正常時は無通知 / 3 時間停止で 1 通 / 再送間隔内は無通知 / 回復で 1 通 / 回復後は無通知 / :17 で `cron_runs` 更新）。実 Discord には送っていない
- [x] E2E `e2e/smoke.spec.ts` 5 pass（health の `cron` フィールド）
- [x] `check-architecture.py` 新規違反ゼロ

## レビューゲート

Opus `code-reviewer` + `security-checker`（codex が起動段階でハングしたためフォールバック）。ブロッキングなし。改善 9 件を反映（詳細は対応表コメント）。

## 不可逆要素

D1 テーブル追加（追加のみ・後方互換）。2026-08-30 の設計議論でユーザーが事前承認済み。

Refs #69

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
