### PR TITLE
docs: /api/me/ の consumer に Chrome 拡張を明記

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -22,7 +22,7 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `GET /api/auth/login/` | Discord OAuth 開始（state Cookie を発行してリダイレクト） | 不要 | `session.ts` |
 | `GET /api/auth/callback/` | OAuth コールバック（state 検証 → users upsert → セッション Cookie 発行） | 不要 | `session.ts` |
 | `POST /api/auth/logout/` | セッション Cookie の破棄（form の `lang` のトップへ 303 リダイレクト。不正・欠落は `ja`） | 本人 | — |
-| `GET /api/me/` | ログイン中のユーザー情報 | 本人 | — |
+| `GET /api/me/` | ログイン中のユーザー情報 | 本人 | 未ログインは 401。応答の `name` は表示用。**Chrome 拡張（web-screen-extension）が host_permissions 経由の Cookie 付き fetch でログイン判定と表示名に使う**ため、401 の意味と `name` の形を変える時は拡張側も追随が要る |
 | `POST /api/uploads/presign/` | R2 へのアップロード先を払い出し、movies に `pending` 行を作る | 本人 | `PresignRequest` / `PresignResponse` |
 | `POST /api/uploads/commit/` | アップロード完了を確定し `ready` にする | 本人（当該 movie の所有者） | `CommitRequest` / `CommitResponse` |
 | `GET /api/history/` | 自分の動画一覧 | 本人 | `HistoryResponse` |


### PR DESCRIPTION
## なぜこの変更が必要か

web-screen-extension v3.0.1 が `GET /api/me/` を「未ログイン = 401」「`name` = 表示名」として消費するようになった（noricha-vr/web-screen-extension の feat/guest-login-guidance）。別リポの consumer が増えたのに契約表に記載が無いと、producer 側の変更時に壊れても気づけない。

## 変更内容

- `docs/api-contracts.md` の `GET /api/me/` 行に consumer と依存内容を 1 行追記

ドキュメントのみの変更のためレビューゲートは省略。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
