### PR TITLE
feat(web): キャプチャ画像のキー規則で png と jpg の両方を受理する

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -82,7 +82,7 @@ Worker 自身のタイムアウト（上流への 150 秒 abort）も `CAPTURE_T
 | 対象 | 公開範囲 | 補足 |
 |------|---------|------|
 | 動画 URL（`movies/{shortId}.mp4`） | **公開**（認証なしで誰でも取得可） | VRChat のプレイヤーが認証なしで取得する必要があるため。**将来も公開のまま変えない**。保護は 12 文字 base62 のランダム ID による推測困難性のみ |
-| キャプチャ画像（`captures/{uuid}/{index}.png`） | 公開 | 同上。動画生成の中間物 |
+| キャプチャ画像（`captures/{uuid}/{index}.{png\|jpg}`） | 公開 | 同上。動画生成の中間物。拡張子は web-capture の設定で決まる（撮影を速くするため JPEG へ移行中）。WebScreen 側は `CaptureResponse.images` の URL をそのまま取得して復号するため、どちらでも扱いは変わらない |
 | 履歴 `GET /api/history/` | 本人のみ | セッション Cookie の uid で絞る |
 | pin `POST /api/movies/{shortId}/pin/` | 本人のみ | 所有者チェック必須 |
 | 削除 `DELETE /api/movies/{shortId}/` | 本人のみ | 所有者チェック必須。他人の shortId は 404（存在を漏らさない） |

--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -47,9 +47,9 @@ bunx wrangler r2 bucket cors list webscreen-beta   # 確認
 
 ## captures/ の掃除主体
 
-`captures/{uuid}/{index}.png`（web-capture が置く動画化の中間物）を消すのは **WebScreen の cron だけ**（`web/cron/` の Worker が `web/src/lib/services/retention-captures.ts` を毎時 17 分に実行し、アップロードから 24 時間経過したものを 1 回あたり最大 1000 件・list 10 ページまで削除する。残りは次の実行が拾う）。**R2 の lifecycle rule は使っていない**（作成もしていない）。掃除を別の場所へ移す時は、この節と `retention-captures.ts` の両方を同時に直すこと。
+`captures/{uuid}/{index}.{png|jpg}`（web-capture が置く動画化の中間物。拡張子は web-capture の設定で決まる。撮影を速くするため JPEG へ移行中で、掃除も取り込みも拡張子を見ないので混在しても問題ない）を消すのは **WebScreen の cron だけ**（`web/cron/` の Worker が `web/src/lib/services/retention-captures.ts` を毎時 17 分に実行し、アップロードから 24 時間経過したものを 1 回あたり最大 1000 件・list 10 ページまで削除する。残りは次の実行が拾う）。**R2 の lifecycle rule は使っていない**（作成もしていない）。掃除を別の場所へ移す時は、この節と `retention-captures.ts` の両方を同時に直すこと。
 
-掃除対象バケット名の正本は **`web/cron/wrangler.jsonc` の `r2_buckets`**（現在 `webscreen-beta`）。web-capture 側の書き込み先（Cloud Run の環境変数 `R2_BUCKET`）が**これと一致していることが契約**で、ずれると中間 PNG は誰にも消されず増え続ける（気づけるのは請求だけ）。2026-08-30 に `gcloud run services describe web-capture` で一致を確認済み。どちらかを変える時は両方同時に変える。
+掃除対象バケット名の正本は **`web/cron/wrangler.jsonc` の `r2_buckets`**（現在 `webscreen-beta`）。web-capture 側の書き込み先（Cloud Run の環境変数 `R2_BUCKET`）が**これと一致していることが契約**で、ずれると中間のキャプチャ画像は誰にも消されず増え続ける（気づけるのは請求だけ）。2026-08-30 に `gcloud run services describe web-capture` で一致を確認済み。どちらかを変える時は両方同時に変える。
 
 ## 削除とキャッシュの既知の穴
 

--- a/web/src/lib/contracts/r2key.ts
+++ b/web/src/lib/contracts/r2key.ts
@@ -71,18 +71,32 @@ const CAPTURE_SESSION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 /**
+ * キャプチャの拡張子。どちらを書くかは web-capture 側の設定で決まる
+ * （撮影を速くするため JPEG へ移行中。移行の前後どちらでも WebScreen が壊れないよう両方を受理する）。
+ */
+export type CaptureExtension = 'png' | 'jpg';
+
+/**
  * web-capture が撮ったスクリーンショットの R2 キー。
  *
  * index は 0 埋め 4 桁にする。R2 の list は辞書順で返るため、0 埋めしないと
  * "10" が "2" より前に並び、スクロール動画のコマ順が破綻する
  * （並び順の契約は contracts/api.ts の CaptureResponse.images と対で守る）。
+ *
+ * 既定を png のままにしてあるのは、web-capture の切り替えより先にこちらを本番へ出すため。
+ * 上流が jpg へ切り替わっても取り込み（fetch → createImageBitmap）と掃除（captures/ prefix）は
+ * 拡張子を見ないので、既定値は表示・記録上の意味しか持たない。
  */
-export function captureKey(sessionId: string, index: number): string {
+export function captureKey(
+  sessionId: string,
+  index: number,
+  extension: CaptureExtension = 'png'
+): string {
   if (!CAPTURE_SESSION_ID_PATTERN.test(sessionId)) {
     throw new Error('captureKey: sessionId は小文字の UUID である必要があります');
   }
   if (!Number.isInteger(index) || index < 0 || index > MAX_CAPTURE_INDEX) {
     throw new Error(`captureKey: index は 0〜${MAX_CAPTURE_INDEX} の整数である必要があります`);
   }
-  return `captures/${sessionId}/${String(index).padStart(CAPTURE_INDEX_DIGITS, '0')}.png`;
+  return `captures/${sessionId}/${String(index).padStart(CAPTURE_INDEX_DIGITS, '0')}.${extension}`;
 }

--- a/web/tests/contracts/r2key.test.ts
+++ b/web/tests/contracts/r2key.test.ts
@@ -79,13 +79,20 @@ describe('captureKey', () => {
     expect(captureKey(SESSION_ID, MAX_CAPTURE_INDEX)).toBe(`captures/${SESSION_ID}/9999.png`);
   });
 
-  test('辞書順が撮影順と一致する（R2 list の並びでコマ順が壊れない）', () => {
-    const shootingOrder = [0, 1, 2, 9, 10, 11, 100, 1000];
-
-    const keys = shootingOrder.map((index) => captureKey(SESSION_ID, index));
-
-    expect([...keys].sort()).toEqual(keys);
+  test('web-capture が jpg を書いても同じ規則でキーを導出できる', () => {
+    expect(captureKey(SESSION_ID, 7, 'jpg')).toBe(`captures/${SESSION_ID}/0007.jpg`);
   });
+
+  test.each([['png'], ['jpg']] as const)(
+    '%s でも辞書順が撮影順と一致する（R2 list の並びでコマ順が壊れない）',
+    (extension) => {
+      const shootingOrder = [0, 1, 2, 9, 10, 11, 100, 1000];
+
+      const keys = shootingOrder.map((index) => captureKey(SESSION_ID, index, extension));
+
+      expect([...keys].sort()).toEqual(keys);
+    }
+  );
 
   test.each([
     ['負の index', -1],

--- a/web/tests/convert/image-formats.test.ts
+++ b/web/tests/convert/image-formats.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { FRAME_HEIGHT, FRAME_WIDTH } from '../../src/lib/convert/image';
+import { imageUrlsToFrames } from '../../src/lib/convert/imageUrls';
+
+/** JPEG の SOI マーカー。web-capture が png から jpg へ切り替えた時に届くバイト列。 */
+const JPEG_MAGIC = [0xff, 0xd8, 0xff] as const;
+/** PNG シグネチャ。切り替え前の web-capture が届けるバイト列。 */
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47] as const;
+
+interface CanvasCall {
+  /** canvas.toBlob に渡された MIME。エンコーダへ渡すフレームの形式。 */
+  mime: string;
+}
+
+/** 復号と描画の代役。bun には実 canvas が無いので、受け取った Blob を記録する側に徹する。 */
+function installBrowserFakes(): { received: Blob[]; canvasCalls: CanvasCall[]; restore: () => void } {
+  const original = {
+    document: globalThis.document,
+    createImageBitmap: globalThis.createImageBitmap,
+    fetch: globalThis.fetch,
+  };
+  const received: Blob[] = [];
+  const canvasCalls: CanvasCall[] = [];
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ({ fillStyle: '', fillRect: () => {}, drawImage: () => {} }),
+    toBlob: (callback: (blob: Blob) => void, mime: string) => {
+      canvasCalls.push({ mime });
+      callback(new Blob([new Uint8Array([1, 2, 3])]));
+    },
+  };
+  Object.assign(globalThis, {
+    document: { createElement: () => canvas },
+    createImageBitmap: async (blob: Blob) => {
+      received.push(blob);
+      return { width: 1920, height: 1080, close: () => {} };
+    },
+  });
+  return {
+    received,
+    canvasCalls,
+    restore: () => Object.assign(globalThis, original),
+  };
+}
+
+/** URL ごとに、指定した形式のバイト列を返す fetch の代役を置く。 */
+function installFetchReturning(magic: readonly number[], mimeType: string): void {
+  Object.assign(globalThis, {
+    fetch: async (url: string) =>
+      new Response(new Blob([new Uint8Array([...magic, ...new TextEncoder().encode(url)])], { type: mimeType }), {
+        status: 200,
+      }),
+  });
+}
+
+const restores: (() => void)[] = [];
+
+afterEach(() => {
+  while (restores.length > 0) restores.pop()?.();
+});
+
+describe('imageUrlsToFrames の入力形式', () => {
+  // web-capture は撮影を速くするため JPEG へ切り替える。取り込み側は形式を判定せず
+  // createImageBitmap に任せる設計なので、png / jpg のどちらでも同じ結果になること。
+  test.each([
+    ['png', PNG_MAGIC, 'image/png'],
+    ['jpeg', JPEG_MAGIC, 'image/jpeg'],
+  ] as const)('%s のキャプチャを撮影順どおりのフレームに変換する', async (_label, magic, mimeType) => {
+    const fakes = installBrowserFakes();
+    restores.push(fakes.restore);
+    installFetchReturning(magic, mimeType);
+    const urls = ['https://cdn.test/0001', 'https://cdn.test/0002', 'https://cdn.test/0003'];
+
+    const frames = await imageUrlsToFrames(urls);
+
+    expect(frames).toHaveLength(urls.length);
+    for (const frame of frames) {
+      expect(frame.width).toBe(FRAME_WIDTH);
+      expect(frame.height).toBe(FRAME_HEIGHT);
+    }
+    // 取得したバイト列が加工されず復号へ渡る（形式ごとの分岐を持ち込まない）。
+    expect(fakes.received.map((blob) => blob.type)).toEqual(urls.map(() => mimeType));
+    const decoded = await Promise.all(
+      fakes.received.map(async (blob) => new TextDecoder().decode((await blob.arrayBuffer()).slice(magic.length)))
+    );
+    expect(decoded).toEqual(urls);
+  });
+
+  test('入力が JPEG でもエンコーダへ渡すフレームは PNG のまま', async () => {
+    const fakes = installBrowserFakes();
+    restores.push(fakes.restore);
+    installFetchReturning(JPEG_MAGIC, 'image/jpeg');
+
+    await imageUrlsToFrames(['https://cdn.test/0001']);
+
+    // convert/encode.ts は frame-%06d.png で ffmpeg に渡すため、正規化後の形式は固定する。
+    expect(fakes.canvasCalls).toEqual([{ mime: 'image/png' }]);
+  });
+});

--- a/web/tests/services/retention-captures.test.ts
+++ b/web/tests/services/retention-captures.test.ts
@@ -39,9 +39,12 @@ function captureObject(index: number, uploadedOffsetMs: number): CaptureObject {
 }
 
 describe('deleteStaleCaptures', () => {
-  it('prefix が contracts の captureKey と一致する', () => {
+  // 掃除は拡張子を見ない。web-capture が png から jpg へ切り替わっても取り残しが出ないこと。
+  it.each([['png'], ['jpg']] as const)('%s のキーも prefix で拾える', (extension) => {
     expect(
-      captureKey('11111111-2222-3333-4444-555555555555', 0).startsWith(CAPTURE_KEY_PREFIX)
+      captureKey('11111111-2222-3333-4444-555555555555', 0, extension).startsWith(
+        CAPTURE_KEY_PREFIX
+      )
     ).toBe(true);
   });
 


### PR DESCRIPTION
## なぜこの変更が必要か

web-capture の撮影を PNG から JPEG に切り替える（noricha-vr/WebScreen#72）。R2 のキー規則 `captures/{uuid}/{index}.png` は WebScreen 側の契約（`contracts/r2key.ts`）で定義されているため、web-capture を切り替える前に WebScreen 側で png / jpg の両方を受理できる状態にしておく（追加 → 切替の順）。

## 変更内容

- `captureKey(sessionId, index, extension = 'png')` に拡張子引数（`png` | `jpg`）を追加。既定は png のまま
- `docs/api-contracts.md` / `docs/r2-delivery.md` の `.png` 記述を「png または jpg（web-capture の設定で決まる）」に
- JPEG 入力（`image/jpeg`）でも `normalizeImageBlob` が動くことをテストで固定（`tests/convert/image-formats.test.ts`）。`retention-captures.ts` の prefix 走査が拡張子非依存であることをテストで確認

本番の取り込み経路（`CaptureResponse.images` の URL を fetch → `createImageBitmap`）と掃除（`captures/` prefix 走査）はどちらも拡張子を見ないため、web-capture が png のままでも jpg に切り替わっても動く。

## テスト

- [x] `cd web && bun run typecheck` / `bun test` 通過

契約の追加（後方互換）とテスト・ドキュメントのみ。web-capture 側の PR: noricha-vr/web-capture の `feat/72-jpeg-capture`。

Refs #72

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
