### PR TITLE
fix: pin テストの時限爆弾を除去して main の CI を回復する

### DIFF
--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -309,7 +309,7 @@ describe('togglePin', () => {
     const database = new FakeMoviesDatabase([...pinnedMovies(MAX_PINNED_MOVIES), movie()]);
 
     await expect(
-      togglePin({ database, userId: USER_ID, shortId: SHORT_ID })
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date('2026-08-30T00:00:00.000Z') })
     ).rejects.toMatchObject({ status: 409 });
     expect(database.movies.get(SHORT_ID)?.pinned).toBe(0);
   });
@@ -473,7 +473,7 @@ describe('togglePin', () => {
     const database = new FakeMoviesDatabase([...pinnedMovies(MAX_PINNED_MOVIES - 1), movie()]);
 
     await expect(
-      togglePin({ database, userId: USER_ID, shortId: SHORT_ID })
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date('2026-08-30T00:00:00.000Z') })
     ).resolves.toMatchObject({ pinned: true });
   });
 
@@ -489,7 +489,7 @@ describe('togglePin', () => {
     const database = new FakeMoviesDatabase([movie({ userId: USER_ID + 1 })]);
 
     await expect(
-      togglePin({ database, userId: USER_ID, shortId: SHORT_ID })
+      togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date('2026-08-30T00:00:00.000Z') })
     ).rejects.toMatchObject({ status: 404 });
     expect(database.movies.get(SHORT_ID)?.pinned).toBe(0);
   });

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -188,7 +188,9 @@ function movie(overrides: Partial<TestMovie> = {}): TestMovie {
     status: 'ready',
     pinned: 0,
     createdAt: CREATED_AT,
-    expiresAt: '2026-08-31T00:00:00.000Z',
+    // 実時刻がこの日付を跨ぐとテストが突然落ちる（実例: 2026-08-31 に now 省略の 2 件が期限切れ 410 化）。
+    // 既定は「期限に関係しないテスト」用なので遠い未来に固定し、期限を試すテストは自分で上書きする。
+    expiresAt: '2099-01-01T00:00:00.000Z',
     ...overrides,
   };
 }


### PR DESCRIPTION
## なぜこの変更が必要か

2026-08-31 の日付変化で main の CI（ユニットテスト）が落ち始め、デプロイが止まった（#120 のデプロイが未反映）。原因はテストフィクスチャの時限爆弾: `movie()` の既定 `expiresAt` が `2026-08-31T00:00:00Z` 固定で、`now` を省略する togglePin の 2 テストだけが実時刻で期限判定されるため、実時刻がこの日付を跨いだ瞬間に「期限切れ 410」へ化けた（最後の green は 8/30 19:33 UTC）。

## 変更内容

- `movie()` の既定 `expiresAt` を遠い未来（2099-01-01）に変更（期限を検証するテストはすべて自前の日付を持つことをレビューで確認済み）
- `now` を省略していた togglePin 呼び出し 3 箇所に固定時刻を明示（実時刻依存を完全除去）

## テスト

- [x] `bun test` 600 pass / 0 fail（落ちていた 2 件が回復）
- [x] typecheck パス
- [x] レビューゲート: codex gpt-5.6-sol high 2 レーン。追加ブロッキング 1 件（2099 への変更は延期にすぎない → now 明示で対応）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
