### PR TITLE
feat(web): 動画の削除時に Cloudflare のキャッシュを purge する

### DIFF
--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -1,6 +1,6 @@
 # 動画配信（R2）の構成
 
-動画の実体は R2 バケット `webscreen-beta` にあり、**2 つの経路で公開されている**。コード側の入力は `web/wrangler.jsonc` の `vars.R2_PUBLIC_BASE_URL` 1 箇所だけで、URL は保存値ではなく毎回そこから組み立てる（`web/src/lib/services/movies.ts` の `publicUrl()`）。
+動画の実体は R2 バケット `webscreen-beta` にあり、**2 つの経路で公開されている**。URL は保存値ではなく毎回 `vars.R2_PUBLIC_BASE_URL` から組み立てる（`web/src/lib/contracts/r2key.ts` の `movieUrl()`）。入力は `web/wrangler.jsonc` の同 var で、保持期間バッチが同じ URL を purge するため `web/cron/wrangler.jsonc` にも同じ値を置いている（下の「削除とキャッシュ」節）。
 
 | 経路 | URL | 用途 | 無効化してよいか |
 |---|---|---|---|
@@ -51,12 +51,29 @@ bunx wrangler r2 bucket cors list webscreen-beta   # 確認
 
 掃除対象バケット名の正本は **`web/cron/wrangler.jsonc` の `r2_buckets`**（現在 `webscreen-beta`）。web-capture 側の書き込み先（Cloud Run の環境変数 `R2_BUCKET`）が**これと一致していることが契約**で、ずれると中間のキャプチャ画像は誰にも消されず増え続ける（気づけるのは請求だけ）。2026-08-30 に `gcloud run services describe web-capture` で一致を確認済み。どちらかを変える時は両方同時に変える。
 
-## 削除とキャッシュの既知の穴
+## 削除とキャッシュ
 
-**動画を削除しても、最大 120 分はキャッシュから配信され続ける。**
+mp4 は Cloudflare の[既定キャッシュ対象](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/)で、200 / 206 の Edge TTL は 120 分（参照日 2026-08-27）。R2 から実体を消しただけでは、その間キャッシュから配信され続ける（r2.dev 経由ではキャッシュされないため、Custom Domain 化で生じた挙動）。
 
-- mp4 は Cloudflare の[既定キャッシュ対象](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/)に含まれ、200 / 206 の Edge TTL は 120 分（参照日 2026-08-27）
-- 削除経路（`services/movies.ts` の `deleteMovie` と `services/retention.ts` の期限切れ削除）はどちらも R2 の `delete` を呼ぶだけで、**キャッシュの purge をしていない**
-- r2.dev 経由ではキャッシュされないため、この挙動は Custom Domain 化で新たに生じたもの
+そのため**削除経路はすべて、R2 の実体を消した直後に公開 URL の purge を投げる**。
 
-URL を知っている人にしか影響しない（そもそも公開 URL である旨はプライバシーポリシーに明記）が、「削除したのに見られる」はユーザーの期待を裏切る。対処は Issue で追跡している。
+| 経路 | 実装 |
+|---|---|
+| 所有者の削除（`DELETE /api/movies/{shortId}/`） | `web/src/lib/services/movies.ts` の `deleteMovie` |
+| 保持期間バッチ（期限切れ・pending 孤児・failed の掃除） | `web/src/lib/services/retention.ts` の各経路 |
+
+purge の実体は `web/src/lib/infra/cloudflare-purge.ts`（Cloudflare の `purge_cache` API）、URL の組み立てと 30 件ずつの分割は `web/src/lib/services/cache-purge.ts`。**公開 URL は `contracts/r2key.ts` の `movieUrl()` で組み立てる**（purge は URL の完全一致でしか効かないため、表示側と別々に組み立てない）。
+
+設定は 2 つ。**どちらかが欠けると purge せず `cache_purge_skipped` を warn するだけで、削除自体は成功する**（ローカル開発はこの状態が正常）。
+
+| 名前 | 置き場所 | 備考 |
+|---|---|---|
+| `CLOUDFLARE_ZONE_ID` | `web/wrangler.jsonc` と `web/cron/wrangler.jsonc` の `vars` | 公開情報。両方に同じ値を置く |
+| `CLOUDFLARE_PURGE_TOKEN` | secret（本体 Worker と cron Worker の両方） | `bunx wrangler secret put CLOUDFLARE_PURGE_TOKEN`（cron は `-c cron/wrangler.jsonc`） |
+
+`R2_PUBLIC_BASE_URL` も cron 側の `vars` に同じ値で置いている（バッチが同じ公開 URL を組み立てるため）。**片方だけ変えると purge が空振りする。**
+
+残る穴と観測方法:
+
+- **purge に失敗した分は最大 120 分残る**。削除自体は完了しているのでリトライせず、自然に切れるのを待つ（`cache_purge_failed` を warn で記録。cron は `cachePurgeRequests` / `cachePurgeFailures` を毎回のログに出し、失敗があれば severity が warn になる）
+- R2 の削除に失敗した動画は purge しない（実体が残っており、purge しても次の取得でキャッシュに戻るため）。次回のバッチが同じ順序でやり直す

--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -55,12 +55,14 @@ bunx wrangler r2 bucket cors list webscreen-beta   # 確認
 
 mp4 は Cloudflare の[既定キャッシュ対象](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/)で、200 / 206 の Edge TTL は 120 分（参照日 2026-08-27）。R2 から実体を消しただけでは、その間キャッシュから配信され続ける（r2.dev 経由ではキャッシュされないため、Custom Domain 化で生じた挙動）。
 
-そのため**削除経路はすべて、R2 の実体を消した直後に公開 URL の purge を投げる**。
+そのため**動画の削除経路は、R2 の実体を消した直後に公開 URL の purge を投げる**。
 
 | 経路 | 実装 |
 |---|---|
 | 所有者の削除（`DELETE /api/movies/{shortId}/`） | `web/src/lib/services/movies.ts` の `deleteMovie` |
 | 保持期間バッチ（期限切れ・pending 孤児・failed の掃除） | `web/src/lib/services/retention.ts` の各経路 |
+
+`captures/` の掃除（`retention-captures.ts`）は purge しない。中間 PNG は変換が終われば誰も参照せず、キャッシュに残っても動画の削除の意図に反しないため。
 
 purge の実体は `web/src/lib/infra/cloudflare-purge.ts`（Cloudflare の `purge_cache` API）、URL の組み立てと 30 件ずつの分割は `web/src/lib/services/cache-purge.ts`。**公開 URL は `contracts/r2key.ts` の `movieUrl()` で組み立てる**（purge は URL の完全一致でしか効かないため、表示側と別々に組み立てない）。
 

--- a/web/.dev.vars.example
+++ b/web/.dev.vars.example
@@ -12,3 +12,12 @@ WEBCAPTURE_TOKEN=replace_with_webcapture_token
 # 本体 Worker は使わない。本番は `bunx wrangler secret put DISCORD_ALERT_WEBHOOK_URL -c cron/wrangler.jsonc` で投入し、
 # ローカルは wrangler dev の --var でダミーを渡す（実 Discord に送らないため）。
 DISCORD_ALERT_WEBHOOK_URL=
+
+# 削除した動画のキャッシュ purge に使う Cloudflare API token（本体・cron の両方に要る secret）。
+# 本番は `bunx wrangler secret put CLOUDFLARE_PURGE_TOKEN`（cron は -c cron/wrangler.jsonc）で投入する。
+# ローカルは空のままでよい（purge せず warn を 1 行出すだけで、削除自体は成功する）。
+CLOUDFLARE_PURGE_TOKEN=
+
+# purge 先のゾーン（web-screen.net）。公開情報なので wrangler.jsonc の vars にも入っている。
+# ローカルで実際に purge を試す時だけ設定する。
+CLOUDFLARE_ZONE_ID=2210192b51f9f0eb6761d70341ca09b0

--- a/web/cron/src/index.ts
+++ b/web/cron/src/index.ts
@@ -20,6 +20,7 @@ import {
   RETENTION_RUN_NAME,
   type CronRunDatabase,
 } from '../../src/lib/services/cron-health';
+import type { CachePurgeSettings } from '../../src/lib/services/cache-purge';
 import { runAlertCron, type AlertEnv } from './alert';
 
 /**
@@ -29,6 +30,11 @@ import { runAlertCron, type AlertEnv } from './alert';
 interface Env extends AlertEnv {
   DB: RetentionDatabase & CronRunDatabase;
   BUCKET: RetentionBucket;
+  /** 動画の配信元。web/wrangler.jsonc の同名 var と同じ値であること（purge の URL に使う）。 */
+  R2_PUBLIC_BASE_URL: string;
+  CLOUDFLARE_ZONE_ID?: string;
+  /** secret。未投入なら purge を諦めて warn だけ出す（掃除は続く）。 */
+  CLOUDFLARE_PURGE_TOKEN?: string;
 }
 
 /** workerd が scheduled ハンドラへ渡すイベント（使うフィールドのみ）。 */
@@ -84,6 +90,16 @@ export default {
   },
 };
 
+/** 削除した動画のキャッシュを落とすための設定を bindings から組む。 */
+function cachePurgeSettings(env: Env): CachePurgeSettings {
+  return {
+    publicBaseUrl: env.R2_PUBLIC_BASE_URL,
+    zoneId: env.CLOUDFLARE_ZONE_ID ?? '',
+    apiToken: env.CLOUDFLARE_PURGE_TOKEN ?? '',
+    source: SOURCE,
+  };
+}
+
 /** 保持期間バッチ本体。成功したら実行記録を残し、件数を 1 行 JSON で出す。 */
 async function runRetentionCron(env: Env, event: ScheduledEvent, cron: string): Promise<void> {
   // Date.now を呼んでよいのはこの層だけ。サービスへは値として渡す。
@@ -94,6 +110,7 @@ async function runRetentionCron(env: Env, event: ScheduledEvent, cron: string): 
       database: env.DB,
       bucket: env.BUCKET,
       now: new Date(event.scheduledTime),
+      cachePurge: cachePurgeSettings(env),
     });
 
     // 死活監視の根拠になる記録。ここが失敗したら成功として扱わない（rethrow に任せる）。
@@ -108,11 +125,15 @@ async function runRetentionCron(env: Env, event: ScheduledEvent, cron: string): 
     // error は回収不能な異常だけに使う。実体だけ消えた行（stranded / missing）は
     // 壊れた URL が残り続けるので error、R2 の削除失敗（deferred）・打ち切り（capped）・
     // 監査の失敗（auditErrors = 検出が働いていない）は次回に回せるので warn。
+    // キャッシュ purge の失敗も warn（削除自体は済んでおり、残っても 120 分で切れる）。
     // 競合で何もしなかった行（skipped）は正常なので info。
     const severity =
       summary.strandedMovies > 0 || summary.missingObjectRows > 0
         ? 'error'
-        : summary.deferredObjectDeletions > 0 || summary.sweepCapped || summary.auditErrors > 0
+        : summary.deferredObjectDeletions > 0 ||
+            summary.sweepCapped ||
+            summary.auditErrors > 0 ||
+            summary.cachePurgeFailures > 0
           ? 'warn'
           : 'info';
     const log =
@@ -128,6 +149,7 @@ async function runRetentionCron(env: Env, event: ScheduledEvent, cron: string): 
       summary.skippedRows > 0 ? ` ${summary.skippedRows} rows skipped this run.` : '';
     const auditErrors =
       summary.auditErrors > 0 ? ` ${summary.auditErrors} audit checks failed.` : '';
+    const purge = ` ${summary.cachePurgeRequests} cache purge requests (${summary.cachePurgeFailures} failed).`;
 
     log(
       JSON.stringify({
@@ -136,7 +158,7 @@ async function runRetentionCron(env: Env, event: ScheduledEvent, cron: string): 
         severity,
         kind: 'event',
         cron,
-        summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures; audited ${summary.checkedReadyRows} ready rows (${summary.missingObjectRows} missing objects).${deferred}${capped}${skipped}${auditErrors}`,
+        summary: `retention backfilled ${summary.backfilledPinned} pinned expiries, deleted ${summary.deletedMovies} expired movies (${summary.strandedMovies} stranded), ${summary.deletedOrphans} orphans, ${summary.deletedFailed} failed rows, ${summary.deletedCaptures} captures; audited ${summary.checkedReadyRows} ready rows (${summary.missingObjectRows} missing objects).${purge}${deferred}${capped}${skipped}${auditErrors}`,
         detail: summary,
         durationMs: Date.now() - startedAt,
       })

--- a/web/cron/wrangler.jsonc
+++ b/web/cron/wrangler.jsonc
@@ -24,6 +24,16 @@
   "observability": {
     "enabled": true
   },
+  // 掃除で消した動画のキャッシュを落とすために使う。
+  // R2_PUBLIC_BASE_URL と CLOUDFLARE_ZONE_ID は web/wrangler.jsonc の同名 var と
+  // 同じ値であることが前提（本体と同じ公開 URL を組み立てて purge する）。片方だけ
+  // 変えると purge が空振りし、削除済みの動画が最大 120 分配信され続ける。
+  // 対になる API token は cron Worker 側にも要る secret:
+  //   bunx wrangler secret put CLOUDFLARE_PURGE_TOKEN -c cron/wrangler.jsonc
+  "vars": {
+    "R2_PUBLIC_BASE_URL": "https://cdn.web-screen.net",
+    "CLOUDFLARE_ZONE_ID": "2210192b51f9f0eb6761d70341ca09b0"
+  },
   "d1_databases": [
     {
       "binding": "DB",

--- a/web/src/lib/contracts/r2key.ts
+++ b/web/src/lib/contracts/r2key.ts
@@ -63,6 +63,17 @@ export function movieKey(shortId: string): string {
   return `movies/${shortId}.mp4`;
 }
 
+/**
+ * 完成した mp4 の公開 URL。配信元（R2_PUBLIC_BASE_URL）とキー規則をここで結ぶ。
+ *
+ * 表示（履歴・プレビュー）と削除時のキャッシュ purge が同じ文字列を組み立てられること
+ * が要件。purge は URL の完全一致でしか効かないため、組み立てが 1 文字でもずれると
+ * 「消したのに配信され続ける」に戻る。
+ */
+export function movieUrl(publicBaseUrl: string, shortId: string): string {
+  return new URL(movieKey(shortId), `${publicBaseUrl}/`).toString();
+}
+
 /** captureKey の index 上限（0 埋め 4 桁で表現できる範囲）。 */
 export const MAX_CAPTURE_INDEX = 9999;
 

--- a/web/src/lib/infra/cloudflare-purge.ts
+++ b/web/src/lib/infra/cloudflare-purge.ts
@@ -51,7 +51,7 @@ export function isPurgeZoneId(zoneId: string): boolean {
  */
 function logFailure(
   source: string,
-  reason: 'request_failed' | 'rejected',
+  reason: 'request_failed' | 'rejected' | 'not_successful',
   count: number,
   status?: number
 ): void {
@@ -61,6 +61,8 @@ function logFailure(
       source,
       severity: 'warn',
       kind: 'event',
+      // infra/worker-log.ts と同じ形にする（ダッシュボードの level 絞り込みから漏れないため）。
+      level: 'warn',
       event: 'cache_purge_failed',
       reason,
       status,
@@ -73,8 +75,10 @@ function logFailure(
 /**
  * URL 単位のキャッシュ purge を 1 回投げる。成功で true、失敗で false（例外は投げない）。
  *
- * 判定は HTTP ステータスだけで行う。Cloudflare は拒否を非 2xx で返すため、本文の
- * `success` を読んでも判断は変わらない（JSON パースという失敗経路が増えるだけ）。
+ * ステータスに加えて本文の `success` も見る。Cloudflare は拒否を非 2xx で返すのが基本
+ * だが、200 + `success: false` を返す経路があるため、ステータスだけだと消えていない
+ * purge を成功と数えてしまう。本文が読めない・JSON でない場合はステータスで判定する
+ * （判定不能を失敗に倒すと、実際は消えているのに失敗として数え続けることになる）。
  */
 export async function purgeCachedUrls(input: PurgeCachedUrlsInput): Promise<boolean> {
   if (input.urls.length === 0) return true;
@@ -105,5 +109,26 @@ export async function purgeCachedUrls(input: PurgeCachedUrlsInput): Promise<bool
     logFailure(input.source, 'rejected', input.urls.length, response.status);
     return false;
   }
+
+  if (await isRejectedBody(response)) {
+    logFailure(input.source, 'not_successful', input.urls.length, response.status);
+    return false;
+  }
   return true;
+}
+
+/**
+ * 2xx だが本文が `success: false` を名乗っているか。
+ *
+ * 本文が読めない・JSON でない・`success` を持たない場合は false（= ステータスの判定を
+ * 採用する）。Cloudflare の応答形式が変わっても、成功している purge を失敗に化けさせない。
+ */
+async function isRejectedBody(response: Response): Promise<boolean> {
+  try {
+    const body: unknown = await response.json();
+    if (typeof body !== 'object' || body === null || !('success' in body)) return false;
+    return body.success === false;
+  } catch {
+    return false;
+  }
 }

--- a/web/src/lib/infra/cloudflare-purge.ts
+++ b/web/src/lib/infra/cloudflare-purge.ts
@@ -1,0 +1,109 @@
+/**
+ * Cloudflare のキャッシュ purge API を叩く境界。
+ *
+ * 配信は R2 の Custom Domain（cdn.web-screen.net）経由で、mp4 は Cloudflare の
+ * 既定キャッシュ対象。R2 から実体を消しても Edge のキャッシュは最大 120 分残るため、
+ * 削除の直後にここで URL 単位の purge を投げる（docs/r2-delivery.md）。
+ *
+ * 例外を投げないのが契約。purge は削除の後始末であり、失敗しても R2 / D1 の削除は
+ * 既に済んでいる（利用者にとっての削除は完了している）。ここで投げると「消えたのに
+ * 削除が失敗した」と伝わるうえ、キャッシュは 120 分で自然に切れる。
+ */
+
+/** 1 リクエストに載せられる URL の上限（Cloudflare API の制約）。超える分は呼び出し側が分割する。 */
+export const MAX_URLS_PER_PURGE = 30;
+
+/**
+ * 応答を待つ上限。Cloudflare API が応答しない時に、削除リクエストの応答（DELETE の 204）や
+ * cron の実行枠をこれ以上待たせない。待ち続けて得られるのは 120 分の短縮だけ。
+ */
+const REQUEST_TIMEOUT_MS = 5000;
+
+/** ゾーン ID の形式。設定ミスをそのまま URL へ連結しないための検査。 */
+const ZONE_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+/** fetch の注入境界（テストで実ネットワークを使わないため）。 */
+export type PurgeFetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const defaultFetch: PurgeFetcher = (input, init) => globalThis.fetch(input, init);
+
+export interface PurgeCachedUrlsInput {
+  /** purge する公開 URL。MAX_URLS_PER_PURGE 件以内であること（分割は呼び出し側の責務）。 */
+  urls: string[];
+  zoneId: string;
+  apiToken: string;
+  /** ログの出所（呼び出す Worker の名前）。本体と cron の両方から呼ばれる。 */
+  source: string;
+  fetcher?: PurgeFetcher;
+}
+
+/** ゾーン ID が使える形式か。空・形式不正はどちらも「未設定」として扱う。 */
+export function isPurgeZoneId(zoneId: string): boolean {
+  return ZONE_ID_PATTERN.test(zoneId);
+}
+
+/**
+ * 失敗を 1 行 JSON で残す。
+ *
+ * URL は出さない。動画の URL は 12 文字の shortId が唯一の保護なので、ログに焼くと
+ * 保護の強さがログを読める範囲まで落ちる。件数と HTTP ステータスがあれば
+ * observability での切り分けには足りる（API token も当然出さない）。
+ */
+function logFailure(
+  source: string,
+  reason: 'request_failed' | 'rejected',
+  count: number,
+  status?: number
+): void {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source,
+      severity: 'warn',
+      kind: 'event',
+      event: 'cache_purge_failed',
+      reason,
+      status,
+      count,
+      summary: `cache purge for ${count} urls failed (${reason}); stale copies expire within 120 minutes.`,
+    })
+  );
+}
+
+/**
+ * URL 単位のキャッシュ purge を 1 回投げる。成功で true、失敗で false（例外は投げない）。
+ *
+ * 判定は HTTP ステータスだけで行う。Cloudflare は拒否を非 2xx で返すため、本文の
+ * `success` を読んでも判断は変わらない（JSON パースという失敗経路が増えるだけ）。
+ */
+export async function purgeCachedUrls(input: PurgeCachedUrlsInput): Promise<boolean> {
+  if (input.urls.length === 0) return true;
+  if (!isPurgeZoneId(input.zoneId) || input.apiToken === '') return false;
+
+  const fetcher = input.fetcher ?? defaultFetch;
+  let response: Response;
+  try {
+    response = await fetcher(
+      `https://api.cloudflare.com/client/v4/zones/${input.zoneId}/purge_cache`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${input.apiToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ files: input.urls }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }
+    );
+  } catch {
+    // タイムアウト（AbortError）もここに来る。理由で分けず、送れなかった事実だけ残す。
+    logFailure(input.source, 'request_failed', input.urls.length);
+    return false;
+  }
+
+  if (!response.ok) {
+    logFailure(input.source, 'rejected', input.urls.length, response.status);
+    return false;
+  }
+  return true;
+}

--- a/web/src/lib/services/cache-purge.ts
+++ b/web/src/lib/services/cache-purge.ts
@@ -21,7 +21,7 @@ import {
 export interface CachePurgeSettings {
   /** 動画の配信元（R2_PUBLIC_BASE_URL）。表示に使うものと同じ値であること。 */
   publicBaseUrl: string;
-  /** CLOUDFLARE_ZONE_ID。未設定・形式不正なら purge せず 1 回だけ warn する。 */
+  /** CLOUDFLARE_ZONE_ID。未設定・形式不正なら purge せず、呼び出しごとに 1 行 warn する。 */
   zoneId: string;
   /** CLOUDFLARE_PURGE_TOKEN（secret）。ローカル開発では空になる。 */
   apiToken: string;
@@ -41,6 +41,13 @@ export interface CachePurgeResult {
 
 const NOTHING_TO_PURGE: CachePurgeResult = { requests: 0, failures: 0 };
 
+/** ログの理由文。event 名と 1 対 1 で対応させる。 */
+const PURGE_ISSUE_REASONS = {
+  cache_purge_skipped: 'purge is not configured',
+  cache_purge_url_invalid: 'public urls are not buildable',
+  movie_delete_cache_purge_failed: 'the owner deleted a movie but the purge request failed',
+} as const;
+
 /**
  * 削除済み動画のキャッシュを落とす。例外は投げない（削除の成否を左右しない）。
  *
@@ -55,7 +62,7 @@ export async function purgeMovieCache(
   if (shortIds.length === 0) return NOTHING_TO_PURGE;
 
   if (!isPurgeZoneId(settings.zoneId) || settings.apiToken === '') {
-    logSkipped(settings.source, shortIds.length);
+    logPurgeIssue(settings.source, 'cache_purge_skipped', shortIds.length);
     return NOTHING_TO_PURGE;
   }
 
@@ -76,7 +83,9 @@ export async function purgeMovieCache(
       if (!purged) failures += 1;
     } catch {
       // 公開 URL を組み立てられなかった（配信元 URL か shortId が不正）。削除は済んで
-      // いるので落とさず、件数だけ残して残りのチャンクを続ける。
+      // いるので落とさず、残りのチャンクを続ける。設定ミスでしか起きないので、
+      // 黙って件数だけ増やさずログにも残す。
+      logPurgeIssue(settings.source, 'cache_purge_url_invalid', chunk.length);
       failures += 1;
     }
   }
@@ -85,21 +94,39 @@ export async function purgeMovieCache(
 }
 
 /**
- * 設定が無いまま呼ばれたことを 1 回だけ知らせる。
+ * purge できなかった理由を 1 行 JSON で残す（1 回の呼び出しにつき 1 行）。
  *
- * ローカル開発（secret 無し）では毎回ここへ来るのが正常なので warn 止まりにする。
- * 本番でこの行が出ていたら、削除したのに 120 分配信され続けている印。
+ * ローカル開発（secret 無し）では毎回 skipped になるのが正常なので warn 止まりにする。
+ * 本番でこの行が出ていたら、削除したのに最大 120 分配信され続けている印。
+ * URL は出さない（shortId が動画の唯一の保護なので、ログに焼かない）。
  */
-function logSkipped(source: string, count: number): void {
+/**
+ * 所有者の削除で purge が失敗したことを残す。
+ *
+ * バッチは件数を summary（cachePurgeRequests / cachePurgeFailures）に出せるが、対話
+ * 削除にはその出口が無い。infra 側の cache_purge_failed だけだと「利用者が消したのに
+ * 見え続けている」経路かどうかを後から切り分けられないので、削除側でも 1 行残す。
+ */
+export function logMovieDeletePurgeFailure(source: string): void {
+  logPurgeIssue(source, 'movie_delete_cache_purge_failed', 1);
+}
+
+function logPurgeIssue(
+  source: string,
+  event: 'cache_purge_skipped' | 'cache_purge_url_invalid' | 'movie_delete_cache_purge_failed',
+  count: number
+): void {
+  const reason = PURGE_ISSUE_REASONS[event];
   console.warn(
     JSON.stringify({
       timestamp: new Date().toISOString(),
       source,
       severity: 'warn',
       kind: 'event',
-      event: 'cache_purge_skipped',
+      level: 'warn',
+      event,
       count,
-      summary: `cache purge is not configured; skipped ${count} urls.`,
+      summary: `cache purge left ${count} urls cached (${reason}); they expire within 120 minutes.`,
     })
   );
 }

--- a/web/src/lib/services/cache-purge.ts
+++ b/web/src/lib/services/cache-purge.ts
@@ -1,0 +1,105 @@
+/**
+ * 削除した動画の公開 URL を Cloudflare のキャッシュから落とす。
+ *
+ * 削除経路（services/movies.ts の deleteMovie と services/retention.ts の各掃除）は
+ * どれもここを通す。shortId から公開 URL を組み立てる規則と、1 リクエスト 30 URL の
+ * 分割を 1 箇所に置き、経路ごとに書き分けない。
+ *
+ * 設定（ゾーン ID / API token / 配信元）は entry 層（pages/ と cron/）が bindings から
+ * 素の文字列で渡す。entry は infra を直接叩けない（docs/architecture-contract.toml）ため、
+ * 設定の型はここで定義して公開する。
+ */
+
+import { movieUrl } from '../contracts/r2key';
+import {
+  MAX_URLS_PER_PURGE,
+  isPurgeZoneId,
+  purgeCachedUrls,
+  type PurgeFetcher,
+} from '../infra/cloudflare-purge';
+
+export interface CachePurgeSettings {
+  /** 動画の配信元（R2_PUBLIC_BASE_URL）。表示に使うものと同じ値であること。 */
+  publicBaseUrl: string;
+  /** CLOUDFLARE_ZONE_ID。未設定・形式不正なら purge せず 1 回だけ warn する。 */
+  zoneId: string;
+  /** CLOUDFLARE_PURGE_TOKEN（secret）。ローカル開発では空になる。 */
+  apiToken: string;
+  /** ログの出所（呼び出す Worker の名前）。 */
+  source: string;
+  /** テストで実ネットワークを使わないための注入口。本番では省略する。 */
+  fetcher?: PurgeFetcher;
+}
+
+/** 1 回の purge 実行の内訳。cron はこれを構造化ログに載せる。 */
+export interface CachePurgeResult {
+  /** Cloudflare API を叩いた回数（30 URL ごとに 1 回）。 */
+  requests: number;
+  /** そのうち失敗した回数。0 以外でも削除自体は完了しており、最大 120 分で自然に切れる。 */
+  failures: number;
+}
+
+const NOTHING_TO_PURGE: CachePurgeResult = { requests: 0, failures: 0 };
+
+/**
+ * 削除済み動画のキャッシュを落とす。例外は投げない（削除の成否を左右しない）。
+ *
+ * 呼ぶのは R2 の実体を消した後だけ。実体が残っている状態で purge しても、次の取得で
+ * 同じものがキャッシュへ戻るだけで意味がない。
+ */
+export async function purgeMovieCache(
+  shortIds: string[],
+  settings: CachePurgeSettings
+): Promise<CachePurgeResult> {
+  // 消すものが無い実行では設定も見ない（毎時の空回り cron が warn を吐き続けないため）。
+  if (shortIds.length === 0) return NOTHING_TO_PURGE;
+
+  if (!isPurgeZoneId(settings.zoneId) || settings.apiToken === '') {
+    logSkipped(settings.source, shortIds.length);
+    return NOTHING_TO_PURGE;
+  }
+
+  let requests = 0;
+  let failures = 0;
+  for (let index = 0; index < shortIds.length; index += MAX_URLS_PER_PURGE) {
+    const chunk = shortIds.slice(index, index + MAX_URLS_PER_PURGE);
+    requests += 1;
+    try {
+      const urls = chunk.map((shortId) => movieUrl(settings.publicBaseUrl, shortId));
+      const purged = await purgeCachedUrls({
+        urls,
+        zoneId: settings.zoneId,
+        apiToken: settings.apiToken,
+        source: settings.source,
+        fetcher: settings.fetcher,
+      });
+      if (!purged) failures += 1;
+    } catch {
+      // 公開 URL を組み立てられなかった（配信元 URL か shortId が不正）。削除は済んで
+      // いるので落とさず、件数だけ残して残りのチャンクを続ける。
+      failures += 1;
+    }
+  }
+
+  return { requests, failures };
+}
+
+/**
+ * 設定が無いまま呼ばれたことを 1 回だけ知らせる。
+ *
+ * ローカル開発（secret 無し）では毎回ここへ来るのが正常なので warn 止まりにする。
+ * 本番でこの行が出ていたら、削除したのに 120 分配信され続けている印。
+ */
+function logSkipped(source: string, count: number): void {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source,
+      severity: 'warn',
+      kind: 'event',
+      event: 'cache_purge_skipped',
+      count,
+      summary: `cache purge is not configured; skipped ${count} urls.`,
+    })
+  );
+}

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -14,8 +14,9 @@ import {
   type PinResponse,
   type RenameMovieResponse,
 } from '../contracts/api';
-import { isShortId, movieKey } from '../contracts/r2key';
+import { isShortId, movieKey, movieUrl } from '../contracts/r2key';
 import { logWorkerFailure } from '../infra/worker-log';
+import { purgeMovieCache, type CachePurgeSettings } from './cache-purge';
 import {
   MAX_PINNED_MOVIES,
   MOVIE_RETENTION_MS,
@@ -279,7 +280,7 @@ export async function renameMovie(
  * （所有者が二度と消せない残骸になる）。
  */
 export async function deleteMovie(
-  input: MovieActionInput & { bucket: MovieBucket }
+  input: MovieActionInput & { bucket: MovieBucket; cachePurge: CachePurgeSettings }
 ): Promise<void> {
   await findOwnedMovie(input.database, input.userId, input.shortId);
 
@@ -289,6 +290,13 @@ export async function deleteMovie(
   // （services/retention-audit.ts）が拾える。自動では直せないので、その場でも
   // 気づける印としてログに残してから呼び出し元へ返す。
   await input.bucket.delete(movieKey(input.shortId));
+
+  // 実体を消した直後に Edge のキャッシュも落とす。ここを飛ばすと最大 120 分は
+  // 削除済みの動画が配信され続ける（docs/r2-delivery.md）。D1 の行を消す前に呼ぶのは、
+  // 行の削除が失敗して実体だけ消えた場合でもキャッシュを残さないため。purge は例外を
+  // 投げない契約なので、失敗しても削除は 204 で完了する（120 分で自然に切れる）。
+  await purgeMovieCache([input.shortId], input.cachePurge);
+
   try {
     await input.database
       .prepare('DELETE FROM movies WHERE short_id = ? AND user_id = ?')
@@ -329,7 +337,7 @@ export async function findPublicMovie(input: {
   return {
     shortId: row.short_id,
     filename: row.filename,
-    publicUrl: publicUrl(input.publicBaseUrl, row.short_id),
+    publicUrl: movieUrl(input.publicBaseUrl, row.short_id),
     pinned: row.pinned !== 0,
     createdAt: toIsoString(row.created_at),
     expiresAt: row.expires_at === null ? null : toIsoString(row.expires_at),
@@ -396,12 +404,8 @@ function toHistoryEntry(row: MovieRow, publicBaseUrl: string): HistoryEntry {
     pinned: row.pinned !== 0,
     createdAt: toIsoString(row.created_at),
     expiresAt: row.expires_at === null ? null : toIsoString(row.expires_at),
-    publicUrl: publicUrl(publicBaseUrl, row.short_id),
+    publicUrl: movieUrl(publicBaseUrl, row.short_id),
   };
-}
-
-function publicUrl(publicBaseUrl: string, shortId: string): string {
-  return new URL(movieKey(shortId), `${publicBaseUrl}/`).toString();
 }
 
 const SQLITE_DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -16,7 +16,11 @@ import {
 } from '../contracts/api';
 import { isShortId, movieKey, movieUrl } from '../contracts/r2key';
 import { logWorkerFailure } from '../infra/worker-log';
-import { purgeMovieCache, type CachePurgeSettings } from './cache-purge';
+import {
+  logMovieDeletePurgeFailure,
+  purgeMovieCache,
+  type CachePurgeSettings,
+} from './cache-purge';
 import {
   MAX_PINNED_MOVIES,
   MOVIE_RETENTION_MS,
@@ -295,7 +299,11 @@ export async function deleteMovie(
   // 削除済みの動画が配信され続ける（docs/r2-delivery.md）。D1 の行を消す前に呼ぶのは、
   // 行の削除が失敗して実体だけ消えた場合でもキャッシュを残さないため。purge は例外を
   // 投げない契約なので、失敗しても削除は 204 で完了する（120 分で自然に切れる）。
-  await purgeMovieCache([input.shortId], input.cachePurge);
+  //
+  // バッチは件数を summary に出せるが、対話削除にはその出口が無い。失敗を握り潰すと
+  // 「消したのに見える」が誰にも見えないまま起きるため、この経路だけログに残す。
+  const purge = await purgeMovieCache([input.shortId], input.cachePurge);
+  if (purge.failures > 0) logMovieDeletePurgeFailure(input.cachePurge.source);
 
   try {
     await input.database

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -47,7 +47,8 @@ export const MAX_EXPIRED_DELETIONS_PER_RUN = 50;
  * 各フェーズの最悪ケースの合計を Workers の上限（1 回の実行で 1000 subrequest）より
  * 下に保つ: 期限の補完 1、期限切れ 1 + 50 × 4 = 201、pending 1 + 150 × 3 = 451、
  * failed 1 + 1 + 10 = 12、captures 10 ページ × 2 = 20、監査 2 + 50 + 50 = 102、
- * キャッシュ purge が 30 URL ごとに 1 回で (50 + 150 + 500) / 30 → 24。合計 811。
+ * キャッシュ purge は経路ごとに 30 URL で 1 回なので ceil(50/30) + ceil(150/30) +
+ * ceil(500/30) = 2 + 5 + 17 = 24。合計 811。
  */
 export const MAX_PENDING_CLAIMS_PER_RUN = 150;
 

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -8,6 +8,10 @@
  * D1 / R2 はインターフェースで注入し、現在時刻も引数で受け取る（Date.now を呼ぶのは
  * cron の entry 層だけ）。これで workerd なしでも全分岐をテストできる。
  *
+ * 実体を消した経路は、続けて公開 URL のキャッシュ purge も投げる（services/cache-purge.ts）。
+ * 投げないと削除済みの動画が最大 120 分配信され続ける（docs/r2-delivery.md）。purge の
+ * 失敗は掃除を止めない（件数だけ summary に出す。キャッシュは 120 分で自然に切れる）。
+ *
  * 実体を消してから行を消す（R2 → D1）。逆にすると D1 の行を消した時点で R2 のキーを
  * 導出できなくなり、実体だけが残って回収不能になる（R2 の delete は存在しないキーでも
  * 成功するため、この順序なら途中失敗しても次回実行でやり直せる）。
@@ -19,6 +23,7 @@
  */
 
 import { movieKey } from '../contracts/r2key';
+import { purgeMovieCache, type CachePurgeSettings } from './cache-purge';
 import { PINNED_RETENTION_MS } from './quota';
 import { auditReadyObjects } from './retention-audit';
 import { deleteStaleCaptures, type CaptureBucket } from './retention-captures';
@@ -41,7 +46,8 @@ export const MAX_EXPIRED_DELETIONS_PER_RUN = 50;
  *
  * 各フェーズの最悪ケースの合計を Workers の上限（1 回の実行で 1000 subrequest）より
  * 下に保つ: 期限の補完 1、期限切れ 1 + 50 × 4 = 201、pending 1 + 150 × 3 = 451、
- * failed 1 + 1 + 10 = 12、captures 10 ページ × 2 = 20、監査 2 + 50 + 50 = 102。合計 787。
+ * failed 1 + 1 + 10 = 12、captures 10 ページ × 2 = 20、監査 2 + 50 + 50 = 102、
+ * キャッシュ purge が 30 URL ごとに 1 回で (50 + 150 + 500) / 30 → 24。合計 811。
  */
 export const MAX_PENDING_CLAIMS_PER_RUN = 150;
 
@@ -87,6 +93,10 @@ export interface RetentionSummary {
   skippedRows: number;
   /** どこかの掃除が 1 回の上限に達して打ち切ったか。true なら残りは次回の実行が拾う。 */
   sweepCapped: boolean;
+  /** キャッシュ purge を投げた回数（30 URL ごとに 1 回）。 */
+  cachePurgeRequests: number;
+  /** そのうち失敗した回数。0 以外なら削除済みの動画が最大 120 分配信され続ける。 */
+  cachePurgeFailures: number;
   deletedCaptures: number;
   /** 実体の有無を確かめた ready 行のサンプル数（services/retention-audit.ts）。 */
   checkedReadyRows: number;
@@ -101,6 +111,8 @@ export interface RetentionInput {
   bucket: RetentionBucket;
   /** バッチの基準時刻。cron の scheduledTime を渡す。 */
   now: Date;
+  /** 削除した動画の公開 URL をキャッシュから落とすための設定（cron の entry が組む）。 */
+  cachePurge: CachePurgeSettings;
 }
 
 interface ShortIdRow {
@@ -114,15 +126,20 @@ interface ShortIdRow {
  * 縮まらず、subrequest のバーストだけが増える）。
  */
 export async function runRetention(input: RetentionInput): Promise<RetentionSummary> {
-  const { database, bucket, now } = input;
+  const { database, bucket, now, cachePurge } = input;
 
   // 掃除より先に走らせる。期限を入れた直後の行は 1 年先なので同じ実行では消えない。
   const backfilledPinned = await backfillPinnedExpiry(database, now);
+  // 経路ごとに、実体を消した直後にキャッシュも落とす（最後にまとめると、後続の掃除が
+  // 落ちた時に先行の分まで purge されず「消したのに 120 分見える」が残る）。
   const expired = await deleteExpiredMovies(database, bucket, now);
+  const expiredPurge = await purgeMovieCache(expired.purged, cachePurge);
   const orphans = await deletePendingOrphans(database, bucket, now);
+  const orphansPurge = await purgeMovieCache(orphans.purged, cachePurge);
   // 孤児の確保で R2 の削除に失敗した行も failed として残っているため、同じ実行の
   // ここで拾い直せる（猶予はどちらも 24 時間）。取りこぼしても次回の実行が同じ条件で拾う。
   const failed = await deleteFailedMovies(database, bucket, now);
+  const failedPurge = await purgeMovieCache(failed.purged, cachePurge);
   const captures = await deleteStaleCaptures(bucket, now);
   // 掃除の後に見る（この実行で消した行を実体なしと数えないため）。何も削除しない。
   const audit = await auditReadyObjects(database, bucket);
@@ -138,6 +155,8 @@ export async function runRetention(input: RetentionInput): Promise<RetentionSumm
     deferredObjectDeletions: expired.deferred + failed.deferred,
     skippedRows: expired.skipped + orphans.skipped,
     sweepCapped: expired.capped || orphans.capped || failed.capped || captures.capped,
+    cachePurgeRequests: expiredPurge.requests + orphansPurge.requests + failedPurge.requests,
+    cachePurgeFailures: expiredPurge.failures + orphansPurge.failures + failedPurge.failures,
     deletedCaptures: captures.deleted,
     checkedReadyRows: audit.checkedReadyRows,
     missingObjectRows: audit.missingObjectRows,
@@ -186,6 +205,8 @@ async function deleteExpiredMovies(
   stranded: number;
   skipped: number;
   deferred: number;
+  /** R2 の実体を消した shortId（行が残ったものも含む。キャッシュは落とす）。 */
+  purged: string[];
   capped: boolean;
 }> {
   const threshold = now.toISOString();
@@ -200,6 +221,7 @@ async function deleteExpiredMovies(
   let stranded = 0;
   let skipped = 0;
   let deferred = 0;
+  const purged: string[] = [];
   for (const row of results) {
     // 初回 SELECT の後に pin（= 期限の延長）が入った場合、R2 を先に消すと生きた
     // 行だけが残る。R2 削除の直前にも期限を読み直し、実体と行の不整合を防ぐ。
@@ -223,6 +245,7 @@ async function deleteExpiredMovies(
       deferred += 1;
       continue;
     }
+    purged.push(row.short_id);
 
     // SELECT 後に期限が延びた動画を巻き込まないよう、削除時にも期限を再確認する。
     const result = await database
@@ -249,6 +272,7 @@ async function deleteExpiredMovies(
     stranded,
     skipped,
     deferred,
+    purged,
     capped: results.length === MAX_EXPIRED_DELETIONS_PER_RUN,
   };
 }
@@ -267,7 +291,7 @@ async function deletePendingOrphans(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<{ deleted: number; skipped: number; capped: boolean }> {
+): Promise<{ deleted: number; skipped: number; purged: string[]; capped: boolean }> {
   const threshold = new Date(now.getTime() - PENDING_ORPHAN_GRACE_MS).toISOString();
   const { results } = await database
     .prepare(
@@ -278,6 +302,7 @@ async function deletePendingOrphans(
 
   let deleted = 0;
   let skipped = 0;
+  const purged: string[] = [];
   for (const row of results) {
     // SELECT 後に commit が確定した行を巻き込まないよう、確保時にも猶予を再確認する。
     const claim = await database
@@ -294,6 +319,7 @@ async function deletePendingOrphans(
 
     // 削除に失敗した行は failed のまま残す（件数は failed の掃除が数える）。
     if (!(await deleteMovieObject(bucket, row.short_id))) continue;
+    purged.push(row.short_id);
 
     const result = await database
       .prepare("DELETE FROM movies WHERE short_id = ? AND status = 'failed'")
@@ -302,7 +328,7 @@ async function deletePendingOrphans(
     deleted += result.meta.changes;
   }
 
-  return { deleted, skipped, capped: results.length === MAX_PENDING_CLAIMS_PER_RUN };
+  return { deleted, skipped, purged, capped: results.length === MAX_PENDING_CLAIMS_PER_RUN };
 }
 
 /**
@@ -333,7 +359,7 @@ async function deleteFailedMovies(
   database: RetentionDatabase,
   bucket: RetentionBucket,
   now: Date
-): Promise<{ deleted: number; deferred: number; capped: boolean }> {
+): Promise<{ deleted: number; deferred: number; purged: string[]; capped: boolean }> {
   const threshold = new Date(now.getTime() - FAILED_RETENTION_MS).toISOString();
   const { results } = await database
     .prepare(
@@ -343,14 +369,14 @@ async function deleteFailedMovies(
     .all<ShortIdRow>();
 
   const capped = results.length === MAX_FAILED_DELETIONS_PER_RUN;
-  if (results.length === 0) return { deleted: 0, deferred: 0, capped };
+  if (results.length === 0) return { deleted: 0, deferred: 0, purged: [], capped };
 
   const shortIds = results.map((row) => row.short_id);
   try {
     await bucket.delete(shortIds.map(movieKey));
   } catch {
     // R2 が落ちている間に行だけ消すと実体が孤児になるため、この実行では行を残す。
-    return { deleted: 0, deferred: shortIds.length, capped };
+    return { deleted: 0, deferred: shortIds.length, purged: [], capped };
   }
 
   let deleted = 0;
@@ -364,5 +390,5 @@ async function deleteFailedMovies(
     deleted += result.meta.changes;
   }
 
-  return { deleted, deferred: 0, capped };
+  return { deleted, deferred: 0, purged: shortIds, capped };
 }

--- a/web/src/lib/services/uploads.ts
+++ b/web/src/lib/services/uploads.ts
@@ -6,7 +6,7 @@ import {
   type PresignRequest,
   type PresignResponse,
 } from '../contracts/api';
-import { generateShortId, movieKey } from '../contracts/r2key';
+import { generateShortId, movieKey, movieUrl } from '../contracts/r2key';
 import { createR2PutPresignedUrl, type R2PresignConfig } from '../infra/r2presign';
 import { logWorkerFailure } from '../infra/worker-log';
 import {
@@ -112,7 +112,7 @@ export async function createPendingUpload(
   return {
     shortId,
     uploadUrl,
-    publicUrl: createPublicUrl(input.publicBaseUrl, key),
+    publicUrl: movieUrl(input.publicBaseUrl, shortId),
   };
 }
 
@@ -236,14 +236,10 @@ async function resolveCommitConflict(input: CommitUploadInput): Promise<CommitRe
   throw new UploadError(400, ERROR_CODES.invalidRequest, 'この動画は commit できません');
 }
 
-function createPublicUrl(publicBaseUrl: string, key: string): string {
-  return new URL(key, `${publicBaseUrl}/`).toString();
-}
-
 function toCommitResponse(movie: MovieRow, publicBaseUrl: string): CommitResponse {
   return {
     shortId: movie.short_id,
-    publicUrl: createPublicUrl(publicBaseUrl, movieKey(movie.short_id)),
+    publicUrl: movieUrl(publicBaseUrl, movie.short_id),
     sizeBytes: movie.size_bytes,
     expiresAt: movie.expires_at,
   };

--- a/web/src/pages/api/movies/[shortId]/index.ts
+++ b/web/src/pages/api/movies/[shortId]/index.ts
@@ -5,6 +5,7 @@ import { ERROR_CODES, validateRenameMovieRequest } from '../../../../lib/contrac
 import { logWorkerFailure } from '../../../../lib/infra/worker-log';
 import { importSigningKey } from '../../../../lib/contracts/session';
 import { requireUser, type AuthDatabase } from '../../../../lib/services/auth';
+import type { CachePurgeSettings } from '../../../../lib/services/cache-purge';
 import {
   deleteMovie,
   MovieActionError,
@@ -19,6 +20,21 @@ interface DeleteBindings {
   DB: AuthDatabase & MoviesDatabase;
   BUCKET: MovieBucket;
   SESSION_SIGNING_KEY: string;
+  R2_PUBLIC_BASE_URL: string;
+  /** wrangler.jsonc の vars（公開情報）。 */
+  CLOUDFLARE_ZONE_ID?: string;
+  /** secret。未投入の環境（ローカル開発）では purge を諦めて warn だけ出す。 */
+  CLOUDFLARE_PURGE_TOKEN?: string;
+}
+
+/** 削除した動画のキャッシュを落とすための設定を bindings から組む。 */
+function cachePurgeSettings(bindings: DeleteBindings): CachePurgeSettings {
+  return {
+    publicBaseUrl: bindings.R2_PUBLIC_BASE_URL,
+    zoneId: bindings.CLOUDFLARE_ZONE_ID ?? '',
+    apiToken: bindings.CLOUDFLARE_PURGE_TOKEN ?? '',
+    source: 'webscreen-beta-worker',
+  };
 }
 
 function invalidRequest(message: string): Response {
@@ -80,6 +96,7 @@ export const DELETE: APIRoute = async ({ request, params }) => {
     await deleteMovie({
       database: bindings.DB,
       bucket: bindings.BUCKET,
+      cachePurge: cachePurgeSettings(bindings),
       userId: result.user.id,
       shortId: params.shortId ?? '',
     });

--- a/web/tests/cron/retention-worker.test.ts
+++ b/web/tests/cron/retention-worker.test.ts
@@ -105,7 +105,8 @@ async function runScheduled(
   try {
     await worker.scheduled(
       { scheduledTime: SCHEDULED_TIME, cron: '17 * * * *' },
-      { DB: database, BUCKET: bucket }
+      // purge の設定は渡さない（secret 未投入の環境と同じ。掃除は続く）。
+      { DB: database, BUCKET: bucket, R2_PUBLIC_BASE_URL: 'https://cdn.example' }
     );
   } finally {
     console.log = original.log;
@@ -124,6 +125,7 @@ describe('保持期間バッチの cron ログ', () => {
     expect(level).toBe('error');
     expect(entry.severity).toBe('error');
     expect(entry.summary).toContain('audited 1 ready rows (1 missing objects)');
+    expect(entry.summary).toContain('0 cache purge requests (0 failed)');
     expect(entry.detail.missingObjectRows).toBe(1);
   });
 

--- a/web/tests/infra/cloudflare-purge.test.ts
+++ b/web/tests/infra/cloudflare-purge.test.ts
@@ -66,6 +66,39 @@ describe('purgeCachedUrls', () => {
     expect(logs[0]).not.toContain(API_TOKEN);
   });
 
+  it('200 でも本文が success: false なら失敗として扱う', async () => {
+    let purged = true;
+    const logs = await captureWarnLogs(async () => {
+      purged = await purgeCachedUrls({
+        urls: [URL_A],
+        zoneId: ZONE_ID,
+        apiToken: API_TOKEN,
+        source: 'test-worker',
+        fetcher: () =>
+          Promise.resolve(
+            new Response(JSON.stringify({ success: false, errors: [{ code: 1012 }] }), {
+              status: 200,
+            })
+          ),
+      });
+    });
+
+    expect(purged).toBe(false);
+    expect(JSON.parse(logs[0]!).reason).toBe('not_successful');
+  });
+
+  it('本文が JSON でなくてもステータスが 2xx なら成功として扱う', async () => {
+    const purged = await purgeCachedUrls({
+      urls: [URL_A],
+      zoneId: ZONE_ID,
+      apiToken: API_TOKEN,
+      source: 'test-worker',
+      fetcher: () => Promise.resolve(new Response('OK', { status: 200 })),
+    });
+
+    expect(purged).toBe(true);
+  });
+
   it('ネットワーク障害でも false を返し、呼び出し側を落とさない', async () => {
     let purged = true;
     const logs = await captureWarnLogs(async () => {

--- a/web/tests/infra/cloudflare-purge.test.ts
+++ b/web/tests/infra/cloudflare-purge.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'bun:test';
+
+import { purgeCachedUrls } from '../../src/lib/infra/cloudflare-purge';
+
+const ZONE_ID = '2210192b51f9f0eb6761d70341ca09b0';
+const API_TOKEN = 'test-token';
+const URL_A = 'https://cdn.example/movies/AbCdEf123456.mp4';
+
+/** console.warn を差し替えて、出力された 1 行 JSON を取る。 */
+async function captureWarnLogs(run: () => Promise<void>): Promise<string[]> {
+  const original = console.warn;
+  const entries: string[] = [];
+  console.warn = (entry: unknown) => {
+    entries.push(String(entry));
+  };
+  try {
+    await run();
+  } finally {
+    console.warn = original;
+  }
+  return entries;
+}
+
+describe('purgeCachedUrls', () => {
+  it('ゾーンの purge_cache へ files として POST し、成功なら true', async () => {
+    let seen: { url: string; init: RequestInit | undefined } | null = null;
+
+    const purged = await purgeCachedUrls({
+      urls: [URL_A],
+      zoneId: ZONE_ID,
+      apiToken: API_TOKEN,
+      source: 'test-worker',
+      fetcher: (url, init) => {
+        seen = { url: String(url), init };
+        return Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 }));
+      },
+    });
+
+    expect(purged).toBe(true);
+    expect(seen!.url).toBe(`https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache`);
+    expect(seen!.init?.method).toBe('POST');
+    expect((seen!.init?.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${API_TOKEN}`
+    );
+    expect(JSON.parse(String(seen!.init?.body))).toEqual({ files: [URL_A] });
+  });
+
+  it('Cloudflare が拒否したら false を返し、例外にしない', async () => {
+    let purged = true;
+    const logs = await captureWarnLogs(async () => {
+      purged = await purgeCachedUrls({
+        urls: [URL_A],
+        zoneId: ZONE_ID,
+        apiToken: API_TOKEN,
+        source: 'test-worker',
+        fetcher: () => Promise.resolve(new Response('forbidden', { status: 403 })),
+      });
+    });
+
+    expect(purged).toBe(false);
+    const entry = JSON.parse(logs[0]!);
+    expect(entry.event).toBe('cache_purge_failed');
+    expect(entry.status).toBe(403);
+    // 動画 URL は shortId が唯一の保護なので、失敗してもログには出さない。
+    expect(logs[0]).not.toContain('AbCdEf123456');
+    expect(logs[0]).not.toContain(API_TOKEN);
+  });
+
+  it('ネットワーク障害でも false を返し、呼び出し側を落とさない', async () => {
+    let purged = true;
+    const logs = await captureWarnLogs(async () => {
+      purged = await purgeCachedUrls({
+        urls: [URL_A],
+        zoneId: ZONE_ID,
+        apiToken: API_TOKEN,
+        source: 'test-worker',
+        fetcher: () => Promise.reject(new Error('timed out')),
+      });
+    });
+
+    expect(purged).toBe(false);
+    expect(JSON.parse(logs[0]!).reason).toBe('request_failed');
+  });
+
+  it('ゾーン ID の形式が不正なら送信しない', async () => {
+    let called = false;
+
+    const purged = await purgeCachedUrls({
+      urls: [URL_A],
+      zoneId: '../zones/other-zone',
+      apiToken: API_TOKEN,
+      source: 'test-worker',
+      fetcher: () => {
+        called = true;
+        return Promise.resolve(new Response(null, { status: 200 }));
+      },
+    });
+
+    expect(purged).toBe(false);
+    expect(called).toBe(false);
+  });
+});

--- a/web/tests/services/cache-purge.test.ts
+++ b/web/tests/services/cache-purge.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'bun:test';
+
+import { MAX_URLS_PER_PURGE } from '../../src/lib/infra/cloudflare-purge';
+import { purgeMovieCache, type CachePurgeSettings } from '../../src/lib/services/cache-purge';
+
+const ZONE_ID = '2210192b51f9f0eb6761d70341ca09b0';
+const PUBLIC_BASE_URL = 'https://cdn.example';
+
+/** 送られた files 配列を記録するフェイクの fetch。 */
+class FakePurgeApi {
+  readonly batches: string[][] = [];
+
+  constructor(private readonly status = 200) {}
+
+  readonly fetcher = (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const body = JSON.parse(String(init?.body)) as { files: string[] };
+    this.batches.push(body.files);
+    return Promise.resolve(new Response(null, { status: this.status }));
+  };
+}
+
+function settings(overrides: Partial<CachePurgeSettings> = {}): CachePurgeSettings {
+  return {
+    publicBaseUrl: PUBLIC_BASE_URL,
+    zoneId: ZONE_ID,
+    apiToken: 'test-token',
+    source: 'test-worker',
+    ...overrides,
+  };
+}
+
+/** 12 文字の shortId を連番で作る（形式は contracts/r2key.ts の規則に合わせる）。 */
+function shortIds(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `Aa${String(index).padStart(10, '0')}`);
+}
+
+async function captureWarnLogs(run: () => Promise<void>): Promise<string[]> {
+  const original = console.warn;
+  const entries: string[] = [];
+  console.warn = (entry: unknown) => {
+    entries.push(String(entry));
+  };
+  try {
+    await run();
+  } finally {
+    console.warn = original;
+  }
+  return entries;
+}
+
+describe('purgeMovieCache', () => {
+  it('配信元とキー規則から組み立てた公開 URL を purge する', async () => {
+    const api = new FakePurgeApi();
+
+    const result = await purgeMovieCache(['AbCdEf123456'], settings({ fetcher: api.fetcher }));
+
+    expect(result).toEqual({ requests: 1, failures: 0 });
+    expect(api.batches).toEqual([[`${PUBLIC_BASE_URL}/movies/AbCdEf123456.mp4`]]);
+  });
+
+  it('30 件を超えたら 30 件ずつに分けて送る', async () => {
+    const api = new FakePurgeApi();
+    const ids = shortIds(MAX_URLS_PER_PURGE + 1);
+
+    const result = await purgeMovieCache(ids, settings({ fetcher: api.fetcher }));
+
+    expect(result.requests).toBe(2);
+    expect(api.batches.map((batch) => batch.length)).toEqual([MAX_URLS_PER_PURGE, 1]);
+    // 分割で取りこぼしが出ないこと（全件がどこかのリクエストに載る）。
+    expect(api.batches.flat()).toHaveLength(ids.length);
+  });
+
+  it('Cloudflare が拒否しても例外にせず、失敗の件数だけ返す', async () => {
+    const api = new FakePurgeApi(500);
+    let result = { requests: 0, failures: 0 };
+
+    await captureWarnLogs(async () => {
+      result = await purgeMovieCache(shortIds(2), settings({ fetcher: api.fetcher }));
+    });
+
+    expect(result).toEqual({ requests: 1, failures: 1 });
+  });
+
+  it('token 未設定なら送信せず、1 回だけ warn を出す', async () => {
+    const api = new FakePurgeApi();
+    let result = { requests: 1, failures: 1 };
+
+    const logs = await captureWarnLogs(async () => {
+      result = await purgeMovieCache(
+        shortIds(3),
+        settings({ apiToken: '', fetcher: api.fetcher })
+      );
+    });
+
+    expect(result).toEqual({ requests: 0, failures: 0 });
+    expect(api.batches).toEqual([]);
+    expect(logs).toHaveLength(1);
+    expect(JSON.parse(logs[0]!).event).toBe('cache_purge_skipped');
+  });
+
+  it('消すものが無い実行では設定を見ず、ログも出さない', async () => {
+    let result = { requests: 1, failures: 1 };
+
+    const logs = await captureWarnLogs(async () => {
+      result = await purgeMovieCache([], settings({ apiToken: '' }));
+    });
+
+    expect(result).toEqual({ requests: 0, failures: 0 });
+    expect(logs).toEqual([]);
+  });
+});

--- a/web/tests/services/cache-purge.test.ts
+++ b/web/tests/services/cache-purge.test.ts
@@ -98,6 +98,23 @@ describe('purgeMovieCache', () => {
     expect(JSON.parse(logs[0]!).event).toBe('cache_purge_skipped');
   });
 
+  it('公開 URL を組み立てられない設定では、黙って諦めずログに残す', async () => {
+    const api = new FakePurgeApi();
+    let result = { requests: 0, failures: 0 };
+
+    const logs = await captureWarnLogs(async () => {
+      result = await purgeMovieCache(
+        shortIds(1),
+        // 配信元が URL として解釈できない（vars の設定ミス）。
+        settings({ publicBaseUrl: 'not a url', fetcher: api.fetcher })
+      );
+    });
+
+    expect(result).toEqual({ requests: 1, failures: 1 });
+    expect(api.batches).toEqual([]);
+    expect(JSON.parse(logs[0]!).event).toBe('cache_purge_url_invalid');
+  });
+
   it('消すものが無い実行では設定を見ず、ログも出さない', async () => {
     let result = { requests: 1, failures: 1 };
 

--- a/web/tests/services/helpers/retention-fakes.ts
+++ b/web/tests/services/helpers/retention-fakes.ts
@@ -193,6 +193,38 @@ export function captureObject(index: number, uploadedOffsetMs: number): CaptureO
   };
 }
 
-export async function run(database: FakeRetentionDatabase, bucket: FakeRetentionBucket) {
-  return runRetention({ database, bucket, now: NOW });
+/** 配信元。purge の URL 組み立てが実際の公開 URL と同じ規則か見るために使う。 */
+export const PUBLIC_BASE_URL = 'https://cdn.example';
+
+/**
+ * キャッシュ purge API のフェイク。1 リクエスト分の files 配列をそのまま記録する。
+ */
+export class FakeCachePurgeApi {
+  readonly batches: string[][] = [];
+
+  constructor(private readonly status = 200) {}
+
+  readonly fetcher = (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    this.batches.push((JSON.parse(String(init?.body)) as { files: string[] }).files);
+    return Promise.resolve(new Response(null, { status: this.status }));
+  };
+}
+
+export async function run(
+  database: FakeRetentionDatabase,
+  bucket: FakeRetentionBucket,
+  purgeApi: FakeCachePurgeApi = new FakeCachePurgeApi()
+) {
+  return runRetention({
+    database,
+    bucket,
+    now: NOW,
+    cachePurge: {
+      publicBaseUrl: PUBLIC_BASE_URL,
+      zoneId: '2210192b51f9f0eb6761d70341ca09b0',
+      apiToken: 'test-token',
+      source: 'test-cron',
+      fetcher: purgeApi.fetcher,
+    },
+  });
 }

--- a/web/tests/services/movies-delete.test.ts
+++ b/web/tests/services/movies-delete.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
+import type { PurgeFetcher } from '../../src/lib/infra/cloudflare-purge';
+import type { CachePurgeSettings } from '../../src/lib/services/cache-purge';
 import {
   deleteMovie,
   type MovieBucket,
@@ -9,6 +11,18 @@ import {
 const USER_ID = 10;
 const SHORT_ID = 'AbCdEf123456';
 const MOVIE_KEY = `movies/${SHORT_ID}.mp4`;
+const PUBLIC_BASE_URL = 'https://cdn.example';
+
+/** purge の設定。fetcher を差し替えて実ネットワークを使わない。 */
+function cachePurge(fetcher?: PurgeFetcher): CachePurgeSettings {
+  return {
+    publicBaseUrl: PUBLIC_BASE_URL,
+    zoneId: '2210192b51f9f0eb6761d70341ca09b0',
+    apiToken: 'test-token',
+    source: 'test-worker',
+    fetcher: fetcher ?? (() => Promise.resolve(new Response(null, { status: 200 }))),
+  };
+}
 
 /** deleteMovie が使う 2 文（所有者の SELECT と DELETE）だけを持つ最小のフェイク。 */
 class FakeMoviesDatabase implements MoviesDatabase {
@@ -49,6 +63,21 @@ class FakeMovieBucket implements MovieBucket {
   }
 }
 
+/** purge の失敗ログ（console.warn の 1 行 JSON）を集める。 */
+async function captureWarnLogs(run: () => Promise<void>): Promise<string[]> {
+  const original = console.warn;
+  const entries: string[] = [];
+  console.warn = (entry: unknown) => {
+    entries.push(String(entry));
+  };
+  try {
+    await run();
+  } finally {
+    console.warn = original;
+  }
+  return entries;
+}
+
 /** logWorkerFailure が error で出した event 名だけを集める。 */
 async function captureErrorEvents(run: () => Promise<void>): Promise<string[]> {
   const original = console.error;
@@ -69,7 +98,13 @@ describe('deleteMovie', () => {
 
     const events = await captureErrorEvents(async () => {
       await expect(
-        deleteMovie({ database, bucket, userId: USER_ID, shortId: SHORT_ID })
+        deleteMovie({
+          database,
+          bucket,
+          cachePurge: cachePurge(),
+          userId: USER_ID,
+          shortId: SHORT_ID,
+        })
       ).rejects.toThrow('D1 unavailable');
     });
 
@@ -83,11 +118,72 @@ describe('deleteMovie', () => {
     const bucket = new FakeMovieBucket();
 
     const events = await captureErrorEvents(async () => {
-      await deleteMovie({ database, bucket, userId: USER_ID, shortId: SHORT_ID });
+      await deleteMovie({
+        database,
+        bucket,
+        cachePurge: cachePurge(),
+        userId: USER_ID,
+        shortId: SHORT_ID,
+      });
     });
 
     expect(events).toEqual([]);
     expect(database.deletedRows).toBe(1);
     expect(bucket.deletedKeys).toEqual([MOVIE_KEY]);
+  });
+
+  it('公開 URL のキャッシュ purge を 1 回投げる', async () => {
+    const database = new FakeMoviesDatabase();
+    const bucket = new FakeMovieBucket();
+    const batches: string[][] = [];
+
+    await deleteMovie({
+      database,
+      bucket,
+      cachePurge: cachePurge((_url, init) => {
+        batches.push((JSON.parse(String(init?.body)) as { files: string[] }).files);
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }),
+      userId: USER_ID,
+      shortId: SHORT_ID,
+    });
+
+    expect(batches).toEqual([[`${PUBLIC_BASE_URL}/${MOVIE_KEY}`]]);
+  });
+
+  it('purge が例外を投げても削除は成功する（DELETE は 204 を返す）', async () => {
+    const database = new FakeMoviesDatabase();
+    const bucket = new FakeMovieBucket();
+
+    await captureWarnLogs(async () => {
+      await deleteMovie({
+        database,
+        bucket,
+        cachePurge: cachePurge(() => Promise.reject(new Error('purge unreachable'))),
+        userId: USER_ID,
+        shortId: SHORT_ID,
+      });
+    });
+
+    expect(bucket.deletedKeys).toEqual([MOVIE_KEY]);
+    expect(database.deletedRows).toBe(1);
+  });
+
+  it('purge が非 2xx を返しても削除は成功する', async () => {
+    const database = new FakeMoviesDatabase();
+    const bucket = new FakeMovieBucket();
+
+    const logs = await captureWarnLogs(async () => {
+      await deleteMovie({
+        database,
+        bucket,
+        cachePurge: cachePurge(() => Promise.resolve(new Response('nope', { status: 403 }))),
+        userId: USER_ID,
+        shortId: SHORT_ID,
+      });
+    });
+
+    expect(database.deletedRows).toBe(1);
+    expect(JSON.parse(logs[0]!).event).toBe('cache_purge_failed');
   });
 });

--- a/web/tests/services/movies-delete.test.ts
+++ b/web/tests/services/movies-delete.test.ts
@@ -184,6 +184,10 @@ describe('deleteMovie', () => {
     });
 
     expect(database.deletedRows).toBe(1);
-    expect(JSON.parse(logs[0]!).event).toBe('cache_purge_failed');
+    // infra の失敗に続けて、削除経路として気づける 1 行も残す。
+    expect(logs.map((line) => JSON.parse(line).event)).toEqual([
+      'cache_purge_failed',
+      'movie_delete_cache_purge_failed',
+    ]);
   });
 });

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -8,6 +8,7 @@ import {
   PINNED_RETENTION_MS,
   UNPIN_GRACE_MS,
 } from '../../src/lib/services/quota';
+import type { CachePurgeSettings } from '../../src/lib/services/cache-purge';
 import {
   deleteMovie,
   findPublicMovie,
@@ -519,12 +520,21 @@ describe('renameMovie', () => {
   });
 });
 
+/** キャッシュ purge の設定。ここでは purge の挙動を見ないので送信だけ止める。 */
+const CACHE_PURGE: CachePurgeSettings = {
+  publicBaseUrl: 'https://cdn.example',
+  zoneId: '2210192b51f9f0eb6761d70341ca09b0',
+  apiToken: 'test-token',
+  source: 'test-worker',
+  fetcher: () => Promise.resolve(new Response(null, { status: 200 })),
+};
+
 describe('deleteMovie', () => {
   it('R2 の実体を消してから D1 の行を消す', async () => {
     const database = new FakeMoviesDatabase([movie()]);
     const bucket = new FakeMovieBucket();
 
-    await deleteMovie({ database, bucket, userId: USER_ID, shortId: SHORT_ID });
+    await deleteMovie({ database, bucket, cachePurge: CACHE_PURGE, userId: USER_ID, shortId: SHORT_ID });
 
     expect(bucket.deletedKeys).toEqual([`movies/${SHORT_ID}.mp4`]);
     expect(database.movies.has(SHORT_ID)).toBe(false);
@@ -535,7 +545,7 @@ describe('deleteMovie', () => {
     const bucket = new FakeMovieBucket();
 
     await expect(
-      deleteMovie({ database, bucket, userId: USER_ID, shortId: SHORT_ID })
+      deleteMovie({ database, bucket, cachePurge: CACHE_PURGE, userId: USER_ID, shortId: SHORT_ID })
     ).rejects.toMatchObject({ status: 404 });
     expect(bucket.deletedKeys).toEqual([]);
     expect(database.movies.has(SHORT_ID)).toBe(true);
@@ -546,7 +556,7 @@ describe('deleteMovie', () => {
     const bucket = new FakeMovieBucket();
 
     await expect(
-      deleteMovie({ database, bucket, userId: USER_ID, shortId: '../../etc/passwd' })
+      deleteMovie({ database, bucket, cachePurge: CACHE_PURGE, userId: USER_ID, shortId: '../../etc/passwd' })
     ).rejects.toMatchObject({ status: 404 });
     expect(bucket.deletedKeys).toEqual([]);
   });

--- a/web/tests/services/retention-purge.test.ts
+++ b/web/tests/services/retention-purge.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test';
+
+import { movieUrl } from '../../src/lib/contracts/r2key';
+import { MAX_URLS_PER_PURGE } from '../../src/lib/infra/cloudflare-purge';
+import { MAX_FAILED_DELETIONS_PER_RUN } from '../../src/lib/services/retention';
+import {
+  DAY_MS,
+  FakeCachePurgeApi,
+  FakeRetentionBucket,
+  FakeRetentionDatabase,
+  HOUR_MS,
+  iso,
+  movie,
+  PUBLIC_BASE_URL,
+  run,
+} from './helpers/retention-fakes';
+
+/** purge に載った URL を、経路をまたいで 1 本の配列にする。 */
+function purgedUrls(api: FakeCachePurgeApi): string[] {
+  return api.batches.flat();
+}
+
+describe('runRetention: キャッシュ purge', () => {
+  it('期限切れで消した動画の公開 URL を purge する', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'expiredAAAAA', expiresAt: iso(-HOUR_MS) }),
+    ]);
+    const api = new FakeCachePurgeApi();
+
+    const summary = await run(database, new FakeRetentionBucket(), api);
+
+    expect(summary.deletedMovies).toBe(1);
+    expect(purgedUrls(api)).toEqual([movieUrl(PUBLIC_BASE_URL, 'expiredAAAAA')]);
+    expect(summary.cachePurgeFailures).toBe(0);
+  });
+
+  it('孤児と failed の掃除で消した動画も purge する', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'orphanAAAAAA', status: 'pending', createdAt: iso(-2 * DAY_MS) }),
+      movie({ shortId: 'failedAAAAAA', status: 'failed', createdAt: iso(-2 * DAY_MS) }),
+    ]);
+    const api = new FakeCachePurgeApi();
+
+    const summary = await run(database, new FakeRetentionBucket(), api);
+
+    expect(summary.deletedOrphans).toBe(1);
+    expect(summary.deletedFailed).toBe(1);
+    expect(purgedUrls(api).sort()).toEqual(
+      [
+        movieUrl(PUBLIC_BASE_URL, 'orphanAAAAAA'),
+        movieUrl(PUBLIC_BASE_URL, 'failedAAAAAA'),
+      ].sort()
+    );
+  });
+
+  it('30 件を超える掃除は 30 件ずつに分けて purge する', async () => {
+    const count = MAX_URLS_PER_PURGE + 1;
+    const database = new FakeRetentionDatabase(
+      Array.from({ length: count }, (_unused, index) =>
+        movie({
+          shortId: `failed${String(index).padStart(6, '0')}`,
+          status: 'failed',
+          createdAt: iso(-2 * DAY_MS),
+        })
+      )
+    );
+    const api = new FakeCachePurgeApi();
+
+    const summary = await run(database, new FakeRetentionBucket(), api);
+
+    expect(summary.deletedFailed).toBe(count);
+    expect(api.batches.map((batch) => batch.length)).toEqual([MAX_URLS_PER_PURGE, 1]);
+    expect(summary.cachePurgeRequests).toBe(2);
+    expect(purgedUrls(api)).toHaveLength(count);
+    expect(count).toBeLessThan(MAX_FAILED_DELETIONS_PER_RUN);
+  });
+
+  it('purge が失敗しても掃除は続き、失敗の件数だけ残る', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'expiredAAAAA', expiresAt: iso(-HOUR_MS) }),
+      movie({ shortId: 'failedAAAAAA', status: 'failed', createdAt: iso(-2 * DAY_MS) }),
+    ]);
+    const api = new FakeCachePurgeApi(500);
+    const original = console.warn;
+    console.warn = () => {};
+
+    try {
+      const summary = await run(database, new FakeRetentionBucket(), api);
+
+      // 削除は完走する（キャッシュは最大 120 分で自然に切れる）。
+      expect(summary.deletedMovies).toBe(1);
+      expect(summary.deletedFailed).toBe(1);
+      expect(database.movies.size).toBe(0);
+      expect(summary.cachePurgeFailures).toBe(2);
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  it('R2 の削除に失敗した動画は purge しない（実体が残っているため）', async () => {
+    const database = new FakeRetentionDatabase([
+      movie({ shortId: 'expiredAAAAA', expiresAt: iso(-HOUR_MS) }),
+    ]);
+    const bucket = new FakeRetentionBucket();
+    bucket.failingKeys.add('movies/expiredAAAAA.mp4');
+    const api = new FakeCachePurgeApi();
+
+    const summary = await run(database, bucket, api);
+
+    expect(summary.deferredObjectDeletions).toBe(1);
+    expect(api.batches).toEqual([]);
+  });
+});

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -145,6 +145,9 @@ describe('runRetention: サマリ', () => {
       deferredObjectDeletions: 0,
       skippedRows: 0,
       sweepCapped: false,
+      // 期限切れ・孤児・failed の 3 経路がそれぞれ 1 回ずつ purge を投げる。
+      cachePurgeRequests: 3,
+      cachePurgeFailures: 0,
       deletedCaptures: 1,
       checkedReadyRows: 0,
       missingObjectRows: 0,

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -25,9 +25,15 @@
     // 既存の r2.dev URL は共有済みリンクを壊さないため公開したまま並走させている。
     //
     // 注意: mp4 は Cloudflare の既定キャッシュ対象で、200/206 の Edge TTL は 120 分。
-    // R2 から削除してもキャッシュ済みのオブジェクトはその間配信され続ける（削除時の
-    // purge は未実装。詳細と対処は docs/r2-delivery.md）。
+    // 削除時は公開 URL を purge しているが、purge に失敗した分はその間配信され続ける
+    // （詳細は docs/r2-delivery.md）。cron/wrangler.jsonc の同名 var と同じ値にすること
+    // （バッチ側も同じ URL を組み立てて purge するため、ずれると purge が効かない）。
     "R2_PUBLIC_BASE_URL": "https://cdn.web-screen.net",
+    // 削除時のキャッシュ purge を投げる先のゾーン（web-screen.net）。ゾーン ID は
+    // 公開情報なのでここに置く。対になる API token は secret（CLOUDFLARE_PURGE_TOKEN）:
+    //   bunx wrangler secret put CLOUDFLARE_PURGE_TOKEN
+    // どちらかが欠けると purge せず warn だけ出す（削除自体は成功する）。
+    "CLOUDFLARE_ZONE_ID": "2210192b51f9f0eb6761d70341ca09b0",
     "WEBCAPTURE_URL": "https://web-capture-345811595113.asia-northeast1.run.app"
   },
   "d1_databases": [


### PR DESCRIPTION
## なぜこの変更が必要か

動画を削除しても Cloudflare のキャッシュ（mp4 の Edge TTL 120 分）から配信され続け、「削除したのに他人が見られる」状態になっていた（Issue #52。Custom Domain 化で新たに生じた挙動）。

## 変更内容

- `infra/cloudflare-purge.ts`: `POST /zones/{zone_id}/purge_cache` に `files`（30 URL ずつ）を投げる。トークンは secret `CLOUDFLARE_PURGE_TOKEN`（両 Worker に投入済み）、ゾーン ID は `wrangler.jsonc` の vars（32 桁 hex を検証）。5 秒タイムアウト。2xx でも本文 `success: false` は失敗
- `services/cache-purge.ts`: 動画削除（`deleteMovie`）と保持期間バッチの各削除経路（期限切れ / pending 孤児 / failed 掃除）で、**R2 の実体を消せた shortId だけ** purge。**purge の失敗で削除は失敗させない**（warn のみ）。トークン未設定は skip + warn
- `RetentionSummary` に `cachePurgeRequests` / `cachePurgeFailures`。cron の subrequest 合計は 811 < 1000
- `contracts/r2key.ts` に `movieUrl()` を追加し、表示側（`movies.ts` / `uploads.ts`）と purge 側で共有（完全一致でないと purge が効かないため正本を 1 つに）
- `docs/r2-delivery.md` の「削除とキャッシュの既知の穴」を実装後の挙動に更新（captures の掃除は purge しない: 変換後に参照されないため）

## 意思決定

### 採用アプローチ
- 恒久対応（purge 実装）。Cache Rule で TTL を縮める暫定案は不採用（ユーザー選択 2026-08-30）
- purge は各削除経路の直後（末尾集約だと後続 phase が落ちた時に先行分が purge されない）
- ログは `worker-log.ts` ではなく purge 側のローカル logger（`logWorkerFailure` はクライアントへ返す失敗の契約で status 必須。cron から呼ぶと source も嘘になる）。出力形状は揃えてある

### 意図的に残した挙動
- DELETE は purge を同期で待つ（最悪 +5 秒）。`waitUntil` に逃がすと「D1 削除の前に purge」の設計意図と衝突する

## テスト

- [x] `cd web && bun run typecheck`
- [x] `bun test` 581 pass / 0 fail（purge 失敗時も `deleteMovie` が resolve、30 件バッチの境界、トークン未設定の skip、`success: false` の失敗計上、経路ごとの purge 件数）
- [x] E2E の削除系 3 本 pass（実 Worker で `cache_purge_skipped` warn を確認）
- [x] `check-architecture.py` 新規違反ゼロ

本番の purge 権限の実証（実オブジェクトで削除 → cdn が即 404）はマージ後に行う。

## レビューゲート

Opus `code-reviewer` + `security-checker`（codex がハングしたためフォールバック）。ブロッキングなし。改善 7 件を反映（詳細は対応表コメント）。

Refs #52

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
