### PR TITLE
feat(web): クライアント側の失敗を識別子だけのテレメトリで Worker のログへ届ける

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -34,9 +34,14 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 エラーは全経路で `ErrorResponse`（`errorCode` + `message`）を返す。
 
 `/api/client-error/` は無認証なので、受け付けるのは allowlist に載る `stage` / `errorCode` /
-`httpStatus` だけで、未知フィールドと 1 KiB 超の本文は 400 で捨てる。送信頻度の上限は
-クライアント側（同じ段 + コードで最大 5 回、送信間隔 1 秒以上）に置く。Worker 側のレート制限は
-持たないので、必要になったら zone の Rate Limiting Rule で `/api/client-error/` を絞る。
+`httpStatus` だけで、未知フィールド・1 KiB 超の本文・`application/json` 以外の Content-Type は
+400 で捨てる。上限は 2 段構え:
+
+- Worker 側: Rate Limiting binding `CLIENT_ERROR_LIMITER` で 30 回 / 分 / IP。超過は 429（本文なし）。
+  binding が無い環境（古い `wrangler dev` 等）は警告を 1 回出して通す（テレメトリのために報告者を 500 にしない）
+- クライアント側: 同じ段 + コードで最大 5 回、送信間隔 1 秒以上
+
+それでも足りなければ zone の Rate Limiting Rule（WAF）で `/api/client-error/` をさらに絞る。
 
 ### 動画入力廃止に伴う互換性
 

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -6,6 +6,7 @@
 | 契約 | 正本ファイル |
 |------|-------------|
 | リクエスト / レスポンス型、エラーコード、上限値、バリデータ | `web/src/lib/contracts/api.ts` |
+| クライアント失敗報告（段・受け付けるコードの allowlist・本文上限） | `web/src/lib/contracts/client-error.ts` |
 | セッション Cookie（名前・署名形式・TTL） | `web/src/lib/contracts/session.ts` |
 | R2 オブジェクトキー、shortId 生成 | `web/src/lib/contracts/r2key.ts` |
 | DB スキーマ | `web/migrations/`（連番の全ファイル。適用は `wrangler d1 migrations apply`） |
@@ -28,8 +29,14 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `POST /api/movies/{shortId}/pin/` | pin の切り替え（保管期限を 1 年後まで延ばす。期限切れは 410 `EXPIRED`） | 本人（所有者） | `PinResponse` |
 | `PATCH /api/movies/{shortId}/` | ファイル名の変更 | 本人（所有者） | `RenameMovieRequest` / `RenameMovieResponse` |
 | `DELETE /api/movies/{shortId}/` | 動画の削除（R2 の実体 → D1 の行の順） | 本人（所有者） | — |
+| `POST /api/client-error/` | クライアント側の失敗報告（識別子だけを受けて `client_error` として構造化ログに残す。応答は 204） | 任意（Cookie があれば `userId` を添える） | `ClientErrorReport` |
 
 エラーは全経路で `ErrorResponse`（`errorCode` + `message`）を返す。
+
+`/api/client-error/` は無認証なので、受け付けるのは allowlist に載る `stage` / `errorCode` /
+`httpStatus` だけで、未知フィールドと 1 KiB 超の本文は 400 で捨てる。送信頻度の上限は
+クライアント側（同じ段 + コードで最大 5 回、送信間隔 1 秒以上）に置く。Worker 側のレート制限は
+持たないので、必要になったら zone の Rate Limiting Rule で `/api/client-error/` を絞る。
 
 ### 動画入力廃止に伴う互換性
 

--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -528,6 +528,34 @@ test.describe('ログイン済み', () => {
     await expect(panel.locator('[data-file-error]')).toBeHidden();
     await expect(panel.getByText(rawMessage)).toHaveCount(0);
   });
+
+  test('変換の失敗は落ちた段と表示コードだけをサーバーへ報告する', async ({ page }) => {
+    await signIn(page);
+    await page.route('**/api/capture/', (route) =>
+      route.fulfill({
+        status: 422,
+        contentType: 'application/json',
+        body: JSON.stringify({ errorCode: 'PDF_URL_NOT_SUPPORTED', message: 'internal upstream detail' }),
+      })
+    );
+    await page.goto('/ja/');
+
+    // 失敗を起こす前に待ち受ける（beacon は失敗表示と同時に飛ぶ）。
+    const report = page.waitForRequest((request) => request.url().includes('/api/client-error/'));
+
+    const panel = page.locator('[data-convert-panel]');
+    await panel.locator('[data-url-input]').fill('https://example.com/report.pdf');
+    await panel.locator('[data-url-form] button[type="submit"]').click();
+
+    const request = await report;
+    const body = request.postData() ?? request.postDataBuffer()?.toString('utf8') ?? '';
+    // URL・ファイル名・下流メッセージが混ざらないことを本文の完全一致で固定する。
+    expect(JSON.parse(body)).toEqual({
+      stage: 'capture',
+      errorCode: 'pdfUrlNotSupported',
+      httpStatus: 422,
+    });
+  });
 });
 
 // 320px は想定する最小幅。ここで横スクロールが出ると、狭い画面でヘッダーが

--- a/web/e2e/top.spec.ts
+++ b/web/e2e/top.spec.ts
@@ -538,19 +538,22 @@ test.describe('ログイン済み', () => {
         body: JSON.stringify({ errorCode: 'PDF_URL_NOT_SUPPORTED', message: 'internal upstream detail' }),
       })
     );
+    // 失敗を起こす前に受け口を用意する（beacon は失敗表示と同時に飛ぶ）。
+    // 全件を溜めて 1 件目だけを見る（何件目が来るかは送信間隔の実装に依存させない）。
+    const reports: string[] = [];
+    await page.route('**/api/client-error/', (route) => {
+      reports.push(route.request().postData() ?? '');
+      return route.fulfill({ status: 204 });
+    });
     await page.goto('/ja/');
-
-    // 失敗を起こす前に待ち受ける（beacon は失敗表示と同時に飛ぶ）。
-    const report = page.waitForRequest((request) => request.url().includes('/api/client-error/'));
 
     const panel = page.locator('[data-convert-panel]');
     await panel.locator('[data-url-input]').fill('https://example.com/report.pdf');
     await panel.locator('[data-url-form] button[type="submit"]').click();
 
-    const request = await report;
-    const body = request.postData() ?? request.postDataBuffer()?.toString('utf8') ?? '';
+    await expect.poll(() => reports.length).toBeGreaterThan(0);
     // URL・ファイル名・下流メッセージが混ざらないことを本文の完全一致で固定する。
-    expect(JSON.parse(body)).toEqual({
+    expect(JSON.parse(reports[0] ?? '')).toEqual({
       stage: 'capture',
       errorCode: 'pdfUrlNotSupported',
       httpStatus: 422,

--- a/web/src/lib/contracts/client-error.ts
+++ b/web/src/lib/contracts/client-error.ts
@@ -1,0 +1,124 @@
+/**
+ * クライアント側の失敗報告（`POST /api/client-error/`）の契約。
+ *
+ * producer はブラウザ（lib/ui）、consumer は Worker（services/client-error.ts）。
+ * 運用の目的は「どの段で落ちたか」を数えることだけなので、載せてよいのは
+ * **識別子と HTTP ステータスだけ**にする。URL・ファイル名・ページ内容・
+ * スタックトレース・自由記述は受け取らない（受け取れば Worker のログに残り、
+ * 後から消せない情報になる）。
+ *
+ * 自由記述を締め出す手段は allowlist と未知キーの拒否の 2 つ。片方だけだと
+ * 「見慣れないフィールドに本文を詰めて送る」経路が残る。
+ *
+ * api.ts と分けているのは、api.ts が契約ファイルの行数上限（400 行）に近く、
+ * この 1 機能を足すと超えるため（層は同じ contracts で、正本の位置は変わらない）。
+ */
+
+import { ERROR_CODES, type ErrorCode, type ValidationResult } from './api';
+
+/** 失敗した段。UI の工程と 1 対 1 に対応させ、ログの絞り込みキーにする。 */
+export const CLIENT_ERROR_STAGES = [
+  'capture',
+  'convert',
+  'upload',
+  'pin',
+  'rename',
+  'delete',
+  'history',
+  'session',
+] as const;
+export type ClientErrorStage = (typeof CLIENT_ERROR_STAGES)[number];
+
+/**
+ * ブラウザ内で完結する失敗の表示コード。ui/upload-flow.ts の UploadErrorCode と
+ * 同じ値を受け付ける（あちらが UI 表示の正本、こちらが受信の正本。取りこぼしは
+ * tests/contracts/client-error.test.ts の包含テストが機械的に検出する）。
+ */
+const CLIENT_UI_ERROR_CODES = [
+  'tooLarge',
+  'unsupported',
+  'tooManyPages',
+  'pageTooLong',
+  'captureTimeout',
+  'sessionExpired',
+  'failed',
+  'pdfUrlNotSupported',
+  'imageUrlNotSupported',
+  'videoUrlNotSupported',
+  'nonWebPageUrl',
+  'wasmLoadTimeout',
+  'imageFetchTimeout',
+  'uploadTimeout',
+  'apiTimeout',
+] as const;
+type ClientUiErrorCode = (typeof CLIENT_UI_ERROR_CODES)[number];
+
+/** 受け付けるコード。API のエラーコードと UI の表示コードの和集合。 */
+export type ClientErrorCode = ErrorCode | ClientUiErrorCode;
+export const CLIENT_ERROR_CODES: readonly ClientErrorCode[] = [
+  ...Object.values(ERROR_CODES),
+  ...CLIENT_UI_ERROR_CODES,
+];
+
+const ALLOWED_CODES: ReadonlySet<string> = new Set<string>(CLIENT_ERROR_CODES);
+
+/** allowlist に載っているコードか。サーバー応答をそのまま転送しないための門番。 */
+export function isClientErrorCode(value: string): value is ClientErrorCode {
+  return ALLOWED_CODES.has(value);
+}
+
+/**
+ * 本文の上限（バイト）。識別子 3 つに 1 KiB は十分すぎるので、これを超える本文は
+ * 中身を見るまでもなく契約違反として捨てる（無認証の口なので読み切る前に止める）。
+ */
+export const MAX_CLIENT_ERROR_BODY_BYTES = 1024;
+
+/** 受け付けるフィールドはこの 3 つだけ。増やすときは「識別子か」を必ず問う。 */
+export interface ClientErrorReport {
+  stage: ClientErrorStage;
+  errorCode: ClientErrorCode;
+  /** 失敗が HTTP 応答由来のときだけ。ブラウザ内の失敗では省く。 */
+  httpStatus?: number;
+}
+
+const REPORT_FIELDS: readonly string[] = ['stage', 'errorCode', 'httpStatus'];
+
+function invalid(message: string): { ok: false; error: { errorCode: ErrorCode; message: string } } {
+  return { ok: false, error: { errorCode: ERROR_CODES.invalidRequest, message } };
+}
+
+/**
+ * 失敗報告を検証する。
+ *
+ * 既存の validate* と違い**未知のフィールドを拒否する**。無視すると、そこへ
+ * 自由記述を詰めた報告が「正当な報告」として通り続けてしまうため。
+ */
+export function validateClientErrorReport(input: unknown): ValidationResult<ClientErrorReport> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return invalid('リクエストボディは JSON オブジェクトである必要があります');
+  }
+  const body = input as Record<string, unknown>;
+
+  for (const key of Object.keys(body)) {
+    if (!REPORT_FIELDS.includes(key)) return invalid('未知のフィールドは受け付けません');
+  }
+
+  const { stage, errorCode, httpStatus } = body;
+
+  if (typeof stage !== 'string' || !(CLIENT_ERROR_STAGES as readonly string[]).includes(stage)) {
+    return invalid('stage が不正です');
+  }
+  if (typeof errorCode !== 'string' || !isClientErrorCode(errorCode)) {
+    return invalid('errorCode が不正です');
+  }
+  if (httpStatus !== undefined) {
+    if (typeof httpStatus !== 'number' || !Number.isInteger(httpStatus)) {
+      return invalid('httpStatus は整数である必要があります');
+    }
+    if (httpStatus < 100 || httpStatus > 599) return invalid('httpStatus が範囲外です');
+  }
+
+  const value: ClientErrorReport = { stage: stage as ClientErrorStage, errorCode };
+  if (httpStatus !== undefined) value.httpStatus = httpStatus;
+  return { ok: true, value };
+}

--- a/web/src/lib/infra/worker-log.ts
+++ b/web/src/lib/infra/worker-log.ts
@@ -1,4 +1,5 @@
 import type { ErrorCode } from '../contracts/api';
+import type { ClientErrorCode, ClientErrorStage } from '../contracts/client-error';
 
 const SOURCE = 'webscreen-beta-worker';
 
@@ -61,4 +62,40 @@ export function logWorkerFailure({
     return;
   }
   console.error(entry);
+}
+
+/**
+ * ブラウザ内で完結した失敗（撮影・変換・アップロードなど）を 1 行 JSON として記録する。
+ *
+ * 出すのは検証済みの識別子だけ。URL・Cookie・User-Agent・本文は含めない
+ * （報告者は無認証のクライアントなので、通した値はそのままログに焼き付く）。
+ * level を warn にするのは Worker 自身の失敗ではないため。混ぜると Worker の
+ * エラー率が読めなくなる。
+ */
+export function logClientError({
+  stage,
+  errorCode,
+  httpStatus,
+  userId,
+}: {
+  stage: ClientErrorStage;
+  errorCode: ClientErrorCode;
+  httpStatus?: number;
+  userId?: number;
+}): void {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source: SOURCE,
+      severity: 'warn',
+      kind: 'event',
+      level: 'warn',
+      event: 'client_error',
+      stage,
+      errorCode,
+      httpStatus,
+      userId,
+      summary: `client reported ${errorCode} at ${stage}.`,
+    })
+  );
 }

--- a/web/src/lib/infra/worker-log.ts
+++ b/web/src/lib/infra/worker-log.ts
@@ -99,3 +99,23 @@ export function logClientError({
     })
   );
 }
+
+/**
+ * 失敗報告のレート制限 binding が無いまま動いていることを知らせる。
+ *
+ * 制限なしで通す判断（テレメトリのために報告者を 500 にしない）とセットで、
+ * 本番で binding が外れていても気づけるようにするための 1 行。
+ */
+export function logClientErrorLimiterMissing(): void {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source: SOURCE,
+      severity: 'warn',
+      kind: 'event',
+      level: 'warn',
+      event: 'client_error_limiter_missing',
+      summary: 'CLIENT_ERROR_LIMITER binding is missing; accepting reports without a limit.',
+    })
+  );
+}

--- a/web/src/lib/services/client-error.ts
+++ b/web/src/lib/services/client-error.ts
@@ -1,0 +1,115 @@
+/**
+ * クライアント側の失敗報告を受けて構造化ログに残す。
+ *
+ * この口は**無認証**（未ログインの失敗こそ見たいため）。したがって受け取った値は
+ * すべて敵性入力として扱い、契約（contracts/client-error.ts）を通った識別子だけを
+ * ログへ渡す。応答は 204 固定で、報告者に情報を返さない。
+ */
+
+import { ERROR_CODES } from '../contracts/api';
+import {
+  MAX_CLIENT_ERROR_BODY_BYTES,
+  validateClientErrorReport,
+} from '../contracts/client-error';
+import { SESSION_COOKIE_NAME, readCookie, verifySession } from '../contracts/session';
+import { logClientError } from '../infra/worker-log';
+
+export interface ClientErrorDeps {
+  /** あればセッションを検証して userId をログに添える。無ければ guest として記録する。 */
+  signingKey?: CryptoKey;
+  nowSeconds?: number;
+}
+
+/** 不正な報告はすべて同じ 400 で落とす（種類を返し分けても報告者には使い道がない）。 */
+function rejected(message: string): Response {
+  return Response.json(
+    { errorCode: ERROR_CODES.invalidRequest, message },
+    { status: 400, headers: { 'Cache-Control': 'no-store' } }
+  );
+}
+
+export async function handleClientErrorReport(
+  request: Request,
+  deps: ClientErrorDeps = {}
+): Promise<Response> {
+  const text = await readLimitedText(request, MAX_CLIENT_ERROR_BODY_BYTES);
+  if (text === null) return rejected('リクエストボディが大きすぎます');
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return rejected('リクエストボディは JSON である必要があります');
+  }
+
+  const result = validateClientErrorReport(payload);
+  if (!result.ok) {
+    return Response.json(result.error, { status: 400, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  const userId = await resolveUserId(request, deps);
+  logClientError({ ...result.value, userId });
+
+  return new Response(null, { status: 204, headers: { 'Cache-Control': 'no-store' } });
+}
+
+/**
+ * Cookie の署名だけで userId を決める（D1 は引かない）。
+ *
+ * 誰でも叩ける口なので、報告 1 件ごとに DB を触らせない。存在しないユーザーの
+ * 署名済み Cookie が来ても、ログに数字が 1 つ残るだけで実害はない。
+ */
+async function resolveUserId(
+  request: Request,
+  deps: ClientErrorDeps
+): Promise<number | undefined> {
+  if (!deps.signingKey) return undefined;
+  const token = readCookie(request.headers.get('Cookie'), SESSION_COOKIE_NAME);
+  if (!token) return undefined;
+  const session = await verifySession(token, deps.signingKey, deps.nowSeconds);
+  return session?.uid;
+}
+
+/**
+ * 上限を超えた時点で読み取りを打ち切る。
+ *
+ * Content-Length は自己申告なので、宣言値の検査だけでは足りない（申告せずに
+ * 大きな本文を流し込めるため）。実際に読んだバイト数でも必ず切る。
+ */
+async function readLimitedText(request: Request, maxBytes: number): Promise<string | null> {
+  const declared = request.headers.get('content-length');
+  if (declared !== null) {
+    const size = Number(declared);
+    if (!Number.isFinite(size) || size > maxBytes) return null;
+  }
+
+  const body = request.body;
+  if (!body) return '';
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return null;
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}

--- a/web/src/lib/services/client-error.ts
+++ b/web/src/lib/services/client-error.ts
@@ -12,11 +12,18 @@ import {
   validateClientErrorReport,
 } from '../contracts/client-error';
 import { SESSION_COOKIE_NAME, readCookie, verifySession } from '../contracts/session';
-import { logClientError } from '../infra/worker-log';
+import { logClientError, logClientErrorLimiterMissing } from '../infra/worker-log';
+
+/** Workers の Rate Limiting binding のうち、ここで使う分だけを型にする。 */
+export interface ClientErrorRateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
 
 export interface ClientErrorDeps {
   /** あればセッションを検証して userId をログに添える。無ければ guest として記録する。 */
   signingKey?: CryptoKey;
+  /** IP 単位の受け入れ上限。binding が無い環境では制限なしで通す。 */
+  limiter?: ClientErrorRateLimiter;
   nowSeconds?: number;
 }
 
@@ -32,6 +39,19 @@ export async function handleClientErrorReport(
   request: Request,
   deps: ClientErrorDeps = {}
 ): Promise<Response> {
+  // 本文を読む前に絞る。壊れたクライアントの連投でログが埋まると、本来見たい
+  // 失敗が読めなくなる（観測のための口が観測を潰す）。
+  if (!(await withinRateLimit(request, deps.limiter))) {
+    return new Response(null, { status: 429, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  // 正規の送信は sendBeacon の Blob type / fetch のヘッダーとも application/json。
+  // CORS-safelisted な型（text/plain 等）を弾くことで、preflight の要らない
+  // クロスオリジンの単純 POST でログを注ぎ込まれる経路を塞ぐ。
+  if (!isJsonContentType(request.headers.get('content-type'))) {
+    return rejected('Content-Type は application/json である必要があります');
+  }
+
   const text = await readLimitedText(request, MAX_CLIENT_ERROR_BODY_BYTES);
   if (text === null) return rejected('リクエストボディが大きすぎます');
 
@@ -51,6 +71,41 @@ export async function handleClientErrorReport(
   logClientError({ ...result.value, userId });
 
   return new Response(null, { status: 204, headers: { 'Cache-Control': 'no-store' } });
+}
+
+/** binding 不在を知らせたか。isolate ごとに 1 回だけ出す（毎回出すとログが埋まる）。 */
+let limiterMissingLogged = false;
+
+/**
+ * IP 単位の上限に収まっているか。
+ *
+ * binding が無い環境（古い wrangler dev・ローカル）では通す。テレメトリの都合で
+ * 500 を返すと、失敗を報告しに来たクライアントを二重に失敗させることになるため。
+ * ただし本番で外れていたら気づけないと困るので、warn を 1 回だけ残す。
+ */
+async function withinRateLimit(
+  request: Request,
+  limiter?: ClientErrorRateLimiter
+): Promise<boolean> {
+  if (!limiter) {
+    if (!limiterMissingLogged) {
+      limiterMissingLogged = true;
+      logClientErrorLimiterMissing();
+    }
+    return true;
+  }
+
+  // cf-connecting-ip は Cloudflare が付ける接続元。無い経路（ローカル等）は
+  // 1 つの鍵に束ねる（区別できない相手を個別に許すより、まとめて絞る方が安全）。
+  const { success } = await limiter.limit({
+    key: request.headers.get('cf-connecting-ip') ?? 'unknown',
+  });
+  return success;
+}
+
+/** charset 付き・大文字混じりでも判定できるように、型の先頭だけを見る。 */
+function isJsonContentType(value: string | null): boolean {
+  return value !== null && value.trimStart().toLowerCase().startsWith('application/json');
 }
 
 /**

--- a/web/src/lib/ui/client-error-report.ts
+++ b/web/src/lib/ui/client-error-report.ts
@@ -1,0 +1,168 @@
+/**
+ * クライアント側の失敗を `POST /api/client-error/` へ投げっぱなしで報告する。
+ *
+ * 目的は運用側が「どの段で落ちたか」を数えられるようにすること。したがって
+ * **送るのは識別子だけ**で、URL・ファイル名・ページ内容・例外メッセージ・
+ * スタックトレースは一切載せない（受信側の allowlist と二重の歯止めにする）。
+ *
+ * 送信は必ず fire-and-forget。ここでの失敗を UI に伝播させない（テレメトリのために
+ * 利用者の画面が壊れるのは本末転倒）。
+ *
+ * 送信頻度の上限もここで持つ。失敗はループしやすく（再試行・連続アップロード）、
+ * 素直に送ると 1 回の事故で数百件のリクエストが飛ぶため。サーバー側での
+ * レート制限は置かない（必要になったら Cloudflare の Rate Limiting Rule で絞る）。
+ */
+
+import {
+  isClientErrorCode,
+  type ClientErrorCode,
+  type ClientErrorReport,
+  type ClientErrorStage,
+} from '../contracts/client-error';
+import { JsonRequestError } from './request-json';
+import type { ProgressStage } from './upload-flow';
+
+/** trailingSlash: 'always' のためスラッシュ必須。省くと 301 を挟む。 */
+export const CLIENT_ERROR_ENDPOINT = '/api/client-error/';
+
+/** 同じ「段 + コード」の組を 1 ページ表示につき送る上限。 */
+export const CLIENT_ERROR_MAX_PER_KEY = 5;
+
+/** 送信間隔の下限（ミリ秒）。組を問わず、この間隔より詰めては送らない。 */
+export const CLIENT_ERROR_MIN_INTERVAL_MS = 1000;
+
+/** 送信済みの記録。ページを読み直せば初期化される（サーバーに状態を持たせない）。 */
+export interface ClientErrorThrottle {
+  readonly counts: Readonly<Record<string, number>>;
+  readonly lastSentAtMs: number | null;
+}
+
+export const INITIAL_CLIENT_ERROR_THROTTLE: ClientErrorThrottle = {
+  counts: {},
+  lastSentAtMs: null,
+};
+
+function throttleKey(report: ClientErrorReport): string {
+  return `${report.stage}:${report.errorCode}`;
+}
+
+/**
+ * 送ってよいかを判定し、次の記録を返す純関数。
+ *
+ * 却下した報告は数えない（数えると、上限に達した後の失敗が延々と記録を更新して
+ * 「いつまでも送れない」状態になる）。
+ */
+export function admitClientError(
+  state: ClientErrorThrottle,
+  report: ClientErrorReport,
+  nowMs: number
+): { admitted: boolean; state: ClientErrorThrottle } {
+  const key = throttleKey(report);
+  const sent = state.counts[key] ?? 0;
+  if (sent >= CLIENT_ERROR_MAX_PER_KEY) return { admitted: false, state };
+  if (state.lastSentAtMs !== null && nowMs - state.lastSentAtMs < CLIENT_ERROR_MIN_INTERVAL_MS) {
+    return { admitted: false, state };
+  }
+
+  return {
+    admitted: true,
+    state: { counts: { ...state.counts, [key]: sent + 1 }, lastSentAtMs: nowMs },
+  };
+}
+
+/**
+ * 送信する本文を組み立てる。
+ *
+ * スプレッドで作らないのは、呼び出し側が余分なフィールドを持つ値を渡しても
+ * 混入させないため（テストでキーの集合を固定している）。
+ */
+export function clientErrorPayload(report: ClientErrorReport): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    stage: report.stage,
+    errorCode: report.errorCode,
+  };
+  if (report.httpStatus !== undefined) payload['httpStatus'] = report.httpStatus;
+  return payload;
+}
+
+/**
+ * 失敗の値から報告コードを決める。
+ *
+ * サーバー応答の errorCode をそのまま転送しない。allowlist に無い値は 'failed' に
+ * 丸める（応答本文が汚染されていても、送るのは既知の識別子だけに保つ）。
+ */
+export function clientErrorCodeOf(error: unknown, fallback: ClientErrorCode = 'failed'): ClientErrorCode {
+  if (error instanceof JsonRequestError && error.errorCode && isClientErrorCode(error.errorCode)) {
+    return error.errorCode;
+  }
+  return fallback;
+}
+
+/** HTTP 応答由来の失敗ならステータスを返す。ブラウザ内の失敗では undefined。 */
+export function clientErrorHttpStatus(error: unknown): number | undefined {
+  return error instanceof JsonRequestError ? error.status : undefined;
+}
+
+/** 変換の進捗段階を、報告する段へ落とす。段が未定のうちの失敗は変換扱いにする。 */
+export function conversionClientStage(stage: ProgressStage | null): ClientErrorStage {
+  if (stage === 'capturing') return 'capture';
+  if (stage === 'uploading') return 'upload';
+  return 'convert';
+}
+
+export interface ClientErrorReporterDeps {
+  /** 実送信。テストと SSR での差し替え口。 */
+  send?: (body: string) => void;
+  now?: () => number;
+}
+
+/**
+ * 上限つきの報告関数を作る。状態は返した関数のクロージャに閉じる
+ * （モジュール全体で共有すると、テストが互いの送信回数に影響される）。
+ */
+export function createClientErrorReporter(
+  deps: ClientErrorReporterDeps = {}
+): (report: ClientErrorReport) => void {
+  const send = deps.send ?? sendClientErrorReport;
+  const now = deps.now ?? (() => Date.now());
+  let throttle = INITIAL_CLIENT_ERROR_THROTTLE;
+
+  return (report) => {
+    try {
+      const decision = admitClientError(throttle, report, now());
+      throttle = decision.state;
+      if (!decision.admitted) return;
+      send(JSON.stringify(clientErrorPayload(report)));
+    } catch {
+      // 報告できないこと自体は利用者に関係がない。画面の失敗表示を優先する。
+    }
+  };
+}
+
+/** sendBeacon を優先する（離脱直前でも送るため）。使えない環境では keepalive の fetch に落とす。 */
+function sendClientErrorReport(body: string): void {
+  const beacon = typeof navigator !== 'undefined' ? navigator.sendBeacon?.bind(navigator) : undefined;
+  if (beacon && beacon(CLIENT_ERROR_ENDPOINT, new Blob([body], { type: 'application/json' }))) {
+    return;
+  }
+
+  void fetch(CLIENT_ERROR_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+    credentials: 'same-origin',
+  }).catch(() => undefined);
+}
+
+/** 画面から使う既定の報告関数。1 ページ表示ぶんの上限を共有する。 */
+export const reportClientError = createClientErrorReporter();
+
+/** HTTP 要求の失敗を 1 行で報告する。送るのは段・allowlist を通したコード・ステータスだけ。 */
+export function reportRequestFailure(stage: ClientErrorStage, error: unknown): void {
+  reportClientError({
+    stage,
+    errorCode: clientErrorCodeOf(error),
+    httpStatus: clientErrorHttpStatus(error),
+  });
+}

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -330,6 +330,9 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     try {
       preflight = await preflightInputFiles(files);
     } catch (error) {
+      // 捨てられた世代の失敗は画面にも報告にも出さない（利用者が既に次の入力へ
+      // 進んでおり、その失敗はもうどこにも影響しない）。
+      if (signal.aborted || current !== generation) return;
       // 選択後にファイルが読めなくなった等。握り潰すと unhandled rejection のまま
       // 画面が idle で固まるので、失敗として見せる。
       console.error('preflight failed', error);
@@ -339,6 +342,9 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     }
     if (current !== generation) return;
     if (!preflight.ok) {
+      // 入力そのものが対象外。撮影も変換も始まっていないが、どの入力が弾かれて
+      // いるかは運用側から見えないので報告する（段は変換の入口として convert）。
+      reportClientError({ stage: 'convert', errorCode: 'unsupported' });
       dispatch({ type: 'failed', errorCode: 'unsupported' }, current);
       return;
     }
@@ -348,6 +354,11 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     };
     const next = reduceUpload(state, event);
     dispatch(event, current);
+    // 選択の時点で弾かれた入力（大きすぎる・種類が混ざっている等）も報告する。
+    // 変換が始まらない失敗は console にすら残らず、運用側から完全に見えないため。
+    if (next.phase === 'error' && next.errorCode !== null) {
+      reportClientError({ stage: 'convert', errorCode: next.errorCode });
+    }
     if (next.phase !== 'converting' || next.kind === null || next.kind === 'web' || next.kind !== preflight.kind) return;
     const kind = next.kind;
     void convertFilesToMp4(

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -17,6 +17,11 @@ import {
 } from '../contracts/api';
 import { isShortId } from '../contracts/r2key';
 import { collectCaptures } from './capture-pages';
+import {
+  clientErrorHttpStatus,
+  conversionClientStage,
+  reportClientError,
+} from './client-error-report';
 import { movieEndpoint } from './history-view';
 import {
   API_REQUEST_TIMEOUT_MS,
@@ -178,6 +183,7 @@ export async function uploadMp4(
   signal?: AbortSignal
 ): Promise<void> {
   if (mp4.size > MAX_UPLOAD_BYTES) {
+    reportClientError({ stage: 'upload', errorCode: 'tooLarge' });
     dispatch({ type: 'failed', errorCode: 'tooLarge' }, runGeneration);
     return;
   }
@@ -269,6 +275,18 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     }
   };
 
+  /**
+   * 失敗した段を報告する。dispatch より先に呼ぶこと（失敗の状態遷移は stage を
+   * 捨てるので、後から読むとどの段で落ちたか分からなくなる）。
+   */
+  const reportFailure = (error: unknown, errorCode: UploadErrorCode): void => {
+    reportClientError({
+      stage: conversionClientStage(state.stage),
+      errorCode,
+      httpStatus: clientErrorHttpStatus(error),
+    });
+  };
+
   let activeRun: AbortController | null = null;
 
   /** 新しい変換の世代と中止シグナルを起こす。前の変換が残っていれば道連れに止める。 */
@@ -315,6 +333,7 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
       // 選択後にファイルが読めなくなった等。握り潰すと unhandled rejection のまま
       // 画面が idle で固まるので、失敗として見せる。
       console.error('preflight failed', error);
+      reportClientError({ stage: 'convert', errorCode: 'failed' });
       dispatch({ type: 'failed', errorCode: 'failed' }, current);
       return;
     }
@@ -356,7 +375,9 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
         // 中止は失敗ではない。cancelRun が既に初期表示へ戻している。
         if (signal.aborted) return;
         console.error('conversion failed', error);
-        dispatch({ type: 'failed', errorCode: uploadErrorCode(error) }, current);
+        const errorCode = uploadErrorCode(error);
+        reportFailure(error, errorCode);
+        dispatch({ type: 'failed', errorCode }, current);
       });
   };
   fileInput?.addEventListener('change', () => {
@@ -429,7 +450,9 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
         // 中止は失敗ではない。cancelRun が既に初期表示へ戻している。
         if (signal.aborted) return;
         console.error('conversion failed', error);
-        dispatch({ type: 'failed', errorCode: uploadErrorCode(error), target: 'url' }, current);
+        const errorCode = uploadErrorCode(error);
+        reportFailure(error, errorCode);
+        dispatch({ type: 'failed', errorCode, target: 'url' }, current);
       });
   });
 

--- a/web/src/lib/ui/history-menu.ts
+++ b/web/src/lib/ui/history-menu.ts
@@ -7,6 +7,7 @@
  */
 
 import type { HistoryEntry } from '../contracts/api';
+import { reportClientError, reportRequestFailure } from './client-error-report';
 import {
   HISTORY_ENDPOINT,
   formatRelativeTime,
@@ -70,6 +71,7 @@ function wireDelete(row: HTMLElement, root: HTMLElement, fetchImpl: typeof fetch
         }, fetchImpl);
       } catch (requestError) {
         error = requestError;
+        reportRequestFailure('delete', requestError);
       }
 
       if (error !== undefined) {
@@ -126,6 +128,7 @@ async function load(root: HTMLElement, fetchImpl: typeof fetch): Promise<void> {
   try {
     payload = await requestJson(HISTORY_ENDPOINT, { credentials: 'same-origin' }, fetchImpl);
   } catch (error) {
+    reportRequestFailure('history', error);
     showError(root, requestFailureMessage(root, error, root.dataset['msgHistoryFailed'] ?? ''));
     return;
   }
@@ -134,6 +137,9 @@ async function load(root: HTMLElement, fetchImpl: typeof fetch): Promise<void> {
   if (malformed || dropped > 0) {
     // 読めた行だけ出すと、全件落ちた時に「履歴なし」と見分けが付かない。
     console.error(malformed ? 'history_payload_malformed' : `history_entries_dropped: ${dropped}`);
+    // 応答は 200 なので通信の失敗としては見えない。中身が壊れていることは
+    // console だけでなくサーバー側にも残す（送るのは段とコードだけ）。
+    reportClientError({ stage: 'history', errorCode: 'failed' });
     showError(root, root.dataset['msgHistoryFailed'] ?? '');
     return;
   }

--- a/web/src/lib/ui/preview-actions.ts
+++ b/web/src/lib/ui/preview-actions.ts
@@ -8,6 +8,7 @@
 import { MAX_FILENAME_LENGTH } from '../contracts/api';
 import { copyToClipboard } from './clipboard';
 import { AUTO_COPY_FEEDBACK_DELAY_MS, consumeAutoCopy, type SessionStorage } from './auto-copy';
+import { reportRequestFailure } from './client-error-report';
 import { movieEndpoint, pinEndpoint } from './history-view';
 import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
 
@@ -112,6 +113,7 @@ function wirePin(root: HTMLElement, fetchImpl: typeof fetch, reload: () => void)
         return;
       } catch (requestError) {
         error = requestError;
+        reportRequestFailure('pin', requestError);
       }
 
       button.disabled = false;
@@ -189,6 +191,7 @@ function wireRename(root: HTMLElement, fetchImpl: typeof fetch, schedule: Schedu
         }, fetchImpl);
       } catch (requestError) {
         error = requestError;
+        reportRequestFailure('rename', requestError);
       }
 
       button.disabled = false;
@@ -270,6 +273,7 @@ function wireDelete(root: HTMLElement, fetchImpl: typeof fetch): void {
         }, fetchImpl);
       } catch (requestError) {
         error = requestError;
+        reportRequestFailure('delete', requestError);
       }
 
       if (error === undefined) {

--- a/web/src/lib/ui/session-view.ts
+++ b/web/src/lib/ui/session-view.ts
@@ -14,6 +14,19 @@ export const ME_ENDPOINT = '/api/me/';
 
 export type AuthState = 'guest' | 'member' | 'error';
 
+/**
+ * ページから離れる最中かどうか。
+ *
+ * 離脱すると進行中の fetch は reject するが、それは障害ではない。区別せずに
+ * 報告すると、遷移のたびに偽の失敗が積み上がって本物の到達不能が埋もれる。
+ */
+let leavingPage = false;
+if (typeof window !== 'undefined') {
+  window.addEventListener('pagehide', () => {
+    leavingPage = true;
+  });
+}
+
 export function applyViewer(root: HTMLElement, viewer: Viewer): void {
   for (const element of root.querySelectorAll<HTMLElement>('[data-viewer-name]')) {
     if (viewer.name !== null) element.textContent = viewer.name;
@@ -73,7 +86,8 @@ export async function resolveAuthState(
     response = await fetchImpl(ME_ENDPOINT, { credentials: 'same-origin' });
   } catch (error) {
     // 到達できないこと自体（CDN 断・オフライン）は運用側から見えないので報告する。
-    reportClientError({ stage: 'session', errorCode: 'failed' });
+    // 離脱による中断はここに来るが障害ではないので送らない。
+    if (!leavingPage) reportClientError({ stage: 'session', errorCode: 'failed' });
     return failAuthState(root, error instanceof Error ? error.name : 'UnknownError');
   }
 
@@ -83,7 +97,7 @@ export async function resolveAuthState(
   }
 
   if (!response.ok) {
-    // 401 は上で返しているので、ここに来るのは認証基盤の異常だけ。
+    // 401 は上で返しているので、ここに来るのは認証基盤の異常だけ（404 も含む）。
     reportClientError({ stage: 'session', errorCode: 'failed', httpStatus: response.status });
     return failAuthState(root, `status ${response.status}`);
   }

--- a/web/src/lib/ui/session-view.ts
+++ b/web/src/lib/ui/session-view.ts
@@ -6,6 +6,7 @@
  * 既定値は guest なので、JS が動かない環境でもログイン導線だけは表示される。
  */
 
+import { reportClientError } from './client-error-report';
 import { parseViewer, viewerInitial, type Viewer } from './viewer';
 
 /** trailingSlash: 'always' のためスラッシュ必須。省くと 301 を挟む。 */
@@ -71,6 +72,8 @@ export async function resolveAuthState(
   try {
     response = await fetchImpl(ME_ENDPOINT, { credentials: 'same-origin' });
   } catch (error) {
+    // 到達できないこと自体（CDN 断・オフライン）は運用側から見えないので報告する。
+    reportClientError({ stage: 'session', errorCode: 'failed' });
     return failAuthState(root, error instanceof Error ? error.name : 'UnknownError');
   }
 
@@ -80,6 +83,8 @@ export async function resolveAuthState(
   }
 
   if (!response.ok) {
+    // 401 は上で返しているので、ここに来るのは認証基盤の異常だけ。
+    reportClientError({ stage: 'session', errorCode: 'failed', httpStatus: response.status });
     return failAuthState(root, `status ${response.status}`);
   }
 

--- a/web/src/pages/api/client-error.ts
+++ b/web/src/pages/api/client-error.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+
+import { importSigningKey } from '../../lib/contracts/session';
+import { handleClientErrorReport } from '../../lib/services/client-error';
+
+export const prerender = false;
+
+interface ClientErrorBindings {
+  SESSION_SIGNING_KEY?: string;
+}
+
+/**
+ * ブラウザ内で完結した失敗の報告を受ける。認証は任意（未ログインの失敗も数えたい）。
+ *
+ * 応答は常に 204 か 400 で、報告者へは何も返さない（beacon の投げっぱなしを前提にする）。
+ */
+export const POST: APIRoute = async ({ request }) => {
+  const bindings = env as unknown as ClientErrorBindings;
+  const signingKey = bindings.SESSION_SIGNING_KEY
+    ? await importSigningKey(bindings.SESSION_SIGNING_KEY)
+    : undefined;
+
+  return handleClientErrorReport(request, { signingKey });
+};

--- a/web/src/pages/api/client-error.ts
+++ b/web/src/pages/api/client-error.ts
@@ -2,12 +2,16 @@ import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 
 import { importSigningKey } from '../../lib/contracts/session';
-import { handleClientErrorReport } from '../../lib/services/client-error';
+import {
+  handleClientErrorReport,
+  type ClientErrorRateLimiter,
+} from '../../lib/services/client-error';
 
 export const prerender = false;
 
 interface ClientErrorBindings {
   SESSION_SIGNING_KEY?: string;
+  CLIENT_ERROR_LIMITER?: ClientErrorRateLimiter;
 }
 
 /**
@@ -17,9 +21,14 @@ interface ClientErrorBindings {
  */
 export const POST: APIRoute = async ({ request }) => {
   const bindings = env as unknown as ClientErrorBindings;
+  // 鍵の欠落は設定不備であって報告者の問題ではないので、ここでは userId 無しに
+  // 降格して受ける（欠落自体は me.ts 側のログインが先に壊れて露見する）。
   const signingKey = bindings.SESSION_SIGNING_KEY
     ? await importSigningKey(bindings.SESSION_SIGNING_KEY)
     : undefined;
 
-  return handleClientErrorReport(request, { signingKey });
+  return handleClientErrorReport(request, {
+    signingKey,
+    limiter: bindings.CLIENT_ERROR_LIMITER,
+  });
 };

--- a/web/tests/contracts/client-error.test.ts
+++ b/web/tests/contracts/client-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ERROR_CODES } from '../../src/lib/contracts/api';
+import {
+  CLIENT_ERROR_CODES,
+  isClientErrorCode,
+  validateClientErrorReport,
+} from '../../src/lib/contracts/client-error';
+import { UPLOAD_ERROR_CODES } from '../../src/lib/ui/upload-flow';
+
+describe('validateClientErrorReport', () => {
+  test('段と表示コードだけの報告を受理する', () => {
+    const result = validateClientErrorReport({ stage: 'capture', errorCode: 'captureTimeout' });
+    expect(result).toEqual({ ok: true, value: { stage: 'capture', errorCode: 'captureTimeout' } });
+  });
+
+  test('httpStatus 付きの報告を受理する', () => {
+    const result = validateClientErrorReport({
+      stage: 'pin',
+      errorCode: ERROR_CODES.forbidden,
+      httpStatus: 403,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.value.httpStatus).toBe(403);
+  });
+
+  test('未知のフィールドは拒否する（自由記述の抜け道を作らない）', () => {
+    const result = validateClientErrorReport({
+      stage: 'convert',
+      errorCode: 'failed',
+      message: 'file:///Users/me/secret.pdf を変換中に失敗',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error.errorCode).toBe(ERROR_CODES.invalidRequest);
+  });
+
+  test('allowlist に無い errorCode は拒否する', () => {
+    expect(validateClientErrorReport({ stage: 'convert', errorCode: 'MADE_UP' }).ok).toBe(false);
+    expect(
+      validateClientErrorReport({ stage: 'convert', errorCode: 'https://example.com/private' }).ok
+    ).toBe(false);
+  });
+
+  test('未知の stage は拒否する', () => {
+    expect(validateClientErrorReport({ stage: 'nowhere', errorCode: 'failed' }).ok).toBe(false);
+  });
+
+  test('httpStatus は 100〜599 の整数だけ受け付ける', () => {
+    const base = { stage: 'upload', errorCode: 'failed' };
+    expect(validateClientErrorReport({ ...base, httpStatus: 99 }).ok).toBe(false);
+    expect(validateClientErrorReport({ ...base, httpStatus: 600 }).ok).toBe(false);
+    expect(validateClientErrorReport({ ...base, httpStatus: 4.5 }).ok).toBe(false);
+    expect(validateClientErrorReport({ ...base, httpStatus: '500' }).ok).toBe(false);
+    expect(validateClientErrorReport({ ...base, httpStatus: 500 }).ok).toBe(true);
+  });
+
+  test('オブジェクト以外は拒否する', () => {
+    expect(validateClientErrorReport(null).ok).toBe(false);
+    expect(validateClientErrorReport('failed').ok).toBe(false);
+    expect(validateClientErrorReport([{ stage: 'convert', errorCode: 'failed' }]).ok).toBe(false);
+  });
+});
+
+describe('CLIENT_ERROR_CODES', () => {
+  test('UI の表示コードをすべて含む（表示だけできて報告できないコードを作らない）', () => {
+    const missing = UPLOAD_ERROR_CODES.filter((code) => !isClientErrorCode(code));
+    expect(missing).toEqual([]);
+  });
+
+  test('API のエラーコードをすべて含む', () => {
+    const missing = Object.values(ERROR_CODES).filter((code) => !isClientErrorCode(code));
+    expect(missing).toEqual([]);
+  });
+
+  test('未知の文字列は含まない', () => {
+    expect(CLIENT_ERROR_CODES).not.toContain('MADE_UP' as never);
+    expect(isClientErrorCode('MADE_UP')).toBe(false);
+  });
+});

--- a/web/tests/services/client-error.test.ts
+++ b/web/tests/services/client-error.test.ts
@@ -23,15 +23,104 @@ function captureLogs(): { entries: Record<string, unknown>[] } {
 }
 
 function reportRequest(body: string, headers: Record<string, string> = {}): Request {
-  return new Request('http://localhost/api/client-error/', { method: 'POST', body, headers });
+  return new Request('http://localhost/api/client-error/', {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
 }
 
+/** 常に通す / 常に断る Rate Limiting binding の代役。 */
+function limiterStub(success: boolean, keys: string[] = []): { limit: (o: { key: string }) => Promise<{ success: boolean }> } {
+  return {
+    limit: async ({ key }) => {
+      keys.push(key);
+      return { success };
+    },
+  };
+}
+
+const allowAll = { limiter: limiterStub(true) };
+
+describe('POST /api/client-error/ のレート制限', () => {
+  // このファイルで唯一 limiter を渡さないテスト。binding 不在の警告は isolate ごとに
+  // 1 回だけなので、他のテストへ警告が漏れないよう先頭に置く。
+  test('binding が無い環境では警告を 1 回だけ出して受け付ける', async () => {
+    const logs = captureLogs();
+
+    const first = await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'failed' }))
+    );
+    const second = await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'failed' }))
+    );
+
+    expect([first.status, second.status]).toEqual([204, 204]);
+    const events = logs.entries.map((entry) => entry['event']);
+    expect(events).toEqual(['client_error_limiter_missing', 'client_error', 'client_error']);
+  });
+
+  test('上限を超えたら 429 を返し、本文もログも出さない', async () => {
+    const logs = captureLogs();
+
+    const response = await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'failed' })),
+      { limiter: limiterStub(false) }
+    );
+
+    expect(response.status).toBe(429);
+    expect(await response.text()).toBe('');
+    expect(logs.entries).toHaveLength(0);
+  });
+
+  test('接続元 IP を鍵にする（無い経路は 1 つに束ねる）', async () => {
+    const keys: string[] = [];
+    captureLogs();
+
+    await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'failed' }), {
+        'cf-connecting-ip': '203.0.113.9',
+      }),
+      { limiter: limiterStub(true, keys) }
+    );
+    await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'failed' })),
+      { limiter: limiterStub(true, keys) }
+    );
+
+    expect(keys).toEqual(['203.0.113.9', 'unknown']);
+  });
+});
+
 describe('POST /api/client-error/', () => {
+  test('application/json 以外の Content-Type は 400 で拒否する', async () => {
+    const logs = captureLogs();
+    const body = JSON.stringify({ stage: 'convert', errorCode: 'failed' });
+
+    const plain = await handleClientErrorReport(
+      new Request('http://localhost/api/client-error/', {
+        method: 'POST',
+        body,
+        headers: { 'content-type': 'text/plain;charset=UTF-8' },
+      }),
+      allowAll
+    );
+    const withCharset = await handleClientErrorReport(
+      reportRequest(body, { 'content-type': 'application/json; charset=utf-8' }),
+      allowAll
+    );
+
+    expect(plain.status).toBe(400);
+    expect(withCharset.status).toBe(204);
+    expect(logs.entries).toHaveLength(1);
+  });
+
   test('正しい報告は 204 を返し、client_error として 1 行だけ記録する', async () => {
     const logs = captureLogs();
 
     const response = await handleClientErrorReport(
-      reportRequest(JSON.stringify({ stage: 'capture', errorCode: 'captureTimeout', httpStatus: 504 }))
+      reportRequest(JSON.stringify({ stage: 'capture', errorCode: 'captureTimeout', httpStatus: 504 })),
+      allowAll
     );
 
     expect(response.status).toBe(204);
@@ -51,11 +140,13 @@ describe('POST /api/client-error/', () => {
         method: 'POST',
         body: JSON.stringify({ stage: 'convert', errorCode: 'failed' }),
         headers: {
+          'content-type': 'application/json',
           cookie: 'ws_session=deadbeef',
           'user-agent': 'Mozilla/5.0 (Secret Browser)',
           referer: 'https://example.com/private/page',
         },
-      })
+      }),
+      allowAll
     );
 
     const entry = logs.entries[0] as Record<string, unknown>;
@@ -84,9 +175,9 @@ describe('POST /api/client-error/', () => {
       new Request('http://localhost/api/client-error/', {
         method: 'POST',
         body: JSON.stringify({ stage: 'pin', errorCode: 'failed' }),
-        headers: { cookie },
+        headers: { 'content-type': 'application/json', cookie },
       }),
-      { signingKey: key }
+      { signingKey: key, ...allowAll }
     );
 
     expect(response.status).toBe(204);
@@ -99,7 +190,7 @@ describe('POST /api/client-error/', () => {
 
     const response = await handleClientErrorReport(
       reportRequest(JSON.stringify({ stage: 'history', errorCode: 'failed' })),
-      { signingKey: key }
+      { signingKey: key, ...allowAll }
     );
 
     expect(response.status).toBe(204);
@@ -114,9 +205,9 @@ describe('POST /api/client-error/', () => {
       new Request('http://localhost/api/client-error/', {
         method: 'POST',
         body: JSON.stringify({ stage: 'pin', errorCode: 'failed' }),
-        headers: { cookie: 'ws_session=eyJ1aWQiOjF9.forged' },
+        headers: { 'content-type': 'application/json', cookie: 'ws_session=eyJ1aWQiOjF9.forged' },
       }),
-      { signingKey: key }
+      { signingKey: key, ...allowAll }
     );
 
     expect(logs.entries[0]).not.toHaveProperty('userId');
@@ -128,7 +219,8 @@ describe('POST /api/client-error/', () => {
     const response = await handleClientErrorReport(
       reportRequest(
         JSON.stringify({ stage: 'convert', errorCode: 'failed', stack: 'at /Users/me/secret.pdf' })
-      )
+      ),
+      allowAll
     );
 
     expect(response.status).toBe(400);
@@ -139,7 +231,8 @@ describe('POST /api/client-error/', () => {
     const logs = captureLogs();
 
     const response = await handleClientErrorReport(
-      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'https://example.com/leak' }))
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'https://example.com/leak' })),
+      allowAll
     );
 
     expect(response.status).toBe(400);
@@ -158,7 +251,7 @@ describe('POST /api/client-error/', () => {
       pad: 'x'.repeat(2000),
     });
 
-    const response = await handleClientErrorReport(reportRequest(oversized));
+    const response = await handleClientErrorReport(reportRequest(oversized), allowAll);
 
     expect(response.status).toBe(400);
     expect(logs.entries).toHaveLength(0);
@@ -172,8 +265,9 @@ describe('POST /api/client-error/', () => {
       new Request('http://localhost/api/client-error/', {
         method: 'POST',
         body: oversized,
-        headers: { 'content-length': '10' },
-      })
+        headers: { 'content-type': 'application/json', 'content-length': '10' },
+      }),
+      allowAll
     );
 
     expect(response.status).toBe(400);
@@ -183,7 +277,7 @@ describe('POST /api/client-error/', () => {
   test('JSON として読めない本文は 400 で拒否する', async () => {
     const logs = captureLogs();
 
-    const response = await handleClientErrorReport(reportRequest('not json'));
+    const response = await handleClientErrorReport(reportRequest('not json'), allowAll);
 
     expect(response.status).toBe(400);
     expect(logs.entries).toHaveLength(0);

--- a/web/tests/services/client-error.test.ts
+++ b/web/tests/services/client-error.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  createSessionPayload,
+  importSigningKey,
+  signSession,
+} from '../../src/lib/contracts/session';
+import { handleClientErrorReport } from '../../src/lib/services/client-error';
+
+const originalWarn = console.warn;
+
+afterEach(() => {
+  console.warn = originalWarn;
+});
+
+/** ログ 1 行を JSON として取り出す。出力の形そのものが契約なので構造で検証する。 */
+function captureLogs(): { entries: Record<string, unknown>[] } {
+  const entries: Record<string, unknown>[] = [];
+  console.warn = ((line: string) => {
+    entries.push(JSON.parse(line) as Record<string, unknown>);
+  }) as typeof console.warn;
+  return { entries };
+}
+
+function reportRequest(body: string, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/client-error/', { method: 'POST', body, headers });
+}
+
+describe('POST /api/client-error/', () => {
+  test('正しい報告は 204 を返し、client_error として 1 行だけ記録する', async () => {
+    const logs = captureLogs();
+
+    const response = await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'capture', errorCode: 'captureTimeout', httpStatus: 504 }))
+    );
+
+    expect(response.status).toBe(204);
+    expect(logs.entries).toHaveLength(1);
+    const entry = logs.entries[0] as Record<string, unknown>;
+    expect(entry['event']).toBe('client_error');
+    expect(entry['stage']).toBe('capture');
+    expect(entry['errorCode']).toBe('captureTimeout');
+    expect(entry['httpStatus']).toBe(504);
+  });
+
+  test('ログに残るキーは識別子だけ（URL・Cookie・UA を持ち込まない）', async () => {
+    const logs = captureLogs();
+
+    await handleClientErrorReport(
+      new Request('http://localhost/api/client-error/?debug=secret', {
+        method: 'POST',
+        body: JSON.stringify({ stage: 'convert', errorCode: 'failed' }),
+        headers: {
+          cookie: 'ws_session=deadbeef',
+          'user-agent': 'Mozilla/5.0 (Secret Browser)',
+          referer: 'https://example.com/private/page',
+        },
+      })
+    );
+
+    const entry = logs.entries[0] as Record<string, unknown>;
+    expect(Object.keys(entry).sort()).toEqual([
+      'errorCode',
+      'event',
+      'kind',
+      'level',
+      'severity',
+      'source',
+      'stage',
+      'summary',
+      'timestamp',
+    ]);
+    expect(JSON.stringify(entry)).not.toContain('Secret Browser');
+    expect(JSON.stringify(entry)).not.toContain('example.com');
+    expect(JSON.stringify(entry)).not.toContain('deadbeef');
+  });
+
+  test('署名済み Cookie があれば userId を添える', async () => {
+    const logs = captureLogs();
+    const key = await importSigningKey('unit-test-signing-key');
+    const cookie = `ws_session=${await signSession(createSessionPayload(42), key)}`;
+
+    const response = await handleClientErrorReport(
+      new Request('http://localhost/api/client-error/', {
+        method: 'POST',
+        body: JSON.stringify({ stage: 'pin', errorCode: 'failed' }),
+        headers: { cookie },
+      }),
+      { signingKey: key }
+    );
+
+    expect(response.status).toBe(204);
+    expect((logs.entries[0] as Record<string, unknown>)['userId']).toBe(42);
+  });
+
+  test('未ログイン（Cookie 無し）でも 204 で記録する', async () => {
+    const logs = captureLogs();
+    const key = await importSigningKey('unit-test-signing-key');
+
+    const response = await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'history', errorCode: 'failed' })),
+      { signingKey: key }
+    );
+
+    expect(response.status).toBe(204);
+    expect(logs.entries[0]).not.toHaveProperty('userId');
+  });
+
+  test('改竄された Cookie は userId を付けずに記録する', async () => {
+    const logs = captureLogs();
+    const key = await importSigningKey('unit-test-signing-key');
+
+    await handleClientErrorReport(
+      new Request('http://localhost/api/client-error/', {
+        method: 'POST',
+        body: JSON.stringify({ stage: 'pin', errorCode: 'failed' }),
+        headers: { cookie: 'ws_session=eyJ1aWQiOjF9.forged' },
+      }),
+      { signingKey: key }
+    );
+
+    expect(logs.entries[0]).not.toHaveProperty('userId');
+  });
+
+  test('未知のフィールドを含む報告は 400 で捨て、ログにも残さない', async () => {
+    const logs = captureLogs();
+
+    const response = await handleClientErrorReport(
+      reportRequest(
+        JSON.stringify({ stage: 'convert', errorCode: 'failed', stack: 'at /Users/me/secret.pdf' })
+      )
+    );
+
+    expect(response.status).toBe(400);
+    expect(logs.entries).toHaveLength(0);
+  });
+
+  test('allowlist 外の errorCode は 400 で拒否する', async () => {
+    const logs = captureLogs();
+
+    const response = await handleClientErrorReport(
+      reportRequest(JSON.stringify({ stage: 'convert', errorCode: 'https://example.com/leak' }))
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      errorCode: 'INVALID_REQUEST',
+      message: 'errorCode が不正です',
+    });
+    expect(logs.entries).toHaveLength(0);
+  });
+
+  test('1 KiB を超える本文は 400 で拒否する', async () => {
+    const logs = captureLogs();
+    const oversized = JSON.stringify({
+      stage: 'convert',
+      errorCode: 'failed',
+      pad: 'x'.repeat(2000),
+    });
+
+    const response = await handleClientErrorReport(reportRequest(oversized));
+
+    expect(response.status).toBe(400);
+    expect(logs.entries).toHaveLength(0);
+  });
+
+  test('Content-Length を偽っても実バイト数で打ち切る', async () => {
+    const logs = captureLogs();
+    const oversized = 'x'.repeat(4000);
+
+    const response = await handleClientErrorReport(
+      new Request('http://localhost/api/client-error/', {
+        method: 'POST',
+        body: oversized,
+        headers: { 'content-length': '10' },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(logs.entries).toHaveLength(0);
+  });
+
+  test('JSON として読めない本文は 400 で拒否する', async () => {
+    const logs = captureLogs();
+
+    const response = await handleClientErrorReport(reportRequest('not json'));
+
+    expect(response.status).toBe(400);
+    expect(logs.entries).toHaveLength(0);
+  });
+});

--- a/web/tests/ui/client-error-report.test.ts
+++ b/web/tests/ui/client-error-report.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ERROR_CODES } from '../../src/lib/contracts/api';
+import {
+  CLIENT_ERROR_MAX_PER_KEY,
+  CLIENT_ERROR_MIN_INTERVAL_MS,
+  INITIAL_CLIENT_ERROR_THROTTLE,
+  admitClientError,
+  clientErrorCodeOf,
+  clientErrorHttpStatus,
+  clientErrorPayload,
+  conversionClientStage,
+  createClientErrorReporter,
+} from '../../src/lib/ui/client-error-report';
+import { JsonRequestError } from '../../src/lib/ui/request-json';
+
+/** 送信本文を溜める報告関数。実送信（sendBeacon / fetch）は差し替える。 */
+function reporterWithSpy(): { report: (r: Parameters<ReturnType<typeof createClientErrorReporter>>[0]) => void; sent: unknown[]; advance: (ms: number) => void } {
+  const sent: unknown[] = [];
+  let nowMs = 0;
+  const report = createClientErrorReporter({
+    send: (body) => sent.push(JSON.parse(body)),
+    now: () => nowMs,
+  });
+  return { report, sent, advance: (ms) => { nowMs += ms; } };
+}
+
+describe('送信ペイロード', () => {
+  test('送るのは stage / errorCode / httpStatus だけ', () => {
+    const spy = reporterWithSpy();
+
+    spy.report({ stage: 'upload', errorCode: 'failed', httpStatus: 500 });
+
+    expect(spy.sent).toEqual([{ stage: 'upload', errorCode: 'failed', httpStatus: 500 }]);
+  });
+
+  test('httpStatus が無いときはキーごと送らない', () => {
+    expect(Object.keys(clientErrorPayload({ stage: 'convert', errorCode: 'failed' }))).toEqual([
+      'stage',
+      'errorCode',
+    ]);
+  });
+
+  test('呼び出し側が余分なフィールドを渡しても混入しない', () => {
+    const contaminated = {
+      stage: 'convert',
+      errorCode: 'failed',
+      url: 'https://example.com/private',
+      stack: 'at secret.pdf',
+    } as unknown as Parameters<typeof clientErrorPayload>[0];
+
+    expect(clientErrorPayload(contaminated)).toEqual({ stage: 'convert', errorCode: 'failed' });
+  });
+});
+
+describe('clientErrorCodeOf', () => {
+  test('allowlist に載るサーバーコードはそのまま使う', () => {
+    const error = new JsonRequestError(403, ERROR_CODES.forbidden);
+    expect(clientErrorCodeOf(error)).toBe(ERROR_CODES.forbidden);
+  });
+
+  test('allowlist 外のサーバーコードは failed に丸める', () => {
+    const error = new JsonRequestError(500, '<script>alert(1)</script>');
+    expect(clientErrorCodeOf(error)).toBe('failed');
+  });
+
+  test('HTTP 由来でない失敗は failed になり、ステータスは付かない', () => {
+    expect(clientErrorCodeOf(new Error('boom'))).toBe('failed');
+    expect(clientErrorHttpStatus(new Error('boom'))).toBeUndefined();
+    expect(clientErrorHttpStatus(new JsonRequestError(404, null))).toBe(404);
+  });
+});
+
+describe('conversionClientStage', () => {
+  test('進捗段階を報告する段へ写す', () => {
+    expect(conversionClientStage('capturing')).toBe('capture');
+    expect(conversionClientStage('preparing')).toBe('convert');
+    expect(conversionClientStage('encoding')).toBe('convert');
+    expect(conversionClientStage('uploading')).toBe('upload');
+    expect(conversionClientStage(null)).toBe('convert');
+  });
+});
+
+describe('送信の上限', () => {
+  test('同じ段 + コードは上限までしか送らない', () => {
+    let state = INITIAL_CLIENT_ERROR_THROTTLE;
+    const report = { stage: 'convert', errorCode: 'failed' } as const;
+    let admitted = 0;
+
+    for (let i = 0; i < CLIENT_ERROR_MAX_PER_KEY + 5; i += 1) {
+      const decision = admitClientError(state, report, i * CLIENT_ERROR_MIN_INTERVAL_MS);
+      state = decision.state;
+      if (decision.admitted) admitted += 1;
+    }
+
+    expect(admitted).toBe(CLIENT_ERROR_MAX_PER_KEY);
+  });
+
+  test('上限に達した組を弾いても、別の組は送れる', () => {
+    let state = INITIAL_CLIENT_ERROR_THROTTLE;
+    for (let i = 0; i < CLIENT_ERROR_MAX_PER_KEY; i += 1) {
+      state = admitClientError(
+        state,
+        { stage: 'convert', errorCode: 'failed' },
+        i * CLIENT_ERROR_MIN_INTERVAL_MS
+      ).state;
+    }
+
+    const blocked = admitClientError(
+      state,
+      { stage: 'convert', errorCode: 'failed' },
+      10 * CLIENT_ERROR_MIN_INTERVAL_MS
+    );
+    const other = admitClientError(
+      blocked.state,
+      { stage: 'upload', errorCode: 'failed' },
+      11 * CLIENT_ERROR_MIN_INTERVAL_MS
+    );
+
+    expect(blocked.admitted).toBe(false);
+    expect(other.admitted).toBe(true);
+  });
+
+  test('間隔の下限より詰まった報告は送らない（失敗ループでも溢れない）', () => {
+    const first = admitClientError(
+      INITIAL_CLIENT_ERROR_THROTTLE,
+      { stage: 'capture', errorCode: 'failed' },
+      1_000
+    );
+    const tooSoon = admitClientError(
+      first.state,
+      { stage: 'convert', errorCode: 'failed' },
+      1_000 + CLIENT_ERROR_MIN_INTERVAL_MS - 1
+    );
+    const later = admitClientError(
+      tooSoon.state,
+      { stage: 'convert', errorCode: 'failed' },
+      1_000 + CLIENT_ERROR_MIN_INTERVAL_MS
+    );
+
+    expect([first.admitted, tooSoon.admitted, later.admitted]).toEqual([true, false, true]);
+  });
+
+  test('弾いた報告は回数に数えない（上限に達したまま復帰できなくならない）', () => {
+    const first = admitClientError(
+      INITIAL_CLIENT_ERROR_THROTTLE,
+      { stage: 'convert', errorCode: 'failed' },
+      0
+    );
+    const blocked = admitClientError(first.state, { stage: 'convert', errorCode: 'failed' }, 1);
+
+    expect(blocked.state).toBe(first.state);
+  });
+
+  test('報告関数も上限に従う', () => {
+    const spy = reporterWithSpy();
+    for (let i = 0; i < CLIENT_ERROR_MAX_PER_KEY + 3; i += 1) {
+      spy.report({ stage: 'history', errorCode: 'failed' });
+      spy.advance(CLIENT_ERROR_MIN_INTERVAL_MS);
+    }
+
+    expect(spy.sent).toHaveLength(CLIENT_ERROR_MAX_PER_KEY);
+  });
+
+  test('送信が失敗しても呼び出し側へ例外を投げない', () => {
+    const report = createClientErrorReporter({
+      send: () => {
+        throw new Error('beacon unavailable');
+      },
+      now: () => 0,
+    });
+
+    expect(() => report({ stage: 'delete', errorCode: 'failed' })).not.toThrow();
+  });
+});

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -48,6 +48,18 @@
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
   },
+  // クライアント失敗報告（POST /api/client-error/）の受け口を IP 単位で絞る。
+  // この口は無認証なので、壊れたクライアントや悪意ある送信で Worker のログが
+  // 埋まると、本来見たい失敗が読めなくなる（観測のための口が観測を潰す）。
+  // namespace_id は Cloudflare のアカウント内で一意な番号を自分で決める識別子で、
+  // 変えると別のカウンタになる（既存の計測をリセットしたい時以外は動かさない）。
+  "ratelimits": [
+    {
+      "name": "CLIENT_ERROR_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 30, "period": 60 }
+    }
+  ],
   // Astro のセッション機能が既定で要求する KV。初回 deploy で wrangler が
   // 自動プロビジョニングしたものを、再デプロイ時の取り違えを防ぐため明示している。
   "kv_namespaces": [


### PR DESCRIPTION
## なぜこの変更が必要か

クライアント側の失敗（変換・エンコード・アップロード・pin・rename・delete・履歴・セッション）はサーバーに一切届かず、変換失敗率・失敗した段・CDN への到達不能が運用側から観測できなかった（Issue #64、握り潰されたエラーの横断監査の根 R2b）。

## 変更内容

- 契約 `contracts/client-error.ts` の `ClientErrorReport`（`stage` 固定 enum / `errorCode` allowlist / `httpStatus?` 整数）。識別子だけ。URL・ファイル名・ページ内容・スタックトレース・自由文字列は受け取らない
- `POST /api/client-error/`（無認証、204）。allowlist 外・未知フィールド・型違い・非 JSON・`application/json` 以外の Content-Type は 400。本文 1 KiB は `Content-Length` を信用せず実バイトで打ち切り。セッション Cookie があれば `userId` を付ける（必須ではない）
- Worker 側レート制限: Rate Limiting binding `CLIENT_ERROR_LIMITER`（30 回 / 分 / IP、超過は 429）。binding 未定義の環境は warn を出して通す
- Worker は `client_error` の構造化ログ（`stage` / `errorCode` / `httpStatus` / `userId` のみ）
- クライアント: `sendBeacon` 優先 / `fetch keepalive` で fire-and-forget。同一 `stage+errorCode` は最大 5 回、間隔 1 秒以上。上流の `errorCode` は転送せず allowlist 外は `failed` に丸める。ページ離脱で reject した fetch は報告しない
- 送信点: 変換フロー（capture / convert / upload。入力ファイルの tooLarge / unsupported も含む）、pin / rename / delete、履歴取得（dropped / malformed も）、セッション取得（401 は guest の正常経路なので除外）
- `docs/api-contracts.md` に 1 行

## 意思決定

### 採用アプローチ
- 送るのは識別子だけ（ユーザー決定 2026-08-30）。allowlist は契約側が上位集合で、UI 側に表示コードを足すと型エラーと包含テストの両方で落ちる
- 契約は `api.ts` ではなく `contracts/client-error.ts`（api.ts が契約層の 400 行上限に近い）

### 却下した代替案
- KV / DO でのレート制限 → Rate Limiting binding で足りる
- Origin 検査 → `SameSite=Lax` によりクロスサイト POST に Cookie は乗らず userId の偽装は成立しない。Content-Type 検査でブラウザ経由の simple POST は弾ける

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 545 pass / 0 fail（契約の allowlist・未知フィールド・型違い・巨大本文・Content-Length 詐称・429・Content-Type、上限の純関数、ログのキー集合）
- [x] E2E `top.spec.ts` 23 pass（beacon の本文を完全一致で固定）、`preview.spec.ts` 36 pass。実 Worker ログで stage=capture / upload / pin / history を実測
- [x] `check-architecture.py` 新規違反ゼロ

## レビューゲート

Opus `code-reviewer` + `security-checker`（codex がハングしたためフォールバック）。ブロッキングなし。改善 11 件を反映（詳細は対応表コメント）。

## 不可逆要素

新規公開エンドポイント `POST /api/client-error/`（2026-08-30 の設計議論でユーザーが事前承認済み）。

Refs #64

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
