### PR TITLE
fix(web): 所有者判定・セッション・履歴で基盤の異常を正常系に見せない

### DIFF
--- a/web/e2e/session-error.spec.ts
+++ b/web/e2e/session-error.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+import ja from '../src/i18n/ja.json' with { type: 'json' };
+import { E2E_FIXTURES } from '../playwright.config';
+import { signIn } from './session';
+
+// 認証基盤が落ちた時の表示。guest 表示へ黙って倒すと障害に気づけないので、
+// 「通常の guest 表示 + 赤いアラート」の併存になっていることを固定する。
+
+test.use({ locale: 'ja-JP', extraHTTPHeaders: { 'Accept-Language': 'ja,en;q=0.8' } });
+
+test('/api/me/ が 5xx なら、ログイン導線を残したままエラーを知らせる', async ({
+  page,
+  context,
+}) => {
+  await signIn(context, E2E_FIXTURES.ownerId);
+  await page.route('**/api/me/', (route) => route.fulfill({ status: 500, body: '{}' }));
+
+  await page.goto('/ja/');
+
+  await expect(page.locator('html')).toHaveAttribute('data-auth-state', 'error');
+
+  // 復帰手段（ログイン導線・トップの案内）を消さない。
+  await expect(page.getByRole('link', { name: ja.nav.login, exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: ja.hero.title })).toBeVisible();
+
+  // ログイン済み前提の操作は出さない（本人だと確認できていないため）。
+  await expect(page.locator('[data-history-menu]')).toBeHidden();
+
+  const alert = page.getByRole('alert').filter({ hasText: ja.nav.sessionUnavailable });
+  await expect(alert).toBeVisible();
+});
+
+test('401 は通常の未ログイン表示のままにする', async ({ page }) => {
+  await page.goto('/ja/');
+
+  await expect(page.locator('html')).toHaveAttribute('data-auth-state', 'guest');
+  await expect(page.getByRole('link', { name: ja.nav.login, exact: true })).toBeVisible();
+  await expect(page.locator('[data-session-error]')).toBeHidden();
+});

--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -36,7 +36,8 @@ test.describe('未ログイン', () => {
     await expect(cta).toHaveAttribute('href', '/api/auth/login/');
 
     // 仕様リストはヒーローと変換パネルの両方にあるので、未ログイン側に絞って見る
-    const hero = page.locator('[data-auth-only="guest"]');
+    // （値は "guest error" のような語リストなので ~= で見る）
+    const hero = page.locator('[data-auth-only~="guest"]');
     await expect(hero.getByText(ja.spec.maxSize)).toBeVisible();
     await expect(hero.getByText(ja.spec.retention)).toBeVisible();
     // ログイン前に変換パネルは出さない

--- a/web/src/components/PreviewUnavailable.astro
+++ b/web/src/components/PreviewUnavailable.astro
@@ -1,0 +1,31 @@
+---
+import { useTranslations, type Locale } from '../i18n';
+
+interface Props {
+  lang: Locale;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang);
+---
+
+{/* 所有者判定に必要な認証基盤（署名鍵・D1）が壊れている時に 503 と一緒に出す。
+    動画そのものは存在するので 404 とは分けて伝える。 */}
+<section class="mx-auto max-w-3xl px-4 py-20 text-center">
+  <p class="flex items-center justify-center gap-2 text-base font-semibold text-slate-500">
+    <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+    <span>503</span>
+  </p>
+  <h1 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">
+    {t.preview.unavailableHeading}
+  </h1>
+  <p class="mt-4 text-base leading-relaxed text-slate-600">{t.preview.unavailableLead}</p>
+
+  <a
+    href={`/${lang}/`}
+    class="mt-8 inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-base font-semibold text-white no-underline hover:bg-brand-700"
+  >
+    <i class="fa-solid fa-house" aria-hidden="true"></i>
+    <span>{t.preview.backHome}</span>
+  </a>
+</section>

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -50,7 +50,7 @@ const LOGOUT_URL = '/api/auth/logout/';
 
     <div class="flex items-center gap-3">
       <a
-        data-auth-only="guest"
+        data-auth-only="guest error"
         href={LOGIN_URL}
         class="inline-flex items-center gap-2 whitespace-nowrap rounded-md bg-brand-500 px-3 py-2 text-base font-semibold text-white hover:bg-brand-700"
       >
@@ -58,15 +58,21 @@ const LOGOUT_URL = '/api/auth/logout/';
         <span>{t.nav.login}</span>
       </a>
 
-      {/* 認証基盤の異常。guest（ログイン導線）に倒すと障害が見えなくなるので、
-          ログイン状態を確認できなかったことをそのまま出す。 */}
+      {/* 認証基盤の異常。guest（ログイン導線）は残したうえで、状態を確認できなかったことを
+          そのまま出す。CSS の display 切り替えでは支援技術に通知されないため、
+          session-view.ts が hidden を外して文言を差し込む（文言は data-* 経由）。
+          display ユーティリティを付けないのは hidden 属性を上書きしないため。 */}
       <p
-        data-auth-only="error"
+        data-session-error
+        hidden
         role="alert"
-        class="flex items-center gap-2 text-base font-semibold text-red-700"
+        data-msg-session-unavailable={t.nav.sessionUnavailable}
+        class="m-0 text-base font-semibold text-red-700"
       >
-        <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
-        <span>{t.nav.sessionUnavailable}</span>
+        <span class="inline-flex items-center gap-2">
+          <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+          <span data-session-error-message></span>
+        </span>
       </p>
 
       <div data-auth-only="member" class="flex items-center gap-2">

--- a/web/src/components/SiteHeader.astro
+++ b/web/src/components/SiteHeader.astro
@@ -58,6 +58,17 @@ const LOGOUT_URL = '/api/auth/logout/';
         <span>{t.nav.login}</span>
       </a>
 
+      {/* 認証基盤の異常。guest（ログイン導線）に倒すと障害が見えなくなるので、
+          ログイン状態を確認できなかったことをそのまま出す。 */}
+      <p
+        data-auth-only="error"
+        role="alert"
+        class="flex items-center gap-2 text-base font-semibold text-red-700"
+      >
+        <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+        <span>{t.nav.sessionUnavailable}</span>
+      </p>
+
       <div data-auth-only="member" class="flex items-center gap-2">
         <HistoryDropdown lang={lang} />
 

--- a/web/src/components/TopPage.astro
+++ b/web/src/components/TopPage.astro
@@ -13,8 +13,9 @@ const { lang } = Astro.props;
 ---
 
 <div class="mx-auto max-w-5xl px-4 py-12">
-  <!-- 未ログイン / ログイン済みの両方を出しておき、data-auth-state で切り替える -->
-  <div data-auth-only="guest">
+  {/* 未ログイン / ログイン済みの両方を出しておき、data-auth-state で切り替える。 */}
+  {/* error（認証基盤の障害）でも guest 側を出すのは、復帰手段まで消さないため。 */}
+  <div data-auth-only="guest error">
     <NoticeBanner lang={lang} />
     <GuestHero lang={lang} />
   </div>

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -88,6 +88,8 @@
     "renameTooLong": "File name is too long ({count} / max {max} characters)",
     "notFoundHeading": "Video not found",
     "notFoundLead": "The URL may be wrong, or the video may have been removed after its retention period.",
+    "unavailableHeading": "Temporarily unavailable",
+    "unavailableLead": "We could not check your sign-in status, so this page cannot be shown right now. Please try again in a moment.",
     "backHome": "Back to the home page",
     "deletedHeading": "Deleted",
     "deletedLead": "This video has been deleted and the URL no longer plays.",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -12,7 +12,8 @@
     "history": "History",
     "logout": "Sign out",
     "bannerAlt": "WebScreen logo",
-    "avatarAlt": "Account avatar"
+    "avatarAlt": "Account avatar",
+    "sessionUnavailable": "Sign-in status unavailable"
   },
   "notice": {
     "heading": "WebScreen has been rebuilt",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -88,6 +88,8 @@
     "renameTooLong": "ファイル名が長すぎます（{count} / 上限 {max} 文字）",
     "notFoundHeading": "動画が見つかりません",
     "notFoundLead": "URL が間違っているか、保管期限が過ぎて削除された可能性があります。",
+    "unavailableHeading": "いま表示できません",
+    "unavailableLead": "ログイン状態を確認できなかったため、このページを表示できませんでした。時間をおいて再度お試しください。",
     "backHome": "トップへ戻る",
     "deletedHeading": "削除しました",
     "deletedLead": "この動画は削除されました。この URL では再生できません。",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -12,7 +12,8 @@
     "history": "履歴",
     "logout": "ログアウト",
     "bannerAlt": "WebScreen のロゴ",
-    "avatarAlt": "アカウントのアバター"
+    "avatarAlt": "アカウントのアバター",
+    "sessionUnavailable": "ログイン状態を確認できません"
   },
   "notice": {
     "heading": "WebScreen は新しくなりました",

--- a/web/src/lib/infra/worker-log.ts
+++ b/web/src/lib/infra/worker-log.ts
@@ -14,6 +14,7 @@ const WORKER_FAILURE_EVENTS = [
   'upload_commit_oversize_claim_missed',
   'upload_commit_oversize_object_delete_failed',
   'movie_delete_row_stranded',
+  'preview_owner_check_failed',
   'capture_request_json_invalid',
   'capture_upstream_response_invalid',
   'capture_worker_timeout',

--- a/web/src/lib/infra/worker-log.ts
+++ b/web/src/lib/infra/worker-log.ts
@@ -31,12 +31,15 @@ export function logWorkerFailure({
   errorCode,
   status,
   upstreamStatus,
+  errorName,
 }: {
   level?: WorkerLogLevel;
   event: WorkerFailureEvent;
   errorCode: ErrorCode;
   status: number;
   upstreamStatus?: number;
+  /** 例外の種別だけ（`error.name`）。message / stack は内容が読めないので入れない。 */
+  errorName?: string;
 }): void {
   // URL・Cookie・上流本文は含めず、Cloudflare observability で安全に絞り込める項目だけを出す。
   const entry = JSON.stringify({
@@ -49,6 +52,7 @@ export function logWorkerFailure({
     errorCode,
     status,
     upstreamStatus,
+    errorName,
     summary: `${event} returned ${status} ${errorCode}.`,
   });
   if (level === 'warn') {

--- a/web/src/lib/services/auth.ts
+++ b/web/src/lib/services/auth.ts
@@ -168,6 +168,9 @@ export type PreviewOwnerResult = { ok: true; isOwner: boolean } | { ok: false };
  *
  * Cookie 不在は鍵にも D1 にも触らずに非所有者で確定させる。所有者は必ず Cookie を持つので
  * 障害の可視性は落ちず、鍵が壊れても匿名の公開閲覧（VRChat からの再生）は巻き込まない。
+ *
+ * 鍵のローテーションで値が入れ替わった場合は import 自体は成功し、旧鍵の Cookie が
+ * 署名不一致になるだけなので 503 ではなく非所有者になる（全員がログアウト相当に見える）。
  */
 export async function resolvePreviewOwner(
   request: Request,
@@ -185,11 +188,12 @@ export async function resolvePreviewOwner(
       nowSeconds: deps.nowSeconds,
     });
     return { ok: true, isOwner: result.ok && result.user.id === deps.ownerId };
-  } catch {
+  } catch (error) {
     logWorkerFailure({
       event: 'preview_owner_check_failed',
       errorCode: ERROR_CODES.internalError,
       status: 503,
+      errorName: error instanceof Error ? error.name : 'UnknownError',
     });
     return { ok: false };
   }

--- a/web/src/lib/services/auth.ts
+++ b/web/src/lib/services/auth.ts
@@ -6,6 +6,7 @@ import {
   base64UrlEncode,
   createSessionPayload,
   generateOAuthState,
+  importSigningKey,
   matchesOAuthState,
   readCookie,
   signSession,
@@ -152,6 +153,40 @@ export async function requireUser(
     status: 401,
     error: { errorCode: ERROR_CODES.unauthorized, message: '認証が必要です' },
   };
+}
+
+/** プレビューページの所有者判定結果。`ok: false` は認証基盤そのものの異常。 */
+export type PreviewOwnerResult = { ok: true; isOwner: boolean } | { ok: false };
+
+/**
+ * 公開プレビューの所有者判定。
+ *
+ * 「Cookie を持たない / 署名が通らない = 他人」と「認証基盤が壊れている（署名鍵の破損・
+ * D1 障害）」を分ける。後者を他人として扱うと、所有者が pin / 削除 UI を失ったまま
+ * ページが正常に見えてしまい、誰も異常に気づけない。
+ *
+ * Cookie 不在は鍵にも D1 にも触らずに非所有者で確定させる。所有者は必ず Cookie を持つので
+ * 障害の可視性は落ちず、鍵が壊れても匿名の公開閲覧（VRChat からの再生）は巻き込まない。
+ */
+export async function resolvePreviewOwner(
+  request: Request,
+  deps: { db: UsersDatabase; signingKeySecret: string; ownerId: number; nowSeconds?: number }
+): Promise<PreviewOwnerResult> {
+  if (!readCookie(request.headers.get('Cookie'), SESSION_COOKIE_NAME)) {
+    return { ok: true, isOwner: false };
+  }
+
+  try {
+    const signingKey = await importSigningKey(deps.signingKeySecret);
+    const result = await requireUser(request, {
+      db: deps.db,
+      signingKey,
+      nowSeconds: deps.nowSeconds,
+    });
+    return { ok: true, isOwner: result.ok && result.user.id === deps.ownerId };
+  } catch {
+    return { ok: false };
+  }
 }
 
 async function verifyOAuthStateToken(

--- a/web/src/lib/services/auth.ts
+++ b/web/src/lib/services/auth.ts
@@ -12,6 +12,7 @@ import {
   signSession,
   verifySession,
 } from '../contracts/session';
+import { logWorkerFailure } from '../infra/worker-log';
 import {
   DiscordApiError,
   createDiscordAuthorizeUrl,
@@ -185,6 +186,11 @@ export async function resolvePreviewOwner(
     });
     return { ok: true, isOwner: result.ok && result.user.id === deps.ownerId };
   } catch {
+    logWorkerFailure({
+      event: 'preview_owner_check_failed',
+      errorCode: ERROR_CODES.internalError,
+      status: 503,
+    });
     return { ok: false };
   }
 }

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -130,10 +130,10 @@ async function load(root: HTMLElement, fetchImpl: typeof fetch): Promise<void> {
     return;
   }
 
-  const { entries, dropped } = parseHistoryEntries(payload);
-  if (dropped > 0) {
+  const { entries, dropped, malformed } = parseHistoryEntries(payload);
+  if (malformed || dropped > 0) {
     // 読めた行だけ出すと、全件落ちた時に「履歴なし」と見分けが付かない。
-    console.error(`history_entries_dropped: ${dropped}`);
+    console.error(malformed ? 'history_payload_malformed' : `history_entries_dropped: ${dropped}`);
     showError(root, root.dataset['msgHistoryFailed'] ?? '');
     return;
   }

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -113,19 +113,32 @@ function render(root: HTMLElement, entries: HistoryEntry[], fetchImpl: typeof fe
   setState(root, 'ready');
 }
 
+function showError(root: HTMLElement, message: string): void {
+  const element = root.querySelector<HTMLElement>('[data-history-error-message]');
+  if (element) element.textContent = message;
+  setState(root, 'error');
+}
+
 async function load(root: HTMLElement, fetchImpl: typeof fetch): Promise<void> {
   setState(root, 'loading');
 
+  let payload: unknown;
   try {
-    const payload = await requestJson(HISTORY_ENDPOINT, { credentials: 'same-origin' }, fetchImpl);
-    render(root, parseHistoryEntries(payload), fetchImpl);
+    payload = await requestJson(HISTORY_ENDPOINT, { credentials: 'same-origin' }, fetchImpl);
   } catch (error) {
-    const message = root.querySelector<HTMLElement>('[data-history-error-message]');
-    if (message) {
-      message.textContent = requestFailureMessage(root, error, root.dataset['msgHistoryFailed'] ?? '');
-    }
-    setState(root, 'error');
+    showError(root, requestFailureMessage(root, error, root.dataset['msgHistoryFailed'] ?? ''));
+    return;
   }
+
+  const { entries, dropped } = parseHistoryEntries(payload);
+  if (dropped > 0) {
+    // 読めた行だけ出すと、全件落ちた時に「履歴なし」と見分けが付かない。
+    console.error(`history_entries_dropped: ${dropped}`);
+    showError(root, root.dataset['msgHistoryFailed'] ?? '');
+    return;
+  }
+
+  render(root, entries, fetchImpl);
 }
 
 /** `<details data-history-menu>` に配線する。開いた時に一覧を取得する。 */

--- a/web/src/lib/ui/history-view.ts
+++ b/web/src/lib/ui/history-view.ts
@@ -42,27 +42,44 @@ function readStatus(record: Record<string, unknown>): MovieStatus | null {
   return (MOVIE_STATUSES as readonly string[]).includes(value) ? (value as MovieStatus) : null;
 }
 
+/** 履歴応答の読み取り結果。dropped は形が違って読めなかった行数。 */
+export interface HistoryParseResult {
+  entries: HistoryEntry[];
+  dropped: number;
+}
+
 /**
  * `GET /api/history/` の応答を読む。
  *
- * 1 件でも形が違えばその行だけ捨てる（一覧全体が消えるより、欠けて表示される方がまし）。
+ * 形が違う行は捨てるが、件数を返して呼び出し側に判断させる。黙って間引くと、
+ * 全件落ちた時に「履歴なし」と区別できず、履歴があるのに空として表示してしまう。
+ *
+ * note: movies が配列でないトップレベルの異常は 0 件として返す（呼び出し側は空表示）。
+ * 行単位の欠落とは別の契約違反なので、扱いを分けるなら呼び出し側で判定する。
  */
-export function parseHistoryEntries(payload: unknown): HistoryEntry[] {
+export function parseHistoryEntries(payload: unknown): HistoryParseResult {
   const record = asRecord(payload);
   const movies = record?.['movies'];
-  if (!Array.isArray(movies)) return [];
+  if (!Array.isArray(movies)) return { entries: [], dropped: 0 };
 
   const entries: HistoryEntry[] = [];
+  let dropped = 0;
   for (const item of movies) {
     const row = asRecord(item);
-    if (!row) continue;
+    if (!row) {
+      dropped += 1;
+      continue;
+    }
 
     const shortId = readString(row, 'shortId');
     const filename = readString(row, 'filename');
     const createdAt = readString(row, 'createdAt');
     const publicUrl = readString(row, 'publicUrl');
     const status = readStatus(row);
-    if (!shortId || !filename || !createdAt || !publicUrl || !status) continue;
+    if (!shortId || !filename || !createdAt || !publicUrl || !status) {
+      dropped += 1;
+      continue;
+    }
 
     entries.push({
       shortId,
@@ -74,7 +91,7 @@ export function parseHistoryEntries(payload: unknown): HistoryEntry[] {
       publicUrl,
     });
   }
-  return entries;
+  return { entries, dropped };
 }
 
 /**

--- a/web/src/lib/ui/history-view.ts
+++ b/web/src/lib/ui/history-view.ts
@@ -42,10 +42,14 @@ function readStatus(record: Record<string, unknown>): MovieStatus | null {
   return (MOVIE_STATUSES as readonly string[]).includes(value) ? (value as MovieStatus) : null;
 }
 
-/** 履歴応答の読み取り結果。dropped は形が違って読めなかった行数。 */
+/**
+ * 履歴応答の読み取り結果。dropped は形が違って読めなかった行数、
+ * malformed は応答そのものが `{ movies: [...] }` の契約から外れていたこと。
+ */
 export interface HistoryParseResult {
   entries: HistoryEntry[];
   dropped: number;
+  malformed: boolean;
 }
 
 /**
@@ -53,14 +57,13 @@ export interface HistoryParseResult {
  *
  * 形が違う行は捨てるが、件数を返して呼び出し側に判断させる。黙って間引くと、
  * 全件落ちた時に「履歴なし」と区別できず、履歴があるのに空として表示してしまう。
- *
- * note: movies が配列でないトップレベルの異常は 0 件として返す（呼び出し側は空表示）。
- * 行単位の欠落とは別の契約違反なので、扱いを分けるなら呼び出し側で判定する。
+ * movies が配列でないトップレベルの契約違反も、0 件（履歴なし）に化けないよう
+ * malformed で区別する。
  */
 export function parseHistoryEntries(payload: unknown): HistoryParseResult {
   const record = asRecord(payload);
   const movies = record?.['movies'];
-  if (!Array.isArray(movies)) return { entries: [], dropped: 0 };
+  if (!Array.isArray(movies)) return { entries: [], dropped: 0, malformed: true };
 
   const entries: HistoryEntry[] = [];
   let dropped = 0;
@@ -91,7 +94,7 @@ export function parseHistoryEntries(payload: unknown): HistoryParseResult {
       publicUrl,
     });
   }
-  return { entries, dropped };
+  return { entries, dropped, malformed: false };
 }
 
 /**

--- a/web/src/lib/ui/session-view.ts
+++ b/web/src/lib/ui/session-view.ts
@@ -2,7 +2,7 @@
  * `GET /api/me/` の結果で画面をログイン前 / ログイン後に切り替える。
  *
  * ページは静的生成（output: 'static'）でセッション Cookie を読めないため、
- * 両方の状態を HTML に含めておき、ここで `data-auth-state` を切り替えて出し分ける。
+ * 各状態の HTML を含めておき、ここで `data-auth-state` を切り替えて出し分ける。
  * 既定値は guest なので、JS が動かない環境でもログイン導線だけは表示される。
  */
 
@@ -11,7 +11,7 @@ import { parseViewer, viewerInitial, type Viewer } from './viewer';
 /** trailingSlash: 'always' のためスラッシュ必須。省くと 301 を挟む。 */
 export const ME_ENDPOINT = '/api/me/';
 
-export type AuthState = 'guest' | 'member';
+export type AuthState = 'guest' | 'member' | 'error';
 
 export function applyViewer(root: HTMLElement, viewer: Viewer): void {
   for (const element of root.querySelectorAll<HTMLElement>('[data-viewer-name]')) {
@@ -32,9 +32,22 @@ export function applyViewer(root: HTMLElement, viewer: Viewer): void {
 }
 
 /**
+ * 認証基盤の異常。guest と分けて `error` に倒し、画面と console の両方に残す。
+ *
+ * guest へ倒すと、ログイン済みのユーザーが黙ってログアウトしたように見えるだけで
+ * 誰も障害に気づけない（ログイン導線を押しても直らない）。
+ */
+function failAuthState(root: HTMLElement, ...detail: unknown[]): 'error' {
+  console.error('session_state_unresolved:', ...detail);
+  root.dataset['authState'] = 'error';
+  return 'error';
+}
+
+/**
  * ログイン状態を解決して `data-auth-state` に反映する。
  *
- * 通信失敗は「未ログイン」として扱う（ログイン導線を出す側に倒す）。
+ * 未ログインと言い切れるのは 401 だけ。通信失敗と 401 以外の失敗応答は
+ * 認証基盤の異常なので error に倒す。
  */
 export async function resolveAuthState(
   root: HTMLElement,
@@ -43,14 +56,17 @@ export async function resolveAuthState(
   let response: Response;
   try {
     response = await fetchImpl(ME_ENDPOINT, { credentials: 'same-origin' });
-  } catch {
+  } catch (error) {
+    return failAuthState(root, 'request failed', error);
+  }
+
+  if (response.status === 401) {
     root.dataset['authState'] = 'guest';
     return 'guest';
   }
 
   if (!response.ok) {
-    root.dataset['authState'] = 'guest';
-    return 'guest';
+    return failAuthState(root, `status ${response.status}`);
   }
 
   let payload: unknown = null;

--- a/web/src/lib/ui/session-view.ts
+++ b/web/src/lib/ui/session-view.ts
@@ -32,14 +32,28 @@ export function applyViewer(root: HTMLElement, viewer: Viewer): void {
 }
 
 /**
+ * 失敗の告知。role="alert" は CSS の display 切り替えでは読み上げられないので、
+ * hidden を外して文言を差し込む（辞書の値は data-* で HTML から受け取る）。
+ */
+function announceAuthFailure(root: HTMLElement): void {
+  for (const element of root.querySelectorAll<HTMLElement>('[data-session-error]')) {
+    const target = element.querySelector<HTMLElement>('[data-session-error-message]');
+    if (target) target.textContent = element.dataset['msgSessionUnavailable'] ?? '';
+    element.hidden = false;
+  }
+}
+
+/**
  * 認証基盤の異常。guest と分けて `error` に倒し、画面と console の両方に残す。
  *
  * guest へ倒すと、ログイン済みのユーザーが黙ってログアウトしたように見えるだけで
- * 誰も障害に気づけない（ログイン導線を押しても直らない）。
+ * 誰も障害に気づけない。ログイン導線は残すが、状態が不明なことは必ず知らせる。
  */
-function failAuthState(root: HTMLElement, ...detail: unknown[]): 'error' {
-  console.error('session_state_unresolved:', ...detail);
+function failAuthState(root: HTMLElement, reason: string): 'error' {
+  // 理由は種別だけ（例外の message / stack は個人情報や URL を含みうる）。
+  console.error(`session_state_unresolved: ${reason}`);
   root.dataset['authState'] = 'error';
+  announceAuthFailure(root);
   return 'error';
 }
 
@@ -57,7 +71,7 @@ export async function resolveAuthState(
   try {
     response = await fetchImpl(ME_ENDPOINT, { credentials: 'same-origin' });
   } catch (error) {
-    return failAuthState(root, 'request failed', error);
+    return failAuthState(root, error instanceof Error ? error.name : 'UnknownError');
   }
 
   if (response.status === 401) {

--- a/web/src/pages/[shortId]/index.astro
+++ b/web/src/pages/[shortId]/index.astro
@@ -6,8 +6,6 @@ import MoviePreview from '../../components/MoviePreview.astro';
 import PreviewUnavailable from '../../components/PreviewUnavailable.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { resolveLocale, useTranslations } from '../../i18n';
-import { ERROR_CODES } from '../../lib/contracts/api';
-import { logWorkerFailure } from '../../lib/infra/worker-log';
 import { resolvePreviewOwner, type AuthDatabase } from '../../lib/services/auth';
 import { findPublicMovie, type MoviesDatabase } from '../../lib/services/movies';
 
@@ -49,12 +47,7 @@ const ownership =
 
 if (!ownership.ok) {
   // 認証基盤の異常。他人の動画として 200 を返すと、所有者が操作 UI を失ったまま
-  // 誰も異常に気づけないので 503 に倒して記録する。
-  logWorkerFailure({
-    event: 'preview_owner_check_failed',
-    errorCode: ERROR_CODES.internalError,
-    status: 503,
-  });
+  // 誰も異常に気づけない（記録は resolvePreviewOwner が出す）。
   Astro.response.status = 503;
 } else if (movie === null) {
   Astro.response.status = 404;

--- a/web/src/pages/[shortId]/index.astro
+++ b/web/src/pages/[shortId]/index.astro
@@ -3,10 +3,12 @@ import { env } from 'cloudflare:workers';
 
 import MovieNotFound from '../../components/MovieNotFound.astro';
 import MoviePreview from '../../components/MoviePreview.astro';
+import PreviewUnavailable from '../../components/PreviewUnavailable.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { resolveLocale, useTranslations } from '../../i18n';
-import { importSigningKey } from '../../lib/contracts/session';
-import { requireUser, type AuthDatabase } from '../../lib/services/auth';
+import { ERROR_CODES } from '../../lib/contracts/api';
+import { logWorkerFailure } from '../../lib/infra/worker-log';
+import { resolvePreviewOwner, type AuthDatabase } from '../../lib/services/auth';
 import { findPublicMovie, type MoviesDatabase } from '../../lib/services/movies';
 
 // 公開ページ（認証不要）だが shortId ごとに内容が変わるので Worker で描画する。
@@ -34,34 +36,44 @@ const movie = await findPublicMovie({
   publicBaseUrl: bindings.R2_PUBLIC_BASE_URL,
 });
 
-/**
- * 所有者判定。未ログイン・署名鍵未設定でも公開表示は壊さない（匿名として扱う）。
- */
-async function resolveIsOwner(ownerId: number): Promise<boolean> {
-  try {
-    const signingKey = await importSigningKey(bindings.SESSION_SIGNING_KEY);
-    const result = await requireUser(Astro.request, { db: bindings.DB, signingKey });
-    return result.ok && result.user.id === ownerId;
-  } catch {
-    return false;
-  }
+// 所有者判定は services 層（resolvePreviewOwner）が持つ。ここは結果を
+// HTTP ステータスと描画に変換するだけ。
+const ownership =
+  movie === null
+    ? ({ ok: true, isOwner: false } as const)
+    : await resolvePreviewOwner(Astro.request, {
+        db: bindings.DB,
+        signingKeySecret: bindings.SESSION_SIGNING_KEY,
+        ownerId: movie.ownerId,
+      });
+
+if (!ownership.ok) {
+  // 認証基盤の異常。他人の動画として 200 を返すと、所有者が操作 UI を失ったまま
+  // 誰も異常に気づけないので 503 に倒して記録する。
+  logWorkerFailure({
+    event: 'preview_owner_check_failed',
+    errorCode: ERROR_CODES.internalError,
+    status: 503,
+  });
+  Astro.response.status = 503;
+} else if (movie === null) {
+  Astro.response.status = 404;
 }
 
-const isOwner = movie === null ? false : await resolveIsOwner(movie.ownerId);
-
-if (movie === null) Astro.response.status = 404;
+const pageTitle = !ownership.ok
+  ? t.preview.unavailableHeading
+  : movie === null
+    ? t.preview.notFoundHeading
+    : `${movie.filename} — WebScreen`;
 ---
 
 {/* analytics={false}: title にアップロード済みファイル名、URL に共有 ID そのものである
     shortId が入るため、GA4 の page_title / page_location として Google へ送らせない。 */}
-<BaseLayout
-  lang={lang}
-  title={movie === null ? t.preview.notFoundHeading : `${movie.filename} — WebScreen`}
-  analytics={false}
-  noindex={true}
->
+<BaseLayout lang={lang} title={pageTitle} analytics={false} noindex={true}>
   {
-    movie === null ? (
+    !ownership.ok ? (
+      <PreviewUnavailable lang={lang} />
+    ) : movie === null ? (
       <MovieNotFound lang={lang} />
     ) : (
       <MoviePreview
@@ -71,7 +83,7 @@ if (movie === null) Astro.response.status = 404;
         publicUrl={movie.publicUrl}
         pinned={movie.pinned}
         expiresAt={movie.expiresAt}
-        isOwner={isOwner}
+        isOwner={ownership.isOwner}
       />
     )
   }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -32,11 +32,13 @@
 
 /*
  * ログイン状態の出し分け。ページは静的生成でセッションを読めないため、
- * 両方の HTML を出しておき src/lib/ui/session-view.ts が data-auth-state を切り替える。
- * 既定は guest（JS が動かなくてもログイン導線は見える）。
+ * 各状態の HTML を出しておき src/lib/ui/session-view.ts が data-auth-state を切り替える。
+ * 既定は guest（JS が動かなくてもログイン導線は見える）。error は認証基盤の異常で、
+ * guest と分けないと障害中のログイン済みユーザーが黙ってログアウト表示になる。
  */
-[data-auth-state='guest'] [data-auth-only='member'],
-[data-auth-state='member'] [data-auth-only='guest'] {
+[data-auth-state='guest'] [data-auth-only]:not([data-auth-only~='guest']),
+[data-auth-state='member'] [data-auth-only]:not([data-auth-only~='member']),
+[data-auth-state='error'] [data-auth-only]:not([data-auth-only~='error']) {
   display: none;
 }
 

--- a/web/tests/services/preview-owner.test.ts
+++ b/web/tests/services/preview-owner.test.ts
@@ -1,0 +1,140 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+
+import {
+  createSessionPayload,
+  importSigningKey,
+  signSession,
+} from '../../src/lib/contracts/session';
+import { resolvePreviewOwner } from '../../src/lib/services/auth';
+import type { UserStatement, UsersDatabase } from '../../src/lib/infra/users';
+
+const NOW = 1_700_000_000;
+const SIGNING_SECRET = 'test-signing-key';
+const OWNER_ID = 42;
+
+let signingKey: CryptoKey;
+
+beforeAll(async () => {
+  signingKey = await importSigningKey(SIGNING_SECRET);
+});
+
+function requestWithCookie(token: string): Request {
+  return new Request('https://example.test/AbCdEf123456/', {
+    headers: { Cookie: `ws_session=${token}` },
+  });
+}
+
+async function sessionCookieFor(userId: number): Promise<string> {
+  return signSession(createSessionPayload(userId, NOW), signingKey);
+}
+
+describe('resolvePreviewOwner', () => {
+  test('Cookie が無ければ D1 にも鍵にも触らず非所有者にする', async () => {
+    const db = new ThrowingUsersDatabase();
+
+    const result = await resolvePreviewOwner(new Request('https://example.test/AbCdEf123456/'), {
+      db,
+      signingKeySecret: '',
+      ownerId: OWNER_ID,
+      nowSeconds: NOW,
+    });
+
+    expect(result).toEqual({ ok: true, isOwner: false });
+    expect(db.prepareCount).toBe(0);
+  });
+
+  test('所有者のセッションなら所有者と判定する', async () => {
+    const db = new FakeUsersDatabase({
+      id: OWNER_ID,
+      discord_id: '123456789',
+      name: 'WebScreen User',
+      avatar: null,
+    });
+
+    const result = await resolvePreviewOwner(
+      requestWithCookie(await sessionCookieFor(OWNER_ID)),
+      { db, signingKeySecret: SIGNING_SECRET, ownerId: OWNER_ID, nowSeconds: NOW }
+    );
+
+    expect(result).toEqual({ ok: true, isOwner: true });
+  });
+
+  test('別のユーザーのセッションは非所有者にする', async () => {
+    const db = new FakeUsersDatabase({
+      id: 7,
+      discord_id: '987654321',
+      name: 'Someone Else',
+      avatar: null,
+    });
+
+    const result = await resolvePreviewOwner(requestWithCookie(await sessionCookieFor(7)), {
+      db,
+      signingKeySecret: SIGNING_SECRET,
+      ownerId: OWNER_ID,
+      nowSeconds: NOW,
+    });
+
+    expect(result).toEqual({ ok: true, isOwner: false });
+  });
+
+  test('署名が通らない Cookie は非所有者にする（基盤の異常ではない）', async () => {
+    const db = new FakeUsersDatabase(null);
+
+    const result = await resolvePreviewOwner(requestWithCookie('tampered.value'), {
+      db,
+      signingKeySecret: SIGNING_SECRET,
+      ownerId: OWNER_ID,
+      nowSeconds: NOW,
+    });
+
+    expect(result).toEqual({ ok: true, isOwner: false });
+  });
+
+  test('署名鍵が壊れていれば失敗として返す', async () => {
+    const db = new FakeUsersDatabase(null);
+
+    const result = await resolvePreviewOwner(requestWithCookie(await sessionCookieFor(OWNER_ID)), {
+      db,
+      signingKeySecret: '',
+      ownerId: OWNER_ID,
+      nowSeconds: NOW,
+    });
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  test('D1 が落ちていれば失敗として返す（他人の動画にしない）', async () => {
+    const db = new ThrowingUsersDatabase();
+
+    const result = await resolvePreviewOwner(requestWithCookie(await sessionCookieFor(OWNER_ID)), {
+      db,
+      signingKeySecret: SIGNING_SECRET,
+      ownerId: OWNER_ID,
+      nowSeconds: NOW,
+    });
+
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+class FakeUsersDatabase implements UsersDatabase {
+  constructor(private readonly row: Record<string, unknown> | null) {}
+
+  prepare(): UserStatement {
+    const statement: UserStatement = {
+      bind: () => statement,
+      first: async <T>() => this.row as T | null,
+    };
+    return statement;
+  }
+}
+
+/** D1 障害の再現。参照されたら必ず throw する。 */
+class ThrowingUsersDatabase implements UsersDatabase {
+  prepareCount = 0;
+
+  prepare(): UserStatement {
+    this.prepareCount += 1;
+    throw new Error('D1_ERROR: network error');
+  }
+}

--- a/web/tests/services/preview-owner.test.ts
+++ b/web/tests/services/preview-owner.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from 'bun:test';
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test';
 
 import {
   createSessionPayload,
@@ -28,8 +28,24 @@ async function sessionCookieFor(userId: number): Promise<string> {
   return signSession(createSessionPayload(userId, NOW), signingKey);
 }
 
+const originalConsoleError = console.error;
+const errors: string[] = [];
+
+/** logWorkerFailure は console.error の 1 行 JSON なので、そこから event を読む。 */
+function captureWorkerLog(): void {
+  errors.length = 0;
+  console.error = (entry: unknown) => {
+    errors.push(String(entry));
+  };
+}
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
 describe('resolvePreviewOwner', () => {
   test('Cookie が無ければ D1 にも鍵にも触らず非所有者にする', async () => {
+    captureWorkerLog();
     const db = new ThrowingUsersDatabase();
 
     const result = await resolvePreviewOwner(new Request('https://example.test/AbCdEf123456/'), {
@@ -41,6 +57,7 @@ describe('resolvePreviewOwner', () => {
 
     expect(result).toEqual({ ok: true, isOwner: false });
     expect(db.prepareCount).toBe(0);
+    expect(errors).toHaveLength(0);
   });
 
   test('所有者のセッションなら所有者と判定する', async () => {
@@ -91,6 +108,7 @@ describe('resolvePreviewOwner', () => {
   });
 
   test('署名鍵が壊れていれば失敗として返す', async () => {
+    captureWorkerLog();
     const db = new FakeUsersDatabase(null);
 
     const result = await resolvePreviewOwner(requestWithCookie(await sessionCookieFor(OWNER_ID)), {
@@ -101,9 +119,12 @@ describe('resolvePreviewOwner', () => {
     });
 
     expect(result).toEqual({ ok: false });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('preview_owner_check_failed');
   });
 
   test('D1 が落ちていれば失敗として返す（他人の動画にしない）', async () => {
+    captureWorkerLog();
     const db = new ThrowingUsersDatabase();
 
     const result = await resolvePreviewOwner(requestWithCookie(await sessionCookieFor(OWNER_ID)), {
@@ -114,6 +135,8 @@ describe('resolvePreviewOwner', () => {
     });
 
     expect(result).toEqual({ ok: false });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('preview_owner_check_failed');
   });
 });
 

--- a/web/tests/services/preview-owner.test.ts
+++ b/web/tests/services/preview-owner.test.ts
@@ -94,7 +94,8 @@ describe('resolvePreviewOwner', () => {
     expect(result).toEqual({ ok: true, isOwner: false });
   });
 
-  test('署名が通らない Cookie は非所有者にする（基盤の異常ではない）', async () => {
+  test('署名が通らない Cookie は非所有者にする（基盤の異常ではないのでログも出さない）', async () => {
+    captureWorkerLog();
     const db = new FakeUsersDatabase(null);
 
     const result = await resolvePreviewOwner(requestWithCookie('tampered.value'), {
@@ -105,6 +106,7 @@ describe('resolvePreviewOwner', () => {
     });
 
     expect(result).toEqual({ ok: true, isOwner: false });
+    expect(errors).toHaveLength(0);
   });
 
   test('署名鍵が壊れていれば失敗として返す', async () => {
@@ -121,6 +123,7 @@ describe('resolvePreviewOwner', () => {
     expect(result).toEqual({ ok: false });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain('preview_owner_check_failed');
+    expect(errors[0]).toContain('DataError');
   });
 
   test('D1 が落ちていれば失敗として返す（他人の動画にしない）', async () => {

--- a/web/tests/ui/history-menu.test.ts
+++ b/web/tests/ui/history-menu.test.ts
@@ -4,6 +4,31 @@ import { mountHistoryMenu } from '../../src/lib/ui/history-menu';
 
 type Listener = (event: Event) => void;
 
+/** 行のひな型から複製される 1 行。fillRow / wireDelete は空の querySelector で足りる。 */
+class FakeRow {
+  readonly dataset: Record<string, string> = {};
+
+  querySelector(): unknown {
+    return null;
+  }
+}
+
+class FakeList {
+  readonly rows: unknown[] = [];
+
+  replaceChildren(): void {
+    this.rows.length = 0;
+  }
+
+  append(row: unknown): void {
+    this.rows.push(row);
+  }
+
+  get children(): { length: number } {
+    return { length: this.rows.length };
+  }
+}
+
 class FakeHistoryMenu {
   readonly dataset: Record<string, string> = {
     historyState: 'idle',
@@ -11,6 +36,7 @@ class FakeHistoryMenu {
     msgSessionExpired: 'session expired',
   };
   readonly errorMessage = { textContent: '' };
+  readonly list = new FakeList();
   open = true;
   private readonly listeners = new Map<string, Listener>();
 
@@ -19,7 +45,12 @@ class FakeHistoryMenu {
   }
 
   querySelector(selector: string): unknown {
-    return selector === '[data-history-error-message]' ? this.errorMessage : null;
+    if (selector === '[data-history-error-message]') return this.errorMessage;
+    if (selector === '[data-history-list]') return this.list;
+    if (selector === '[data-history-item]') {
+      return { content: { cloneNode: () => ({ querySelector: () => new FakeRow() }) } };
+    }
+    return null;
   }
 
   dispatch(type: string): void {
@@ -28,28 +59,83 @@ class FakeHistoryMenu {
 }
 
 const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+const originalConsoleError = console.error;
+const errors: unknown[][] = [];
 
 afterEach(() => {
   if (originalDocument) Object.defineProperty(globalThis, 'document', originalDocument);
   else Reflect.deleteProperty(globalThis, 'document');
+  console.error = originalConsoleError;
 });
+
+/** 履歴メニューを開いた直後の状態を返す。 */
+async function openMenu(respond: () => Response): Promise<FakeHistoryMenu> {
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: { addEventListener: () => {} },
+  });
+  errors.length = 0;
+  console.error = (...args: unknown[]) => {
+    errors.push(args);
+  };
+
+  const menu = new FakeHistoryMenu();
+  mountHistoryMenu(
+    menu as unknown as HTMLDetailsElement,
+    (async () => respond()) as unknown as typeof fetch
+  );
+
+  menu.dispatch('toggle');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return menu;
+}
+
+function movie(overrides: Record<string, unknown> = {}) {
+  return {
+    shortId: 'AbCdEf123456',
+    filename: 'slides.pdf',
+    status: 'ready',
+    pinned: false,
+    createdAt: '2026-08-25T11:00:00.000Z',
+    expiresAt: '2026-09-24T11:00:00.000Z',
+    publicUrl: 'https://public.example/movies/AbCdEf123456.mp4',
+    ...overrides,
+  };
+}
 
 describe('履歴の取得失敗', () => {
   test('401 はセッション切れの文言を表示する', async () => {
-    Object.defineProperty(globalThis, 'document', {
-      configurable: true,
-      value: { addEventListener: () => {} },
-    });
-    const menu = new FakeHistoryMenu();
-    mountHistoryMenu(
-      menu as unknown as HTMLDetailsElement,
-      (async () => Response.json({ errorCode: 'UNAUTHORIZED' }, { status: 401 })) as unknown as typeof fetch
-    );
-
-    menu.dispatch('toggle');
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    const menu = await openMenu(() => Response.json({ errorCode: 'UNAUTHORIZED' }, { status: 401 }));
 
     expect(menu.dataset['historyState']).toBe('error');
     expect(menu.errorMessage.textContent).toBe('session expired');
+  });
+
+  test('読めない行が 1 件でもあれば、残りを出さずエラーにする', async () => {
+    const menu = await openMenu(() =>
+      Response.json({ movies: [movie(), movie({ status: 'unknown' })] })
+    );
+
+    expect(menu.dataset['historyState']).toBe('error');
+    expect(menu.errorMessage.textContent).toBe('history failed');
+    expect(menu.list.rows).toHaveLength(0);
+    expect(errors).toEqual([['history_entries_dropped: 1']]);
+  });
+});
+
+describe('履歴の取得成功', () => {
+  test('全件読めれば一覧を表示する', async () => {
+    const menu = await openMenu(() => Response.json({ movies: [movie(), movie()] }));
+
+    expect(menu.dataset['historyState']).toBe('ready');
+    expect(menu.list.rows).toHaveLength(2);
+    expect(errors).toHaveLength(0);
+  });
+
+  test('0 件はエラーではなく空として表示する', async () => {
+    const menu = await openMenu(() => Response.json({ movies: [] }));
+
+    expect(menu.dataset['historyState']).toBe('empty');
+    expect(errors).toHaveLength(0);
   });
 });

--- a/web/tests/ui/history-menu.test.ts
+++ b/web/tests/ui/history-menu.test.ts
@@ -119,7 +119,16 @@ describe('履歴の取得失敗', () => {
     expect(menu.dataset['historyState']).toBe('error');
     expect(menu.errorMessage.textContent).toBe('history failed');
     expect(menu.list.rows).toHaveLength(0);
-    expect(errors).toEqual([['history_entries_dropped: 1']]);
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain('history_entries_dropped');
+  });
+
+  test('movies が配列でない応答は「履歴なし」ではなくエラーにする', async () => {
+    const menu = await openMenu(() => Response.json({ movies: 'broken' }));
+
+    expect(menu.dataset['historyState']).toBe('error');
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain('history_payload_malformed');
   });
 });
 

--- a/web/tests/ui/history-view.test.ts
+++ b/web/tests/ui/history-view.test.ts
@@ -38,6 +38,7 @@ describe('parseHistoryEntries', () => {
         },
       ],
       dropped: 0,
+      malformed: false,
     });
   });
 
@@ -49,6 +50,7 @@ describe('parseHistoryEntries', () => {
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0]?.shortId).toBe('AbCdEf123456');
     expect(result.dropped).toBe(3);
+    expect(result.malformed).toBe(false);
   });
 
   test('pin されていない動画の expiresAt は残す', () => {
@@ -57,8 +59,16 @@ describe('parseHistoryEntries', () => {
     ).toBeNull();
   });
 
-  test.each([[null], [{}], [{ movies: 'x' }], [[]]])('%p は空配列', (payload) => {
-    expect(parseHistoryEntries(payload)).toEqual({ entries: [], dropped: 0 });
+  test.each([[null], [{}], [{ movies: 'x' }], [[]]])('%p は契約違反として印を付ける', (payload) => {
+    expect(parseHistoryEntries(payload)).toEqual({ entries: [], dropped: 0, malformed: true });
+  });
+
+  test('0 件の応答は契約違反ではない', () => {
+    expect(parseHistoryEntries({ movies: [] })).toEqual({
+      entries: [],
+      dropped: 0,
+      malformed: false,
+    });
   });
 });
 

--- a/web/tests/ui/history-view.test.ts
+++ b/web/tests/ui/history-view.test.ts
@@ -25,34 +25,40 @@ function entry(overrides: Record<string, unknown> = {}) {
 
 describe('parseHistoryEntries', () => {
   test('正常な応答をそのまま読み取る', () => {
-    expect(parseHistoryEntries({ movies: [entry({ pinned: true })] })).toEqual([
-      {
-        shortId: 'AbCdEf123456',
-        filename: 'slides.pdf',
-        status: 'ready',
-        pinned: true,
-        createdAt: '2026-08-25T11:00:00.000Z',
-        expiresAt: '2026-09-24T11:00:00.000Z',
-        publicUrl: 'https://public.example/movies/AbCdEf123456.mp4',
-      },
-    ]);
+    expect(parseHistoryEntries({ movies: [entry({ pinned: true })] })).toEqual({
+      entries: [
+        {
+          shortId: 'AbCdEf123456',
+          filename: 'slides.pdf',
+          status: 'ready',
+          pinned: true,
+          createdAt: '2026-08-25T11:00:00.000Z',
+          expiresAt: '2026-09-24T11:00:00.000Z',
+          publicUrl: 'https://public.example/movies/AbCdEf123456.mp4',
+        },
+      ],
+      dropped: 0,
+    });
   });
 
-  test('形が違う行だけを捨てて残りを表示する', () => {
-    const entries = parseHistoryEntries({
+  test('読めなかった行数を数える', () => {
+    const result = parseHistoryEntries({
       movies: [entry({ filename: 123 }), entry({ status: 'unknown' }), null, entry()],
     });
 
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.shortId).toBe('AbCdEf123456');
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]?.shortId).toBe('AbCdEf123456');
+    expect(result.dropped).toBe(3);
   });
 
   test('pin されていない動画の expiresAt は残す', () => {
-    expect(parseHistoryEntries({ movies: [entry({ expiresAt: null })] })[0]?.expiresAt).toBeNull();
+    expect(
+      parseHistoryEntries({ movies: [entry({ expiresAt: null })] }).entries[0]?.expiresAt
+    ).toBeNull();
   });
 
   test.each([[null], [{}], [{ movies: 'x' }], [[]]])('%p は空配列', (payload) => {
-    expect(parseHistoryEntries(payload)).toEqual([]);
+    expect(parseHistoryEntries(payload)).toEqual({ entries: [], dropped: 0 });
   });
 });
 

--- a/web/tests/ui/session-view.test.ts
+++ b/web/tests/ui/session-view.test.ts
@@ -2,18 +2,30 @@ import { afterEach, describe, expect, test } from 'bun:test';
 
 import { resolveAuthState } from '../../src/lib/ui/session-view';
 
-/** resolveAuthState が触るのは dataset と querySelectorAll だけ。 */
-class FakeRoot {
-  readonly dataset: Record<string, string> = { authState: 'guest' };
+/** ヘッダーの失敗告知（hidden を外して文言を差し込む先）。 */
+class FakeAlert {
+  readonly dataset: Record<string, string> = { msgSessionUnavailable: 'ログイン状態を確認できません' };
+  readonly message = { textContent: '' };
+  hidden = true;
 
-  querySelectorAll(): unknown[] {
-    return [];
+  querySelector(selector: string): unknown {
+    return selector === '[data-session-error-message]' ? this.message : null;
   }
 }
 
-function fakeRoot(): { root: HTMLElement; dataset: Record<string, string> } {
+/** resolveAuthState が触るのは dataset と querySelectorAll だけ。 */
+class FakeRoot {
+  readonly dataset: Record<string, string> = { authState: 'guest' };
+  readonly alert = new FakeAlert();
+
+  querySelectorAll(selector: string): unknown[] {
+    return selector === '[data-session-error]' ? [this.alert] : [];
+  }
+}
+
+function fakeRoot(): { root: HTMLElement; dataset: Record<string, string>; alert: FakeAlert } {
   const fake = new FakeRoot();
-  return { root: fake as unknown as HTMLElement, dataset: fake.dataset };
+  return { root: fake as unknown as HTMLElement, dataset: fake.dataset, alert: fake.alert };
 }
 
 function respondWith(status: number, body = '{}'): typeof fetch {
@@ -41,10 +53,11 @@ afterEach(() => {
 describe('resolveAuthState', () => {
   test('401 は未ログインとして guest にする', async () => {
     captureConsoleError();
-    const { root, dataset } = fakeRoot();
+    const { root, dataset, alert } = fakeRoot();
 
     expect(await resolveAuthState(root, respondWith(401))).toBe('guest');
     expect(dataset['authState']).toBe('guest');
+    expect(alert.hidden).toBe(true);
     expect(errors).toHaveLength(0);
   });
 
@@ -57,20 +70,33 @@ describe('resolveAuthState', () => {
 
   test('通信できないときは guest ではなくエラー表示にする', async () => {
     captureConsoleError();
-    const { root, dataset } = fakeRoot();
+    const { root, dataset, alert } = fakeRoot();
     const failing = (() => Promise.reject(new Error('offline'))) as unknown as typeof fetch;
 
     expect(await resolveAuthState(root, failing)).toBe('error');
     expect(dataset['authState']).toBe('error');
-    expect(errors).toHaveLength(1);
+    expect(alert.hidden).toBe(false);
+    expect(alert.message.textContent).toBe('ログイン状態を確認できません');
+  });
+
+  test('console には例外の種別だけを出し、Error オブジェクトを渡さない', async () => {
+    captureConsoleError();
+    const { root } = fakeRoot();
+    const failing = (() =>
+      Promise.reject(new TypeError('Failed to fetch https://secret.example/'))) as unknown as typeof fetch;
+
+    await resolveAuthState(root, failing);
+
+    expect(errors).toEqual([['session_state_unresolved: TypeError']]);
   });
 
   test.each([[500], [502], [403]])('%p は guest ではなくエラー表示にする', async (status) => {
     captureConsoleError();
-    const { root, dataset } = fakeRoot();
+    const { root, dataset, alert } = fakeRoot();
 
     expect(await resolveAuthState(root, respondWith(status))).toBe('error');
     expect(dataset['authState']).toBe('error');
-    expect(errors).toHaveLength(1);
+    expect(alert.hidden).toBe(false);
+    expect(errors).toEqual([[`session_state_unresolved: status ${status}`]]);
   });
 });

--- a/web/tests/ui/session-view.test.ts
+++ b/web/tests/ui/session-view.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { resolveAuthState } from '../../src/lib/ui/session-view';
+
+/** resolveAuthState が触るのは dataset と querySelectorAll だけ。 */
+class FakeRoot {
+  readonly dataset: Record<string, string> = { authState: 'guest' };
+
+  querySelectorAll(): unknown[] {
+    return [];
+  }
+}
+
+function fakeRoot(): { root: HTMLElement; dataset: Record<string, string> } {
+  const fake = new FakeRoot();
+  return { root: fake as unknown as HTMLElement, dataset: fake.dataset };
+}
+
+function respondWith(status: number, body = '{}'): typeof fetch {
+  return (async () =>
+    new Response(body, {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch;
+}
+
+const originalConsoleError = console.error;
+const errors: unknown[][] = [];
+
+function captureConsoleError(): void {
+  errors.length = 0;
+  console.error = (...args: unknown[]) => {
+    errors.push(args);
+  };
+}
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+describe('resolveAuthState', () => {
+  test('401 は未ログインとして guest にする', async () => {
+    captureConsoleError();
+    const { root, dataset } = fakeRoot();
+
+    expect(await resolveAuthState(root, respondWith(401))).toBe('guest');
+    expect(dataset['authState']).toBe('guest');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('200 はログイン済みとして member にする', async () => {
+    const { root, dataset } = fakeRoot();
+
+    expect(await resolveAuthState(root, respondWith(200, '{"name":"noricha"}'))).toBe('member');
+    expect(dataset['authState']).toBe('member');
+  });
+
+  test('通信できないときは guest ではなくエラー表示にする', async () => {
+    captureConsoleError();
+    const { root, dataset } = fakeRoot();
+    const failing = (() => Promise.reject(new Error('offline'))) as unknown as typeof fetch;
+
+    expect(await resolveAuthState(root, failing)).toBe('error');
+    expect(dataset['authState']).toBe('error');
+    expect(errors).toHaveLength(1);
+  });
+
+  test.each([[500], [502], [403]])('%p は guest ではなくエラー表示にする', async (status) => {
+    captureConsoleError();
+    const { root, dataset } = fakeRoot();
+
+    expect(await resolveAuthState(root, respondWith(status))).toBe('error');
+    expect(dataset['authState']).toBe('error');
+    expect(errors).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## なぜこの変更が必要か

失敗を成功や「空」として扱うフォールバックが 3 つ残っていた（Issue #65、握り潰されたエラーの横断監査の根 R3b）。所有者判定の catch が全例外を「他人」にするため署名鍵の破損・D1 障害でも正常表示され所有者が pin / 削除 UI を失う。セッション取得の通信失敗を guest 扱いにして認証基盤の障害を検知できない。履歴のパースで落ちた行を黙って間引き、全件落ちると「履歴なし」に見える。

## 変更内容

- 所有者判定を `services/auth.ts` の `resolvePreviewOwner`（判別 union）に集約。基盤異常は `preview_owner_check_failed`（`errorName` 付き）を error 記録して **503**（`PreviewUnavailable.astro`）。Cookie 不在は鍵にも D1 にも触れず非所有者で確定（匿名の公開閲覧・VRChat からの再生は 200 のまま）
- セッション取得: 401 だけが guest。fetch の reject と 401 以外の失敗は `data-auth-state='error'` にしてヘッダーに告知（`hidden` 切替 + i18n 文言）。error 時も guest の hero・変換パネル・ログイン導線は残す（`data-auth-only="guest error"`）
- 履歴: `parseHistoryEntries` が `{ entries, dropped, malformed }` を返し、1 件でも落ちたら（または `movies` が非配列なら）error 表示。件数を `console.error`
- `logWorkerFailure` に任意の `errorName`（message / stack は入れない）

## 意思決定

### 採用アプローチ
- 基盤異常は 503（他人の動画として正常表示しない）。ログイン済み利用者が他人の公開動画を見る時も障害中は 503 になるが、fail-loud を優先（匿名は影響なし。ユーザー決定 2026-08-30）
- 判定ロジックは services に置き、`.astro` は 503 / 404 / 200 への変換だけ（`architecture-contract.toml` の entrypoints → infra 禁止に合わせ、ログ呼び出しも services 側）

### 却下した代替案
- 障害時に「非所有者ビュー + バナー（200）」へ縮退 → 静かに弱い方へ倒れる形が残るため不採用
- 履歴で読めた行だけ表示 + 警告 → Issue の仕様（1 件でも落ちたら error）を優先

## テスト

- [x] `cd web && bun run typecheck` / `bun run build`
- [x] `bun test` 414 pass / 0 fail（所有者判定 6 経路、セッション 6 経路、履歴の dropped / malformed）
- [x] E2E `top.spec.ts` + `preview.spec.ts` + 新規 `session-error.spec.ts` 59 pass
- [x] `check-architecture.py` 新規違反ゼロ

## Screenshot

UI 変更: ヘッダーの認証エラー告知 / 503 ページ。スクショはローカル撮影のみ（`docs/tmp/screenshots/03-session-error-with-guest.png`）。

## レビューゲート

Opus `code-reviewer` + `security-checker`（codex がハングしたためフォールバック）。ブロッキングなし。改善 7 件を反映（詳細は対応表コメント）。

Refs #65

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
