### PR TITLE
docs(streaming): Quest は PC と同一 rtspt URL で再生可、HLS は保留

### DIFF
--- a/docs/streaming/requirements.md
+++ b/docs/streaming/requirements.md
@@ -27,15 +27,17 @@ Issue #93 で決定・凍結した。
 
 | 経路 | URL 形式 |
 |---|---|
-| PC（RTSP） | `rtspt://stream.web-screen.net/live/{id}`（**ポート省略**。2026-09-01 に VRChat 実機で確認 = I11） |
-| Quest（HLS） | `https://cdn.web-screen.net/live/{id}/index.m3u8` |
+| **PC / Quest 共通（RTSP）** | `rtspt://stream.web-screen.net/live/{id}`（**ポート省略**。PC = I11、Quest = I12 で実機確認） |
+| Quest（HLS・**保留**） | `https://cdn.web-screen.net/live/{id}/index.m3u8`（Quest が rtspt を直接再生できたため実装しない。rtspt が使えなくなった時のフォールバック設計として残す） |
 
 - `{id}` は**推測困難な 12 文字のランダム ID**（既存の動画 shortId と同じ文字種・長さ）。
   **ハイフンを含めない**（VRChat 側でハイフン以降が切り詰められる = I10）
 - RTSP は**既定ポート 554 でリッスンする**（`rtspAddress: :554`）。VRChat がポート省略の URL を受けるため、
   URL から `:8554` を落とせる（I11）。1024 未満のバインドには root か `CAP_NET_BIND_SERVICE` が要るので、
   systemd ユニットに `AmbientCapabilities=CAP_NET_BIND_SERVICE` を入れる（#126）
-- Quest 向け HLS は新ホストを作らず **既存の `cdn.web-screen.net` に相乗り**する（HLS セグメントを R2 経由で配る設計と一致し、
+- **Quest も PC と同一の rtspt URL を案内する**（I12）。音声も AAC で鳴る。体感遅延は 2〜3 秒（PC の 0.08 秒より大きいが十分低遅延）。
+  **`rtmp://` は案内しない**: Quest のプレイヤーは rtmp スキームでも RTSP を話すため、スキームを検査する MediaMTX が弾く（I12）
+- Quest 向け HLS を実装する場合は新ホストを作らず **既存の `cdn.web-screen.net` に相乗り**する（HLS セグメントを R2 経由で配る設計と一致し、
   ワールド作者の allowlist 消費が新規 1 枠 = `stream.web-screen.net` だけで済む）
 - **サブドメインを今後増やさない**（ワイルドカード非対応のため、増やすたびに全ワールドの再登録が要る）
 - 複数台へスケールする時は L4 ロードバランサか DNS の複数 A レコードで**同一ホスト名のまま**振り分ける

--- a/docs/streaming/verification.md
+++ b/docs/streaming/verification.md
@@ -239,6 +239,29 @@ RTSP の既定ポート 554 が補われている。
   allowlist 登録済みワールドへの影響はない（VRChat の Allowed Domains はホスト名だけを見る）
 - 効果: `rtspt://stream.web-screen.net/live/{id}` となり、TopazChat（`rtspt://topaz.chat/live/{key}`）と同程度の長さになる
 
+### I12: Quest は PC と同一の rtspt URL で再生できる。HLS は不要（Quest 実機・2026-09-01）
+
+Meta Quest 単体の VRChat で `rtspt://stream.web-screen.net/live/qtest`（本番形そのもの。ホスト名 + ポート省略 554）を
+貼って再生できた。**PC と Quest で URL を分ける必要がなく、Quest 向け HLS 配信も不要**。
+
+| 確認 | 結果 |
+|---|---|
+| 映像 | 再生 OK（RTSP over TCP。サーバーログに `with TCP, 2 tracks (H264, MPEG-4 Audio)`） |
+| 音声 | **AAC が Quest で鳴る**（R3 の実機裏取り） |
+| 体感遅延 | **2〜3 秒**（PC の Use Low Latency ON = 0.08 秒より大きい。ExoPlayer 側のバッファ） |
+| 安定性 | 80 秒前後のセッションを複数回、切断なし |
+| `rtsp://`（8554 明示） | 再生 OK |
+
+- **`rtmp://` は使えない**: Quest のプレイヤーは rtmp スキームの URL でも RTSP プロトコルで接続し、
+  リクエスト URI のスキームを rtmp のまま送る。MediaMTX はスキーム検査で
+  `invalid URL (rtmp://...)` として弾く（3 回再現）。TopazChat が「Quest は rtmp://」と案内して
+  動くのは、同社サーバーがスキームを検査しないためと推測される。**WebScreen は rtmp を案内しない**
+- 「2026-07 の VRChat アップデートで Quest の rtsp:// が動かなくなった」という TopazChat 開発者の報告
+  （[X 2026-07-03](https://x.com/TyounanMOTI/status/2073100093818044578)）は、**本構成（MediaMTX v1.20.1 +
+  rtspt/rtsp・TCP）では再現しなかった**
+- HLS（`https://stream.web-screen.net/live/{id}/index.m3u8`・Caddy TLS 終端）はサーバー側の生成・配信まで
+  確認済みだが、Quest 実機での再生は rtspt が通ったため**未検証のまま打ち切り**（必要になったら再開する）
+
 ### I5: 動画素材の画面共有は 600 kbps では成立しない（VRChat 実機・2026-08-31）
 
 VRChat PC 実機（ProTV）で `getDisplayMedia` の実画面（YouTube 再生中のタブ・1916x1060）を配信して観測した。


### PR DESCRIPTION
## なぜこの変更が必要か

ゲート #4 の最後の技術検証だった Quest 対応（#96）の結論を正本に反映する。当初設計は「Quest は HLS（約 6 秒遅延・TLS + R2 パイプラインの実装が必要）」だったが、実機検証で前提が変わった。

## 変更内容

- `verification.md` に I12 を追加: Quest は **PC と同一の `rtspt://stream.web-screen.net/live/{id}`** で再生できる（映像・AAC 音声・遅延 2〜3 秒・RTSP over TCP）
- `requirements.md` の URL 表を「PC / Quest 共通（RTSP）」に統合し、HLS 行を**保留**に変更（実装しない。rtspt が使えなくなった時のフォールバック設計として温存）
- `rtmp://` を案内しない理由を記録（Quest のプレイヤーは rtmp スキームでも RTSP を話し、MediaMTX がスキーム検査で弾く）

## 意思決定

### 採用アプローチ
- Quest も rtspt 単一 URL。URL を分けない・HLS を作らない（実装コストゼロ・低遅延・allowlist 1 枠のまま）

### 却下した代替案
- RTMP を Quest 経路にする（TopazChat 方式）→ 却下: 実機で 3 回再現した失敗ログのとおり、MediaMTX では構造的に受けられない
- HLS を予定どおり実装 → 保留: rtspt が動く以上、TLS + R2 パイプラインの実装コストに見合う価値がない

## テスト

- [x] Quest 実機（VRChat スタンドアロン）で本番形 URL の再生・音声・遅延を確認
- [x] サーバーログに RTSP over TCP の読み取りセッション（H264 + MPEG-4 Audio）を複数回記録
- ドキュメントのみの変更のため自動テスト対象外

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
