### PR TITLE
fix: 署名 URL の再利用経路を塞ぎ presign にレートリミットを追加する（#137/#138）

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -23,8 +23,8 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `GET /api/auth/callback/` | OAuth コールバック（state 検証 → users upsert → セッション Cookie 発行） | 不要 | `session.ts` |
 | `POST /api/auth/logout/` | セッション Cookie の破棄（form の `lang` のトップへ 303 リダイレクト。不正・欠落は `ja`） | 本人 | — |
 | `GET /api/me/` | ログイン中のユーザー情報 | 本人 | 未ログインは 401。応答の `name` は表示用。**Chrome 拡張（web-screen-extension）が host_permissions 経由の Cookie 付き fetch でログイン判定と表示名に使う**ため、401 の意味と `name` の形を変える時は拡張側も追随が要る |
-| `POST /api/uploads/presign/` | R2 へのアップロード先を払い出し、movies に `pending` 行を原子的に容量予約して作る | 本人 | `PresignRequest` / `PresignResponse`。予約後の合計が容量上限を超える場合は 413 `PAYLOAD_TOO_LARGE`、同時 pending が 10 件なら 429 `TOO_MANY_PENDING_UPLOADS` |
-| `POST /api/uploads/commit/` | R2 の実測サイズで容量を原子的に再判定し、アップロード完了を `ready` にする | 本人（当該 movie の所有者） | `CommitRequest` / `CommitResponse`。実測サイズで容量上限を超える場合は 413 `PAYLOAD_TOO_LARGE` |
+| `POST /api/uploads/presign/` | R2 の一時キー `tmp/{shortId}` へのアップロード先を払い出し、movies に `pending` 行を原子的に容量予約して作る | 本人 | `PresignRequest` / `PresignResponse`。`publicUrl` は commit 後の `movies/{shortId}.mp4` を指す。予約後の合計が容量上限を超える場合は 413 `PAYLOAD_TOO_LARGE`、同時 pending が 10 件なら 429 `TOO_MANY_PENDING_UPLOADS`。1 ユーザー 10 回 / 60 秒を超える署名発行は 429 `TOO_MANY_PRESIGN_REQUESTS`（`Retry-After: 60`） |
+| `POST /api/uploads/commit/` | 一時実体の実測サイズで容量を原子的に再判定し、R2 内で公開キーが未作成の場合だけ stream コピーして `ready` にする | 本人（当該 movie の所有者） | `CommitRequest` / `CommitResponse`。並行 commit は最初の公開 object の実測サイズを採用する。実測サイズで容量上限を超える場合は 413 `PAYLOAD_TOO_LARGE`。ready 化後は一時キーを削除する |
 | `POST /api/uploads/abandon/` | 所有する `pending` アップロードを `failed` にし、署名 URL 失効後の保持期間バッチへ回収を委ねる | 本人（当該 movie の所有者） | `AbandonUploadRequest`。JSON 本文は 4 KiB 上限（超過は 413 `PAYLOAD_TOO_LARGE`）。対象が `pending` 以外・不存在・他人所有でも状態を漏らさず 204 |
 | `GET /api/history/` | 自分の動画一覧 | 本人 | `HistoryResponse` |
 | `POST /api/movies/{shortId}/pin/` | pin の切り替え（保管期限を 1 年後まで延ばす。期限切れは 410 `EXPIRED`） | 本人（所有者） | `PinResponse` |

--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -30,7 +30,11 @@ WebScreen では VRChat のワールド内で複数人が同時に同じ動画�
 
 ### CORS（アップロード経路）
 
-アップロードはブラウザから **R2 の S3 エンドポイントへ直接 PUT** する（`web/src/lib/infra/r2presign.ts` が署名 URL を払い出す）。配信ドメインではなく `https://{accountId}.r2.cloudflarestorage.com` が相手なので、**サイトのオリジンを R2 のバケット CORS に登録しないと preflight が 403 になり変換できない**。
+アップロードはブラウザから **R2 の S3 エンドポイントへ直接 PUT** する（`web/src/lib/infra/r2presign.ts` が `tmp/{shortId}` への署名 URL を払い出す）。配信ドメインではなく `https://{accountId}.r2.cloudflarestorage.com` が相手なので、**サイトのオリジンを R2 のバケット CORS に登録しないと preflight が 403 になり変換できない**。
+
+署名先と配信先は分離する。ブラウザが書けるのは公開 URL に採用しない `tmp/{shortId}` だけで、commit は同じ R2 binding から一時実体を `get()` し、実測サイズを検証してから body stream を `movies/{shortId}.mp4` へ条件付き `put()`（`etagDoesNotMatch: '*'`）する。並行 commit で条件が成立しなければ既存公開 object の実測サイズを D1 確定値に使い、最初の公開コピーを上書きしない。ready 化後は `tmp/` を削除する。50 MiB の実体を Worker メモリへバッファ化しない。
+
+この分離により、5 分間の署名 URL が再利用されても書き換わるのは `tmp/` だけで、commit 済みの `movies/` は上書きされない。ready DELETE 後に同じ署名 URL を再利用しても公開キーは復活しない。なお同一バケットの Custom Domain は prefix 単位の読取 ACL ではないため、「公開 URL に採用しない」は `tmp/` の読取拒否を意味しない。読取自体も遮断する場合は、別の private bucket または配信 Worker で `tmp/` を拒否する設計が別途必要になる。
 
 設定の正本は `web/r2-cors.json`。反映はこのコマンド:
 
@@ -49,15 +53,32 @@ bunx wrangler r2 bucket cors list webscreen-beta   # 確認
 
 PUT の署名 URL は 5 分有効。ブラウザから `Content-Length` を固定できず、R2 が署名した長さを
 実体サイズの上限として検証する保証もないため、申告サイズだけで PUT 自体を制限しない。
-署名失効 + 60 秒後も `pending` の行は `failed` へ移し、保持期間バッチが R2 を毎時反復削除する。
+署名失効 + 60 秒後も `pending` の行は `failed` へ移し、保持期間バッチが `tmp/{shortId}` と、旧実装が直接署名していた `movies/{shortId}.mp4` の両方を毎時反復削除する。
 `failed` 行は 24 時間残すので、失効直前に開始した PUT が最初の削除後に完了しても次回に回収できる。
 バッチは既存の 24 時間超 `failed` 行を削除してから `pending` を `failed` へ移し、その実体を
 同じ実行の failed object sweep で R2 から削除する。24 時間超の backlog も D1 行はその場で消さず、
 最低 1 サイクル追跡してから次回以降の failed 行削除へ渡す。
 
+### presign のレート制限
+
+`POST /api/uploads/presign/` は Workers Rate Limiting binding `PRESIGN_LIMITER` で、認証済みユーザーごとに 10 回 / 60 秒へ制限する。`web/wrangler.jsonc` の namespace `1002` が正本で、pending 10 件上限とは別に、短時間の署名発行と一時オブジェクト作成によるコストを抑える。
+
+この binding のカウンタは Cloudflare のロケーション（PoP）単位で、更新は eventual consistency のため厳密な全世界共通上限ではない。アプリ側の pending 件数・容量検査は引き続き必須であり、この制限だけをクォータ境界には使わない。
+
+### tmp/ の Lifecycle 安全網
+
+アプリの commit・abandon・保持期間バッチが `tmp/` の主掃除主体で、R2 Lifecycle は D1 行が消えた後の遅延 PUT や継続的な R2 障害に対する最終安全網にする。Cloudflare ダッシュボードで次のルールを設定する。
+
+1. R2 Object Storage から対象バケット `webscreen-beta` を開く。
+2. Settings → Object lifecycle rules → Add rule を選ぶ。
+3. prefix を `tmp/`、action を object expiration、期間を 1 day にする。
+4. 保存後、ルールが Enabled で prefix が `tmp/` に限定されていることを確認する。
+
+推奨 TTL は 1 日。署名 TTL 5 分と時計差の猶予 60 秒を十分に越え、進行中 PUT を早期削除せず、それでも追跡不能な一時実体の課金期間を 24 時間程度に抑えられる。`movies/` や `captures/` を同じルールへ含めると公開動画・変換中画像を失うため、prefix なしのルールは禁止する。
+
 ## captures/ の掃除主体
 
-`captures/{uuid}/{index}.{png|jpg}`（web-capture が置く動画化の中間物。拡張子は web-capture の設定で決まる。撮影を速くするため JPEG へ移行中で、掃除も取り込みも拡張子を見ないので混在しても問題ない）を消すのは **WebScreen の cron だけ**（`web/cron/` の Worker が `web/src/lib/services/retention-captures.ts` を毎時 17 分に実行し、アップロードから 24 時間経過したものを 1 回あたり最大 1000 件・list 10 ページまで削除する。残りは次の実行が拾う）。**R2 の lifecycle rule は使っていない**（作成もしていない）。掃除を別の場所へ移す時は、この節と `retention-captures.ts` の両方を同時に直すこと。
+`captures/{uuid}/{index}.{png|jpg}`（web-capture が置く動画化の中間物。拡張子は web-capture の設定で決まる。撮影を速くするため JPEG へ移行中で、掃除も取り込みも拡張子を見ないので混在しても問題ない）を消すのは **WebScreen の cron だけ**（`web/cron/` の Worker が `web/src/lib/services/retention-captures.ts` を毎時 17 分に実行し、アップロードから 24 時間経過したものを 1 回あたり最大 1000 件・list 10 ページまで削除する。残りは次の実行が拾う）。`tmp/` 専用ルールと違い、**`captures/` に R2 Lifecycle rule は使わない**。掃除を別の場所へ移す時は、この節と `retention-captures.ts` の両方を同時に直すこと。
 
 掃除対象バケット名の正本は **`web/cron/wrangler.jsonc` の `r2_buckets`**（現在 `webscreen-beta`）。web-capture 側の書き込み先（Cloud Run の環境変数 `R2_BUCKET`）が**これと一致していることが契約**で、ずれると中間のキャプチャ画像は誰にも消されず増え続ける（気づけるのは請求だけ）。2026-08-30 に `gcloud run services describe web-capture` で一致を確認済み。どちらかを変える時は両方同時に変える。
 

--- a/web/src/lib/contracts/api.ts
+++ b/web/src/lib/contracts/api.ts
@@ -64,6 +64,7 @@ export const ERROR_CODES = {
   expired: 'EXPIRED',
   payloadTooLarge: 'PAYLOAD_TOO_LARGE',
   tooManyPendingUploads: 'TOO_MANY_PENDING_UPLOADS',
+  tooManyPresignRequests: 'TOO_MANY_PRESIGN_REQUESTS',
   captureFailed: 'CAPTURE_FAILED',
   pageTooLong: 'PAGE_TOO_LONG',
   captureTimeout: 'CAPTURE_TIMEOUT',

--- a/web/src/lib/contracts/r2key.ts
+++ b/web/src/lib/contracts/r2key.ts
@@ -63,6 +63,14 @@ export function movieKey(shortId: string): string {
   return `movies/${shortId}.mp4`;
 }
 
+/** 署名 PUT が書き込む、公開配信キーと分離した一時キー。 */
+export function temporaryUploadKey(shortId: string): string {
+  if (!isShortId(shortId)) {
+    throw new Error(`temporaryUploadKey: shortId の形式が不正です (length=${shortId.length})`);
+  }
+  return `tmp/${shortId}`;
+}
+
 /**
  * 完成した mp4 の公開 URL。配信元（R2_PUBLIC_BASE_URL）とキー規則をここで結ぶ。
  *

--- a/web/src/lib/infra/r2presign.ts
+++ b/web/src/lib/infra/r2presign.ts
@@ -14,7 +14,7 @@ export const PRESIGN_TTL_MS = 5 * 60 * 1000;
 export const PRESIGN_EXPIRY_GRACE_MS = PRESIGN_TTL_MS + 60 * 1000;
 const PRESIGN_TTL_SECONDS = PRESIGN_TTL_MS / 1000;
 
-/** R2 への video/mp4 専用、5分間有効な単発 PUT 署名 URL を発行する。 */
+/** R2 への video/mp4 専用、5分間有効な PUT 署名 URL を発行する。 */
 export async function createR2PutPresignedUrl(
   config: R2PresignConfig,
   key: string

--- a/web/src/lib/infra/worker-log.ts
+++ b/web/src/lib/infra/worker-log.ts
@@ -14,6 +14,8 @@ const WORKER_FAILURE_EVENTS = [
   'upload_commit_failed',
   'upload_abandon_failed',
   'upload_commit_oversize_claim_missed',
+  'upload_tmp_cleanup_failed',
+  'upload_public_cleanup_failed',
   'movie_delete_row_stranded',
   'preview_owner_check_failed',
   'capture_request_json_invalid',
@@ -62,6 +64,28 @@ export function logWorkerFailure({
     return;
   }
   console.error(entry);
+}
+
+/** upload commit の cleanup 失敗を、安全な識別子だけで記録する。 */
+export function logUploadCleanupFailure({
+  event,
+  errorName,
+}: {
+  event: 'upload_tmp_cleanup_failed' | 'upload_public_cleanup_failed';
+  errorName?: string;
+}): void {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source: SOURCE,
+      severity: 'warn',
+      kind: 'event',
+      level: 'warn',
+      event,
+      errorName,
+      summary: `${event}; tracked cleanup or the tmp lifecycle remains available.`,
+    })
+  );
 }
 
 /**

--- a/web/src/lib/services/movies.ts
+++ b/web/src/lib/services/movies.ts
@@ -14,7 +14,7 @@ import {
   type PinResponse,
   type RenameMovieResponse,
 } from '../contracts/api';
-import { isShortId, movieKey, movieUrl } from '../contracts/r2key';
+import { isShortId, movieKey, movieUrl, temporaryUploadKey } from '../contracts/r2key';
 import { logWorkerFailure } from '../infra/worker-log';
 import {
   logMovieDeletePurgeFailure,
@@ -47,7 +47,7 @@ export interface MoviesDatabase {
 
 /** R2 の削除に必要な最小操作面。 */
 export interface MovieBucket {
-  delete(key: string): Promise<void>;
+  delete(keys: string | string[]): Promise<void>;
 }
 
 /** エントリポイントが HTTP 応答へ変換するドメインエラー。 */
@@ -293,7 +293,7 @@ export async function deleteMovie(
   // R2 を先に消せば、残るのは実体の無い ready 行で、保持期間バッチの監査
   // （services/retention-audit.ts）が拾える。自動では直せないので、その場でも
   // 気づける印としてログに残してから呼び出し元へ返す。
-  await input.bucket.delete(movieKey(input.shortId));
+  await input.bucket.delete([movieKey(input.shortId), temporaryUploadKey(input.shortId)]);
 
   // 実体を消した直後に Edge のキャッシュも落とす。ここを飛ばすと最大 120 分は
   // 削除済みの動画が配信され続ける（docs/r2-delivery.md）。D1 の行を消す前に呼ぶのは、

--- a/web/src/lib/services/presign-errors.ts
+++ b/web/src/lib/services/presign-errors.ts
@@ -1,0 +1,11 @@
+import { ERROR_CODES } from '../contracts/api';
+import { logWorkerFailure } from '../infra/worker-log';
+
+/** presign の想定外失敗を機密値なしで構造化ログへ記録する。 */
+export function logPresignInternalFailure(): void {
+  logWorkerFailure({
+    event: 'upload_presign_failed',
+    errorCode: ERROR_CODES.internalError,
+    status: 500,
+  });
+}

--- a/web/src/lib/services/presign-rate-limit.ts
+++ b/web/src/lib/services/presign-rate-limit.ts
@@ -1,0 +1,35 @@
+import { ERROR_CODES, type ErrorResponse } from '../contracts/api';
+
+/** 1 ユーザーが 1 ウィンドウ内に発行できる数。wrangler の PRESIGN_LIMITER と同期する。 */
+export const PRESIGN_RATE_LIMIT = 10;
+
+/** 固定ウィンドウ（秒）。wrangler の PRESIGN_LIMITER と同期する。 */
+export const PRESIGN_RATE_LIMIT_PERIOD_SECONDS = 60;
+
+/** Workers の Rate Limiting binding のうち presign が使う操作面。 */
+export interface PresignRateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+/** ユーザー単位の presign 上限を検査し、超過時だけ 429 応答を返す。 */
+export async function enforcePresignRateLimit(
+  limiter: PresignRateLimiter | undefined,
+  userId: number
+): Promise<Response | null> {
+  if (!limiter) throw new Error('PRESIGN_LIMITER binding is required');
+
+  const { success } = await limiter.limit({ key: String(userId) });
+  if (success) return null;
+
+  const body: ErrorResponse = {
+    errorCode: ERROR_CODES.tooManyPresignRequests,
+    message: 'アップロードURLの発行回数が上限を超えました',
+  };
+  return Response.json(body, {
+    status: 429,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Retry-After': String(PRESIGN_RATE_LIMIT_PERIOD_SECONDS),
+    },
+  });
+}

--- a/web/src/lib/services/retention-failed.ts
+++ b/web/src/lib/services/retention-failed.ts
@@ -1,6 +1,6 @@
 /** failed アップロードのR2早期回収と24時間後の行削除を扱う。 */
 
-import { movieKey } from '../contracts/r2key';
+import { movieKey, temporaryUploadKey } from '../contracts/r2key';
 import { PRESIGN_EXPIRY_GRACE_MS } from '../infra/r2presign';
 
 /** failed 行を残す期間（原因調査のための猶予）。 */
@@ -57,7 +57,7 @@ export async function deleteFailedMovies(
 
   const shortIds = results.map((row) => row.short_id);
   try {
-    await bucket.delete(shortIds.map(movieKey));
+    await bucket.delete(objectKeys(shortIds));
   } catch {
     // R2 が落ちている間に行だけ消すと実体が孤児になるため、この実行では行を残す。
     return { deleted: 0, deferred: shortIds.length, purged: [], capped };
@@ -95,7 +95,7 @@ export async function sweepFailedObjects(
   try {
     // 存在しないキーの delete も成功するため head は不要。行を残し、
     // 削除後に遅延 PUT が完了しても次回 cron で再回収する。
-    await bucket.delete(shortIds.map(movieKey));
+    await bucket.delete(objectKeys(shortIds));
   } catch {
     return { swept: 0, deferred: shortIds.length, purged: [], capped };
   }
@@ -142,4 +142,8 @@ function chunksOf(shortIds: string[]): string[][] {
     chunks.push(shortIds.slice(index, index + MAX_IDS_PER_MUTATION));
   }
   return chunks;
+}
+
+function objectKeys(shortIds: string[]): string[] {
+  return shortIds.flatMap((shortId) => [movieKey(shortId), temporaryUploadKey(shortId)]);
 }

--- a/web/src/lib/services/retention.ts
+++ b/web/src/lib/services/retention.ts
@@ -22,7 +22,7 @@
  * 失敗しても行は消えず、failed の掃除が同じ順序（R2 → D1）で回収し直せる。
  */
 
-import { movieKey } from '../contracts/r2key';
+import { movieKey, temporaryUploadKey } from '../contracts/r2key';
 import { purgeMovieCache, type CachePurgeSettings } from './cache-purge';
 import { PINNED_RETENTION_MS } from './quota';
 import { auditReadyObjects } from './retention-audit';
@@ -240,7 +240,7 @@ async function deleteExpiredMovies(
     }
 
     try {
-      await bucket.delete(movieKey(row.short_id));
+      await bucket.delete([movieKey(row.short_id), temporaryUploadKey(row.short_id)]);
     } catch {
       // R2 が落ちている間に D1 の行だけ消すと実体が孤児になるため、この行は
       // 飛ばして次回の実行に委ねる（削除は冪等なのでやり直しで問題ない）。

--- a/web/src/lib/services/upload-commit.ts
+++ b/web/src/lib/services/upload-commit.ts
@@ -1,0 +1,180 @@
+import { ERROR_CODES, MAX_UPLOAD_BYTES, type CommitResponse } from '../contracts/api';
+import { movieUrl } from '../contracts/r2key';
+import { logWorkerFailure } from '../infra/worker-log';
+import { USER_STORAGE_QUOTA_BYTES } from './quota';
+import {
+  getTemporaryUpload,
+  publishTemporaryUpload,
+  tryDeletePublishedUpload,
+  tryDeleteTemporaryUpload,
+  type UploadBucket,
+} from './upload-objects';
+import { UploadError, type UploadDatabase } from './upload-types';
+
+interface MovieRow {
+  short_id: string;
+  user_id: number;
+  size_bytes: number;
+  status: 'pending' | 'ready' | 'failed';
+  expires_at: string | null;
+}
+
+/** upload commit に必要な D1・R2 と所有者情報。 */
+export interface CommitUploadInput {
+  database: UploadDatabase;
+  bucket: UploadBucket;
+  userId: number;
+  shortId: string;
+  publicBaseUrl: string;
+}
+
+/** 一時 R2 実体を検証し、所有者の pending movie を ready に確定する。 */
+export async function commitUpload(input: CommitUploadInput): Promise<CommitResponse> {
+  const movie = await findMovie(input.database, input.userId, input.shortId);
+  if (!movie) throw new UploadError(404, ERROR_CODES.notFound, '対象の動画が見つかりません');
+
+  if (movie.status === 'ready') {
+    await tryDeleteTemporaryUpload(input.bucket, input.shortId);
+    return toCommitResponse(movie, input.publicBaseUrl);
+  }
+  if (movie.status !== 'pending') {
+    throw new UploadError(400, ERROR_CODES.invalidRequest, 'この動画は commit できません');
+  }
+  return commitPendingUpload(input, movie);
+}
+
+async function commitPendingUpload(
+  input: CommitUploadInput,
+  movie: MovieRow
+): Promise<CommitResponse> {
+  const object = await getTemporaryUpload(input.bucket, input.shortId);
+  if (!object) {
+    throw new UploadError(400, ERROR_CODES.invalidRequest, 'アップロード済みの動画が見つかりません');
+  }
+
+  if (object.size > MAX_UPLOAD_BYTES || object.size > movie.size_bytes * 2) {
+    return rejectOversizedUpload(input, object.size);
+  }
+
+  const published = await publishTemporaryUpload(input.bucket, input.shortId, object.body);
+  if (!published) throw new Error('published upload disappeared after conditional put');
+  if (published.size > MAX_UPLOAD_BYTES || published.size > movie.size_bytes * 2) {
+    return resolvePublishedConflict(input, published.size);
+  }
+  return finalizePublishedUpload(input, movie, published.size);
+}
+
+async function finalizePublishedUpload(
+  input: CommitUploadInput,
+  movie: MovieRow,
+  actualSize: number
+): Promise<CommitResponse> {
+  const updated = await input.database
+    .prepare(
+      `UPDATE movies SET status = 'ready', size_bytes = ?
+       WHERE short_id = ? AND user_id = ? AND status = 'pending'
+       AND COALESCE((
+         SELECT SUM(size_bytes) FROM movies
+         WHERE user_id = ? AND short_id <> ? AND status IN ('pending', 'ready', 'failed')
+       ), 0) + ? <= ?`
+    )
+    .bind(
+      actualSize,
+      input.shortId,
+      input.userId,
+      input.userId,
+      input.shortId,
+      actualSize,
+      USER_STORAGE_QUOTA_BYTES
+    )
+    .run();
+
+  if (updated.meta.changes === 0) return resolvePublishedConflict(input, actualSize);
+  await tryDeleteTemporaryUpload(input.bucket, input.shortId);
+  return toCommitResponse({ ...movie, size_bytes: actualSize, status: 'ready' }, input.publicBaseUrl);
+}
+
+async function resolvePublishedConflict(
+  input: CommitUploadInput,
+  actualSize: number
+): Promise<CommitResponse> {
+  let current = await findMovie(input.database, input.userId, input.shortId);
+  if (current?.status === 'pending') {
+    if (await claimOversizedUpload(input, actualSize)) {
+      await tryDeletePublishedUpload(input.bucket, input.shortId);
+      throw oversizedUploadError();
+    }
+    current = await findMovie(input.database, input.userId, input.shortId);
+  }
+
+  if (current?.status !== 'ready') {
+    await tryDeletePublishedUpload(input.bucket, input.shortId);
+  } else {
+    await tryDeleteTemporaryUpload(input.bucket, input.shortId);
+  }
+  return resolveCurrentMovie(current, input.publicBaseUrl);
+}
+
+async function rejectOversizedUpload(
+  input: CommitUploadInput,
+  actualSize: number
+): Promise<CommitResponse> {
+  if (await claimOversizedUpload(input, actualSize)) throw oversizedUploadError();
+  const current = await findMovie(input.database, input.userId, input.shortId);
+  return resolveCurrentMovie(current, input.publicBaseUrl);
+}
+
+/** 上限超過の pending を failed へ確保し、実測サイズを容量へ計上する。 */
+async function claimOversizedUpload(input: CommitUploadInput, actualSize: number): Promise<boolean> {
+  const claim = await input.database
+    .prepare(
+      "UPDATE movies SET status = 'failed', size_bytes = ? WHERE short_id = ? AND user_id = ? AND status = 'pending'"
+    )
+    .bind(actualSize, input.shortId, input.userId)
+    .run();
+  if (claim.meta.changes > 0) return true;
+
+  logWorkerFailure({
+    level: 'warn',
+    event: 'upload_commit_oversize_claim_missed',
+    errorCode: ERROR_CODES.payloadTooLarge,
+    status: 413,
+  });
+  return false;
+}
+
+function oversizedUploadError(): UploadError {
+  return new UploadError(
+    413,
+    ERROR_CODES.payloadTooLarge,
+    'アップロード済み動画が保存上限を超えています'
+  );
+}
+
+function resolveCurrentMovie(movie: MovieRow | null, publicBaseUrl: string): CommitResponse {
+  if (!movie) throw new UploadError(404, ERROR_CODES.notFound, '対象の動画が見つかりません');
+  if (movie.status === 'ready') return toCommitResponse(movie, publicBaseUrl);
+  throw new UploadError(400, ERROR_CODES.invalidRequest, 'この動画は commit できません');
+}
+
+async function findMovie(
+  database: UploadDatabase,
+  userId: number,
+  shortId: string
+): Promise<MovieRow | null> {
+  return database
+    .prepare(
+      'SELECT short_id, user_id, size_bytes, status, expires_at FROM movies WHERE short_id = ? AND user_id = ?'
+    )
+    .bind(shortId, userId)
+    .first<MovieRow>();
+}
+
+function toCommitResponse(movie: MovieRow, publicBaseUrl: string): CommitResponse {
+  return {
+    shortId: movie.short_id,
+    publicUrl: movieUrl(publicBaseUrl, movie.short_id),
+    sizeBytes: movie.size_bytes,
+    expiresAt: movie.expires_at,
+  };
+}

--- a/web/src/lib/services/upload-objects.ts
+++ b/web/src/lib/services/upload-objects.ts
@@ -1,0 +1,85 @@
+import { movieKey, temporaryUploadKey } from '../contracts/r2key';
+import { logUploadCleanupFailure } from '../infra/worker-log';
+
+/** R2 の一時オブジェクト。body はバッファ化せず公開キーへの PUT に渡す。 */
+export interface TemporaryUploadObject {
+  size: number;
+  body: ReadableStream<Uint8Array>;
+}
+
+/** R2 が保存済みオブジェクトについて返す、確定処理に必要なメタデータ。 */
+export interface PublishedUploadObject {
+  size: number;
+}
+
+/** アップロードの確定処理が必要とする R2 の最小操作面。 */
+export interface UploadBucket {
+  get(key: string): Promise<TemporaryUploadObject | null>;
+  head(key: string): Promise<PublishedUploadObject | null>;
+  put(
+    key: string,
+    body: ReadableStream<Uint8Array>,
+    options: {
+      httpMetadata: { contentType: string };
+      onlyIf: { etagDoesNotMatch: '*' };
+    }
+  ): Promise<PublishedUploadObject | null>;
+  delete(keys: string | string[]): Promise<void>;
+}
+
+/** 公開配信キーと分離した一時キーから、検証対象の実体を取得する。 */
+export function getTemporaryUpload(
+  bucket: UploadBucket,
+  shortId: string
+): Promise<TemporaryUploadObject | null> {
+  return bucket.get(temporaryUploadKey(shortId));
+}
+
+/** 検証済みの stream を公開動画キーへ保存する。 */
+export async function publishTemporaryUpload(
+  bucket: UploadBucket,
+  shortId: string,
+  body: ReadableStream<Uint8Array>
+): Promise<PublishedUploadObject | null> {
+  const key = movieKey(shortId);
+  const created = await bucket.put(key, body, {
+    httpMetadata: { contentType: 'video/mp4' },
+    onlyIf: { etagDoesNotMatch: '*' },
+  });
+  if (created) return created;
+  return bucket.head(key);
+}
+
+/** commit 後の一時実体を削除する。 */
+export async function tryDeleteTemporaryUpload(
+  bucket: UploadBucket,
+  shortId: string
+): Promise<void> {
+  try {
+    await bucket.delete(temporaryUploadKey(shortId));
+  } catch (error) {
+    logCleanupFailure('upload_tmp_cleanup_failed', error);
+  }
+}
+
+/** ready 化できなかった公開コピーを削除する。 */
+export async function tryDeletePublishedUpload(
+  bucket: UploadBucket,
+  shortId: string
+): Promise<void> {
+  try {
+    await bucket.delete(movieKey(shortId));
+  } catch (error) {
+    logCleanupFailure('upload_public_cleanup_failed', error);
+  }
+}
+
+function logCleanupFailure(
+  event: 'upload_tmp_cleanup_failed' | 'upload_public_cleanup_failed',
+  error: unknown
+): void {
+  logUploadCleanupFailure({
+    event,
+    errorName: error instanceof Error ? error.name : undefined,
+  });
+}

--- a/web/src/lib/services/upload-types.ts
+++ b/web/src/lib/services/upload-types.ts
@@ -1,0 +1,23 @@
+import type { ErrorCode } from '../contracts/api';
+import type { QuotaDatabase } from './quota';
+
+/** D1 の更新まで含む、アップロードサービスが必要とする最小の操作面。 */
+export interface UploadDatabase extends QuotaDatabase {
+  prepare(query: string): {
+    bind(...values: unknown[]): {
+      first<T>(): Promise<T | null>;
+      run(): Promise<{ meta: { changes: number } }>;
+    };
+  };
+}
+
+/** API ハンドラが HTTP 応答へ変換するドメインエラー。 */
+export class UploadError extends Error {
+  constructor(
+    public readonly status: 400 | 404 | 413 | 429,
+    public readonly errorCode: ErrorCode,
+    message: string
+  ) {
+    super(message);
+  }
+}

--- a/web/src/lib/services/uploads.ts
+++ b/web/src/lib/services/uploads.ts
@@ -1,12 +1,9 @@
 import {
   ERROR_CODES,
-  MAX_UPLOAD_BYTES,
-  type CommitResponse,
-  type ErrorCode,
   type PresignRequest,
   type PresignResponse,
 } from '../contracts/api';
-import { generateShortId, movieKey, movieUrl } from '../contracts/r2key';
+import { generateShortId, movieUrl, temporaryUploadKey } from '../contracts/r2key';
 import { createR2PutPresignedUrl, type R2PresignConfig } from '../infra/r2presign';
 import { logWorkerFailure } from '../infra/worker-log';
 import {
@@ -14,45 +11,15 @@ import {
   MAX_PENDING_UPLOADS_PER_USER,
   MOVIE_RETENTION_MS,
   USER_STORAGE_QUOTA_BYTES,
-  type QuotaDatabase,
 } from './quota';
+import { UploadError, type UploadDatabase } from './upload-types';
 
-/** D1 の更新まで含む、アップロードサービスが必要とする最小の操作面。 */
-export interface UploadDatabase extends QuotaDatabase {
-  prepare(query: string): {
-    bind(...values: unknown[]): {
-      first<T>(): Promise<T | null>;
-      run(): Promise<{ meta: { changes: number } }>;
-    };
-  };
-}
-
-/** R2 の commit 確認に必要な最小操作面。 */
-export interface UploadBucket {
-  head(key: string): Promise<{ size: number } | null>;
-}
+export type { UploadBucket } from './upload-objects';
+export { commitUpload, type CommitUploadInput } from './upload-commit';
+export { UploadError, type UploadDatabase } from './upload-types';
 
 /** R2 URL 発行をテストから差し替えるための境界。 */
 export type UploadUrlGenerator = (key: string) => Promise<string>;
-
-/** API ハンドラが HTTP 応答へ変換するドメインエラー。 */
-export class UploadError extends Error {
-  constructor(
-    public readonly status: 400 | 404 | 413 | 429,
-    public readonly errorCode: ErrorCode,
-    message: string
-  ) {
-    super(message);
-  }
-}
-
-interface MovieRow {
-  short_id: string;
-  user_id: number;
-  size_bytes: number;
-  status: 'pending' | 'ready' | 'failed';
-  expires_at: string | null;
-}
 
 export interface CreatePendingUploadInput {
   database: UploadDatabase;
@@ -62,14 +29,6 @@ export interface CreatePendingUploadInput {
   createUploadUrl: UploadUrlGenerator;
   generateId?: () => string;
   now?: Date;
-}
-
-export interface CommitUploadInput {
-  database: UploadDatabase;
-  bucket: UploadBucket;
-  userId: number;
-  shortId: string;
-  publicBaseUrl: string;
 }
 
 /** 未確定アップロードを所有者条件付きで failed にする入力。 */
@@ -89,7 +48,7 @@ export async function createPendingUpload(
   input: CreatePendingUploadInput
 ): Promise<PresignResponse> {
   const shortId = (input.generateId ?? generateShortId)();
-  const key = movieKey(shortId);
+  const key = temporaryUploadKey(shortId);
 
   // URL の発行を INSERT より先に行う。逆順だと発行に失敗した時に pending 行だけが残り、
   // 署名失効後の回収が拾うまで保存容量を食い続ける（利用者からは理由が見えない）。
@@ -149,110 +108,6 @@ export async function createPendingUpload(
   };
 }
 
-/** R2 実体を検証し、所有者の pending movie を ready に確定する。 */
-export async function commitUpload(input: CommitUploadInput): Promise<CommitResponse> {
-  const movie = await input.database
-    .prepare(
-      'SELECT short_id, user_id, size_bytes, status, expires_at FROM movies WHERE short_id = ? AND user_id = ?'
-    )
-    .bind(input.shortId, input.userId)
-    .first<MovieRow>();
-
-  if (!movie) {
-    throw new UploadError(404, ERROR_CODES.notFound, '対象の動画が見つかりません');
-  }
-
-  const key = movieKey(input.shortId);
-  if (movie.status === 'ready') return toCommitResponse(movie, input.publicBaseUrl);
-  if (movie.status !== 'pending') {
-    throw new UploadError(400, ERROR_CODES.invalidRequest, 'この動画は commit できません');
-  }
-
-  const object = await input.bucket.head(key);
-  if (!object) {
-    throw new UploadError(400, ERROR_CODES.invalidRequest, 'アップロード済みの動画が見つかりません');
-  }
-
-  const exceedsPerFileLimit = object.size > MAX_UPLOAD_BYTES;
-  const exceedsDeclaredSizeLimit = object.size > movie.size_bytes * 2;
-  if (exceedsPerFileLimit || exceedsDeclaredSizeLimit) {
-    // 確保に負けた行は、この呼び出しが上限超過として扱ってよい対象ではない。
-    // 413 を返し続けると既に ready の行へ誤った理由を返すため、最終状態から引き直す。
-    if (!(await claimOversizedUpload(input, object.size))) return resolveCommitConflict(input);
-    throw new UploadError(
-      413,
-      ERROR_CODES.payloadTooLarge,
-      'アップロード済み動画が保存上限を超えています'
-    );
-  }
-
-  const updated = await input.database
-    .prepare(
-      `UPDATE movies SET status = 'ready', size_bytes = ?
-       WHERE short_id = ? AND user_id = ? AND status = 'pending'
-       AND COALESCE((
-         SELECT SUM(size_bytes) FROM movies
-         WHERE user_id = ? AND short_id <> ? AND status IN ('pending', 'ready', 'failed')
-       ), 0) + ? <= ?`
-    )
-    .bind(
-      object.size,
-      input.shortId,
-      input.userId,
-      input.userId,
-      input.shortId,
-      object.size,
-      USER_STORAGE_QUOTA_BYTES
-    )
-    .run();
-
-  // 0 件 = SELECT と R2 確認の間に行が pending でなくなった。成功として返すと、
-  // 保持期間バッチが回収した動画の公開 URL を返してしまう（行も実体も無いのに再生できる想定になる）。
-  if (updated.meta.changes === 0) {
-    const current = await findMovie(input.database, input.userId, input.shortId);
-    if (current?.status === 'pending') {
-      if (await claimOversizedUpload(input, object.size)) {
-        throw new UploadError(
-          413,
-          ERROR_CODES.payloadTooLarge,
-          'アップロード済み動画が保存上限を超えています'
-        );
-      }
-    }
-    return resolveCommitConflict(input);
-  }
-
-  return toCommitResponse({ ...movie, size_bytes: object.size, status: 'ready' }, input.publicBaseUrl);
-}
-
-/**
- * 上限を超えた動画の予約を failed へ確保する。確保できたら true を返す。
- *
- * 署名 URL は発行から 5 分間有効なので、413 の直後に R2 を消すと遅延した PUT が
- * 孤児になる。実測サイズと failed 行を残し、署名失効後の保持期間バッチが R2 → D1 の
- * 順に回収する。確保に負けた（0 件）行には一切触れない。
- */
-async function claimOversizedUpload(input: CommitUploadInput, actualSize: number): Promise<boolean> {
-  const claim = await input.database
-    .prepare(
-      "UPDATE movies SET status = 'failed', size_bytes = ? WHERE short_id = ? AND user_id = ? AND status = 'pending'"
-    )
-    .bind(actualSize, input.shortId, input.userId)
-    .run();
-
-  if (claim.meta.changes === 0) {
-    logWorkerFailure({
-      level: 'warn',
-      event: 'upload_commit_oversize_claim_missed',
-      errorCode: ERROR_CODES.payloadTooLarge,
-      status: 413,
-    });
-    return false;
-  }
-
-  return true;
-}
-
 /** 所有者の未確定アップロードを failed にし、保持期間バッチへ回収を委ねる。 */
 export async function abandonUpload(input: AbandonUploadInput): Promise<void> {
   try {
@@ -271,44 +126,4 @@ export async function abandonUpload(input: AbandonUploadInput): Promise<void> {
     });
     throw error;
   }
-}
-
-/**
- * ready への UPDATE が 0 件だった理由を引き直して返す。
- *
- * 行が消えていれば 404（pending の掃除が勝った）、既に ready なら並行 commit が
- * 先に確定しただけなので同じ応答で成功する（services/movies.ts の pin と同じ形）。
- * 稀な経路なので、通常時に追加のクエリを増やさないようここでだけ読み直す。
- */
-async function resolveCommitConflict(input: CommitUploadInput): Promise<CommitResponse> {
-  const current = await findMovie(input.database, input.userId, input.shortId);
-
-  if (!current) {
-    throw new UploadError(404, ERROR_CODES.notFound, '対象の動画が見つかりません');
-  }
-  if (current.status === 'ready') return toCommitResponse(current, input.publicBaseUrl);
-  throw new UploadError(400, ERROR_CODES.invalidRequest, 'この動画は commit できません');
-}
-
-/** shortId と所有者で movie を読み出す。並行更新後の状態解決に使う。 */
-async function findMovie(
-  database: UploadDatabase,
-  userId: number,
-  shortId: string
-): Promise<MovieRow | null> {
-  return database
-    .prepare(
-      'SELECT short_id, user_id, size_bytes, status, expires_at FROM movies WHERE short_id = ? AND user_id = ?'
-    )
-    .bind(shortId, userId)
-    .first<MovieRow>();
-}
-
-function toCommitResponse(movie: MovieRow, publicBaseUrl: string): CommitResponse {
-  return {
-    shortId: movie.short_id,
-    publicUrl: movieUrl(publicBaseUrl, movie.short_id),
-    sizeBytes: movie.size_bytes,
-    expiresAt: movie.expires_at,
-  };
 }

--- a/web/src/pages/api/uploads/presign.ts
+++ b/web/src/pages/api/uploads/presign.ts
@@ -2,9 +2,13 @@ import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 
 import { ERROR_CODES, type ErrorResponse, validatePresignRequest } from '../../../lib/contracts/api';
-import { logWorkerFailure } from '../../../lib/infra/worker-log';
 import { importSigningKey } from '../../../lib/contracts/session';
 import { requireUser, type AuthDatabase } from '../../../lib/services/auth';
+import { logPresignInternalFailure } from '../../../lib/services/presign-errors';
+import {
+  enforcePresignRateLimit,
+  type PresignRateLimiter,
+} from '../../../lib/services/presign-rate-limit';
 import {
   createPendingUpload,
   createR2UploadUrlGenerator,
@@ -24,6 +28,7 @@ interface UploadBindings {
   R2_PUBLIC_BASE_URL: string;
   R2_ACCESS_KEY_ID: string;
   R2_SECRET_ACCESS_KEY: string;
+  PRESIGN_LIMITER?: PresignRateLimiter;
 }
 
 /** pending movie を予約し、R2 への直接 PUT URL を払い出す。 */
@@ -33,10 +38,14 @@ export const POST: APIRoute = async ({ request }) => {
   const authenticated = await requireUser(request, { db: bindings.DB, signingKey });
   if (!authenticated.ok) return json(authenticated.error, authenticated.status);
 
-  const validation = validatePresignRequest(await readJson(request));
-  if (!validation.ok) return json(validation.error, 400);
-
   try {
+    // pending 件数上限とは別に、署名発行の時間当たりコストを本文処理前に抑える。
+    const limited = await enforcePresignRateLimit(bindings.PRESIGN_LIMITER, authenticated.user.id);
+    if (limited) return limited;
+
+    const validation = validatePresignRequest(await readJson(request));
+    if (!validation.ok) return json(validation.error, 400);
+
     const response = await createPendingUpload({
       database: bindings.DB,
       userId: authenticated.user.id,
@@ -65,7 +74,7 @@ async function readJson(request: Request): Promise<unknown> {
 
 function uploadErrorResponse(error: unknown): Response {
   if (error instanceof UploadError) return errorResponse(error.status, error.errorCode, error.message);
-  logWorkerFailure({ event: 'upload_presign_failed', errorCode: ERROR_CODES.internalError, status: 500 });
+  logPresignInternalFailure();
   return errorResponse(500, ERROR_CODES.internalError, 'アップロードURLの発行に失敗しました');
 }
 

--- a/web/tests/api/uploads-presign-rate-limit.test.ts
+++ b/web/tests/api/uploads-presign-rate-limit.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import {
+  createSessionPayload,
+  importSigningKey,
+  signSession,
+} from '../../src/lib/contracts/session';
+
+const runtimeEnv: Record<string, unknown> = {};
+mock.module('cloudflare:workers', () => ({ env: runtimeEnv }));
+const { POST } = await import('../../src/pages/api/uploads/presign');
+
+const SIGNING_SECRET = 'presign-rate-limit-test-secret';
+const originalError = console.error;
+
+afterEach(() => {
+  console.error = originalError;
+});
+
+function authenticatedDatabase(userId: number) {
+  const statement = {
+    bind: () => statement,
+    first: async () => ({ id: userId, discord_id: 'discord-user', name: 'tester', avatar: null }),
+  };
+  return { prepare: () => statement };
+}
+
+async function authenticatedRequest(userId: number): Promise<{ request: Request; bodyReads: () => number }> {
+  const signingKey = await importSigningKey(SIGNING_SECRET);
+  const session = await signSession(createSessionPayload(userId), signingKey);
+  const request = new Request('https://web-screen.net/api/uploads/presign/', {
+    method: 'POST',
+    headers: { cookie: `ws_session=${session}`, 'content-type': 'application/json' },
+    body: '{}',
+  });
+  let reads = 0;
+  Object.defineProperty(request, 'json', {
+    value: async () => {
+      reads += 1;
+      return { filename: 'movie.mp4', sizeBytes: 100, kind: 'image' };
+    },
+  });
+  return { request, bodyReads: () => reads };
+}
+
+async function callPresign(request: Request): Promise<Response> {
+  return POST({ request } as Parameters<typeof POST>[0]);
+}
+
+describe('POST /api/uploads/presign/ のレート制限境界', () => {
+  test('binding が拒否したら JSON 本文を読まず429を返す', async () => {
+    Object.assign(runtimeEnv, {
+      DB: authenticatedDatabase(42),
+      SESSION_SIGNING_KEY: SIGNING_SECRET,
+      PRESIGN_LIMITER: { limit: async () => ({ success: false }) },
+    });
+    const { request, bodyReads } = await authenticatedRequest(42);
+
+    const response = await callPresign(request);
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('60');
+    expect(bodyReads()).toBe(0);
+  });
+
+  test('binding が欠落したら500にして既存の構造化ログへ記録する', async () => {
+    Object.assign(runtimeEnv, {
+      DB: authenticatedDatabase(42),
+      SESSION_SIGNING_KEY: SIGNING_SECRET,
+      PRESIGN_LIMITER: undefined,
+    });
+    const entries: Array<Record<string, unknown>> = [];
+    console.error = ((line: string) => {
+      entries.push(JSON.parse(line) as Record<string, unknown>);
+    }) as typeof console.error;
+    const { request, bodyReads } = await authenticatedRequest(42);
+
+    const response = await callPresign(request);
+
+    expect(response.status).toBe(500);
+    expect(bodyReads()).toBe(0);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      event: 'upload_presign_failed',
+      errorCode: 'INTERNAL_ERROR',
+      status: 500,
+    });
+    expect(Object.keys(entries[0] ?? {})).not.toContain('url');
+    expect(Object.keys(entries[0] ?? {})).not.toContain('cookie');
+    expect(Object.keys(entries[0] ?? {})).not.toContain('shortId');
+  });
+});

--- a/web/tests/contracts/r2key.test.ts
+++ b/web/tests/contracts/r2key.test.ts
@@ -8,6 +8,7 @@ import {
   generateShortId,
   isShortId,
   movieKey,
+  temporaryUploadKey,
 } from '../../src/lib/contracts/r2key';
 
 const SESSION_ID = '0f9c2b1a-4d3e-4a6b-8c7d-1e2f3a4b5c6d';
@@ -69,6 +70,20 @@ describe('movieKey', () => {
     ['長すぎる', 'aB3dE5fG7hJ9X'],
   ])('%s shortId は拒否する', (_label, value) => {
     expect(() => movieKey(value)).toThrow(/shortId/);
+  });
+});
+
+describe('temporaryUploadKey', () => {
+  test('tmp/{shortId} を返す', () => {
+    expect(temporaryUploadKey('aB3dE5fG7hJ9')).toBe('tmp/aB3dE5fG7hJ9');
+  });
+
+  test.each([
+    ['短すぎる', 'abc'],
+    ['記号を含む', 'aB3dE5fG7h/9'],
+    ['長すぎる', 'aB3dE5fG7hJ9X'],
+  ])('%s shortId は拒否する', (_label, value) => {
+    expect(() => temporaryUploadKey(value)).toThrow(/shortId/);
   });
 });
 

--- a/web/tests/services/movies-delete.test.ts
+++ b/web/tests/services/movies-delete.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
+import { temporaryUploadKey } from '../../src/lib/contracts/r2key';
 import type { PurgeFetcher } from '../../src/lib/infra/cloudflare-purge';
 import type { CachePurgeSettings } from '../../src/lib/services/cache-purge';
 import {
@@ -61,8 +62,8 @@ class FakeMoviesDatabase implements MoviesDatabase {
 class FakeMovieBucket implements MovieBucket {
   readonly deletedKeys: string[] = [];
 
-  async delete(key: string): Promise<void> {
-    this.deletedKeys.push(key);
+  async delete(keys: string | string[]): Promise<void> {
+    this.deletedKeys.push(...(Array.isArray(keys) ? keys : [keys]));
   }
 }
 
@@ -130,7 +131,7 @@ describe('deleteMovie', () => {
     });
 
     // 実体だけが消え、ready の行が残る（プレビューが再生不能になる）状態。
-    expect(bucket.deletedKeys).toEqual([MOVIE_KEY]);
+    expect(bucket.deletedKeys).toEqual([MOVIE_KEY, temporaryUploadKey(SHORT_ID)]);
     expect(events).toEqual(['movie_delete_row_stranded']);
   });
 
@@ -150,7 +151,7 @@ describe('deleteMovie', () => {
 
     expect(events).toEqual([]);
     expect(database.deletedRows).toBe(1);
-    expect(bucket.deletedKeys).toEqual([MOVIE_KEY]);
+    expect(bucket.deletedKeys).toEqual([MOVIE_KEY, temporaryUploadKey(SHORT_ID)]);
   });
 
   it('公開 URL のキャッシュ purge を 1 回投げる', async () => {
@@ -186,7 +187,7 @@ describe('deleteMovie', () => {
       });
     });
 
-    expect(bucket.deletedKeys).toEqual([MOVIE_KEY]);
+    expect(bucket.deletedKeys).toEqual([MOVIE_KEY, temporaryUploadKey(SHORT_ID)]);
     expect(database.deletedRows).toBe(1);
   });
 

--- a/web/tests/services/movies-metadata.test.ts
+++ b/web/tests/services/movies-metadata.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  findPublicMovie,
+  renameMovie,
+  type MoviesDatabase,
+} from '../../src/lib/services/movies';
+
+type MovieStatus = 'pending' | 'ready' | 'failed';
+
+interface TestMovie {
+  shortId: string;
+  userId: number;
+  filename: string;
+  status: MovieStatus;
+}
+
+class MetadataDatabase implements MoviesDatabase {
+  readonly movies = new Map<string, TestMovie>();
+
+  constructor(movies: TestMovie[] = []) {
+    for (const movie of movies) this.movies.set(movie.shortId, { ...movie });
+  }
+
+  prepare(query: string) {
+    return {
+      bind: (...values: unknown[]) => ({
+        first: async <T>(): Promise<T | null> => this.first<T>(query, values),
+        all: async <T>(): Promise<{ results: T[] }> => ({ results: [] }),
+        run: async (): Promise<{ meta: { changes: number } }> => this.run(query, values),
+      }),
+    };
+  }
+
+  private first<T>(query: string, values: unknown[]): T | null {
+    const shortId = values[0] as string;
+    const movie = this.movies.get(shortId);
+    if (!movie) return null;
+    if (query.includes("status = 'ready'")) {
+      return movie.status === 'ready' ? (toRow(movie) as T) : null;
+    }
+    const userId = values[1] as number;
+    return movie.userId === userId ? (toRow(movie) as T) : null;
+  }
+
+  private run(query: string, values: unknown[]): { meta: { changes: number } } {
+    if (!query.startsWith('UPDATE movies SET filename')) return { meta: { changes: 0 } };
+    const [filename, shortId, userId] = values as [string, string, number];
+    const movie = this.movies.get(shortId);
+    if (!movie || movie.userId !== userId) return { meta: { changes: 0 } };
+    movie.filename = filename;
+    return { meta: { changes: 1 } };
+  }
+}
+
+const USER_ID = 10;
+const SHORT_ID = 'AbCdEf123456';
+const PUBLIC_URL = 'https://public.example';
+
+function movie(overrides: Partial<TestMovie> = {}): TestMovie {
+  return {
+    shortId: SHORT_ID,
+    userId: USER_ID,
+    filename: 'slides.pdf',
+    status: 'ready',
+    ...overrides,
+  };
+}
+
+function toRow(value: TestMovie) {
+  return {
+    short_id: value.shortId,
+    user_id: value.userId,
+    filename: value.filename,
+    status: value.status,
+    pinned: 0,
+    created_at: '2026-08-01 00:00:00',
+    expires_at: '2099-01-01T00:00:00.000Z',
+  };
+}
+
+describe('renameMovie', () => {
+  it('所有者のファイル名を変更する', async () => {
+    const database = new MetadataDatabase([movie()]);
+
+    await expect(
+      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
+    ).resolves.toEqual({ shortId: SHORT_ID, filename: 'renamed.mp4' });
+    expect(database.movies.get(SHORT_ID)?.filename).toBe('renamed.mp4');
+  });
+
+  it('他人と不在の動画は 404 で拒否する', async () => {
+    const other = new MetadataDatabase([movie({ userId: USER_ID + 1 })]);
+    const missing = new MetadataDatabase();
+
+    await expect(
+      renameMovie({ database: other, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      renameMovie({ database: missing, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('findPublicMovie', () => {
+  it('ready の動画を公開 URL 付きで返す', async () => {
+    const database = new MetadataDatabase([movie()]);
+
+    await expect(
+      findPublicMovie({ database, shortId: SHORT_ID, publicBaseUrl: PUBLIC_URL })
+    ).resolves.toMatchObject({
+      shortId: SHORT_ID,
+      filename: 'slides.pdf',
+      publicUrl: `${PUBLIC_URL}/movies/${SHORT_ID}.mp4`,
+      pinned: false,
+      ownerId: USER_ID,
+    });
+  });
+
+  it('pending / failed は公開しない', async () => {
+    for (const status of ['pending', 'failed'] as const) {
+      const database = new MetadataDatabase([movie({ status })]);
+      await expect(
+        findPublicMovie({ database, shortId: SHORT_ID, publicBaseUrl: PUBLIC_URL })
+      ).resolves.toBeNull();
+    }
+  });
+
+  it.each(['ja', 'abcdefghijklm', 'AbCdEf-12345', '../../etc/pw'])(
+    '%s は DB を引かずに null',
+    async (shortId) => {
+      const database = new MetadataDatabase([movie()]);
+      await expect(findPublicMovie({ database, shortId, publicBaseUrl: PUBLIC_URL })).resolves.toBeNull();
+    }
+  );
+});

--- a/web/tests/services/movies.test.ts
+++ b/web/tests/services/movies.test.ts
@@ -8,14 +8,9 @@ import {
   PINNED_RETENTION_MS,
   UNPIN_GRACE_MS,
 } from '../../src/lib/services/quota';
-import type { CachePurgeSettings } from '../../src/lib/services/cache-purge';
 import {
-  deleteMovie,
-  findPublicMovie,
   listHistory,
-  renameMovie,
   togglePin,
-  type MovieBucket,
   type MoviesDatabase,
 } from '../../src/lib/services/movies';
 
@@ -72,12 +67,6 @@ class FakeMoviesDatabase implements MoviesDatabase {
       return { total } as T;
     }
 
-    if (query.includes("status = 'ready'")) {
-      const shortId = values[0] as string;
-      const movie = this.movies.get(shortId);
-      return movie && movie.status === 'ready' ? (toRow(movie) as T) : null;
-    }
-
     const [shortId, userId] = values as [string, number];
     const movie = this.movies.get(shortId);
     return movie && movie.userId === userId ? (toRow(movie) as T) : null;
@@ -97,13 +86,6 @@ class FakeMoviesDatabase implements MoviesDatabase {
   }
 
   private run(query: string, values: unknown[]): { meta: { changes: number } } {
-    if (query.startsWith('UPDATE movies SET filename')) {
-      const [filename, shortId, userId] = values as [string, string, number];
-      const movie = this.movies.get(shortId);
-      if (movie && movie.userId === userId) movie.filename = filename;
-      return { meta: { changes: movie && movie.userId === userId ? 1 : 0 } };
-    }
-
     if (query.startsWith('UPDATE movies SET pinned')) {
       const [pinned, expiresAt, shortId, userId] = values as [number, string | null, string, number];
       // UPDATE の直前に走らせるフック（判定から書き込みまでの間の割り込みを再現する）
@@ -133,22 +115,7 @@ class FakeMoviesDatabase implements MoviesDatabase {
       return { meta: { changes: 1 } };
     }
 
-    if (query.startsWith('DELETE FROM movies')) {
-      const [shortId, userId] = values as [string, number];
-      const movie = this.movies.get(shortId);
-      if (movie && movie.userId === userId) this.movies.delete(shortId);
-      return { meta: { changes: movie && movie.userId === userId ? 1 : 0 } };
-    }
-
     return { meta: { changes: 0 } };
-  }
-}
-
-class FakeMovieBucket implements MovieBucket {
-  readonly deletedKeys: string[] = [];
-
-  async delete(key: string): Promise<void> {
-    this.deletedKeys.push(key);
   }
 }
 
@@ -492,113 +459,5 @@ describe('togglePin', () => {
       togglePin({ database, userId: USER_ID, shortId: SHORT_ID, now: new Date('2026-08-30T00:00:00.000Z') })
     ).rejects.toMatchObject({ status: 404 });
     expect(database.movies.get(SHORT_ID)?.pinned).toBe(0);
-  });
-});
-
-describe('renameMovie', () => {
-  it('所有者のファイル名を変更する', async () => {
-    const database = new FakeMoviesDatabase([movie()]);
-
-    await expect(
-      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
-    ).resolves.toEqual({ shortId: SHORT_ID, filename: 'renamed.mp4' });
-    expect(database.movies.get(SHORT_ID)?.filename).toBe('renamed.mp4');
-  });
-
-  it('他人の動画は 404 で拒否する', async () => {
-    const database = new FakeMoviesDatabase([movie({ userId: USER_ID + 1 })]);
-
-    await expect(
-      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
-    ).rejects.toMatchObject({ status: 404 });
-  });
-
-  it('不在の動画は 404 で拒否する', async () => {
-    const database = new FakeMoviesDatabase();
-
-    await expect(
-      renameMovie({ database, userId: USER_ID, shortId: SHORT_ID, filename: 'renamed.mp4' })
-    ).rejects.toMatchObject({ status: 404 });
-  });
-});
-
-/** キャッシュ purge の設定。ここでは purge の挙動を見ないので送信だけ止める。 */
-const CACHE_PURGE: CachePurgeSettings = {
-  publicBaseUrl: 'https://cdn.example',
-  zoneId: '2210192b51f9f0eb6761d70341ca09b0',
-  apiToken: 'test-token',
-  source: 'test-worker',
-  fetcher: () => Promise.resolve(new Response(null, { status: 200 })),
-};
-
-describe('deleteMovie', () => {
-  it('R2 の実体を消してから D1 の行を消す', async () => {
-    const database = new FakeMoviesDatabase([movie()]);
-    const bucket = new FakeMovieBucket();
-
-    await deleteMovie({ database, bucket, cachePurge: CACHE_PURGE, userId: USER_ID, shortId: SHORT_ID });
-
-    expect(bucket.deletedKeys).toEqual([`movies/${SHORT_ID}.mp4`]);
-    expect(database.movies.has(SHORT_ID)).toBe(false);
-  });
-
-  it('他人の動画は 404 で拒否し、R2 にも触らない', async () => {
-    const database = new FakeMoviesDatabase([movie({ userId: USER_ID + 1 })]);
-    const bucket = new FakeMovieBucket();
-
-    await expect(
-      deleteMovie({ database, bucket, cachePurge: CACHE_PURGE, userId: USER_ID, shortId: SHORT_ID })
-    ).rejects.toMatchObject({ status: 404 });
-    expect(bucket.deletedKeys).toEqual([]);
-    expect(database.movies.has(SHORT_ID)).toBe(true);
-  });
-
-  it('shortId の形式が不正なら DB を引く前に 404 で止める', async () => {
-    const database = new FakeMoviesDatabase([movie()]);
-    const bucket = new FakeMovieBucket();
-
-    await expect(
-      deleteMovie({ database, bucket, cachePurge: CACHE_PURGE, userId: USER_ID, shortId: '../../etc/passwd' })
-    ).rejects.toMatchObject({ status: 404 });
-    expect(bucket.deletedKeys).toEqual([]);
-  });
-});
-
-describe('findPublicMovie', () => {
-  it('ready の動画を公開 URL 付きで返す', async () => {
-    const database = new FakeMoviesDatabase([movie()]);
-
-    await expect(
-      findPublicMovie({ database, shortId: SHORT_ID, publicBaseUrl: PUBLIC_URL })
-    ).resolves.toMatchObject({
-      shortId: SHORT_ID,
-      filename: 'slides.pdf',
-      publicUrl: `${PUBLIC_URL}/movies/${SHORT_ID}.mp4`,
-      pinned: false,
-      ownerId: USER_ID,
-    });
-  });
-
-  it('pending / failed は公開しない', async () => {
-    for (const status of ['pending', 'failed'] as const) {
-      const database = new FakeMoviesDatabase([movie({ status })]);
-
-      await expect(
-        findPublicMovie({ database, shortId: SHORT_ID, publicBaseUrl: PUBLIC_URL })
-      ).resolves.toBeNull();
-    }
-  });
-
-  it.each([
-    ['ja', '短すぎる'],
-    ['abcdefghijklm', '長すぎる'],
-    ['AbCdEf-12345', '記号を含む'],
-    ['../../etc/pw', 'パス区切りを含む'],
-  ])('%s（%s）は DB を引かずに null', async (shortId) => {
-    const database = new FakeMoviesDatabase([movie()]);
-
-    await expect(
-      findPublicMovie({ database, shortId: shortId as string, publicBaseUrl: PUBLIC_URL })
-    ).resolves.toBeNull();
   });
 });

--- a/web/tests/services/presign-rate-limit.test.ts
+++ b/web/tests/services/presign-rate-limit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ERROR_CODES } from '../../src/lib/contracts/api';
+import {
+  PRESIGN_RATE_LIMIT,
+  PRESIGN_RATE_LIMIT_PERIOD_SECONDS,
+  enforcePresignRateLimit,
+  type PresignRateLimiter,
+} from '../../src/lib/services/presign-rate-limit';
+
+/** namespace 内のユーザー別カウンタを再現する Rate Limiting binding の代役。 */
+class StatefulLimiter implements PresignRateLimiter {
+  private readonly counts = new Map<string, number>();
+
+  async limit({ key }: { key: string }): Promise<{ success: boolean }> {
+    const next = (this.counts.get(key) ?? 0) + 1;
+    this.counts.set(key, next);
+    return { success: next <= PRESIGN_RATE_LIMIT };
+  }
+}
+
+describe('presign のユーザー単位レート制限', () => {
+  test('同じユーザーは最初の10回を許可し、11回目を429で拒否する', async () => {
+    const limiter = new StatefulLimiter();
+
+    for (let count = 0; count < PRESIGN_RATE_LIMIT; count += 1) {
+      expect(await enforcePresignRateLimit(limiter, 42)).toBeNull();
+    }
+
+    const response = await enforcePresignRateLimit(limiter, 42);
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get('Retry-After')).toBe(String(PRESIGN_RATE_LIMIT_PERIOD_SECONDS));
+    expect(response?.headers.get('Cache-Control')).toBe('no-store');
+    expect(await response?.json()).toEqual({
+      errorCode: ERROR_CODES.tooManyPresignRequests,
+      message: 'アップロードURLの発行回数が上限を超えました',
+    });
+  });
+
+  test('カウンタのキーはユーザーごとに分離する', async () => {
+    const limiter = new StatefulLimiter();
+    for (let count = 0; count < PRESIGN_RATE_LIMIT; count += 1) {
+      await enforcePresignRateLimit(limiter, 42);
+    }
+
+    expect((await enforcePresignRateLimit(limiter, 42))?.status).toBe(429);
+    expect(await enforcePresignRateLimit(limiter, 84)).toBeNull();
+  });
+
+  test('binding の欠落や失敗は fail-open しない', async () => {
+    await expect(enforcePresignRateLimit(undefined, 42)).rejects.toThrow(
+      'PRESIGN_LIMITER binding is required'
+    );
+    await expect(
+      enforcePresignRateLimit(
+        { limit: async () => Promise.reject(new Error('binding unavailable')) },
+        42
+      )
+    ).rejects.toThrow('binding unavailable');
+  });
+});

--- a/web/tests/services/retention-orphans.test.ts
+++ b/web/tests/services/retention-orphans.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { movieKey } from '../../src/lib/contracts/r2key';
+import { movieKey, temporaryUploadKey } from '../../src/lib/contracts/r2key';
 import {
   MAX_FAILED_DELETIONS_PER_RUN,
   MAX_PENDING_CLAIMS_PER_RUN,
@@ -21,14 +21,20 @@ describe('runRetention: pending 孤児と failed', () => {
     const database = new FakeRetentionDatabase([
       movie({ shortId: 'orphanAAAAAA', status: 'pending', createdAt: iso(-DAY_MS - HOUR_MS) }),
     ]);
-    const bucket = new FakeRetentionBucket(new Set([movieKey('orphanAAAAAA')]));
+    const bucket = new FakeRetentionBucket(
+      new Set([movieKey('orphanAAAAAA'), temporaryUploadKey('orphanAAAAAA')])
+    );
 
     const summary = await run(database, bucket);
 
     expect(summary.recoveredPendingUploads).toBe(1);
     expect(summary.deletedFailed).toBe(0);
     expect(summary.sweptFailedObjects).toBe(1);
-    expect(bucket.deleted).toEqual([movieKey('orphanAAAAAA')]);
+    expect(bucket.deleted).toEqual([
+      movieKey('orphanAAAAAA'),
+      temporaryUploadKey('orphanAAAAAA'),
+    ]);
+    expect(bucket.objects.size).toBe(0);
     expect(database.movies.get('orphanAAAAAA')?.status).toBe('failed');
   });
 
@@ -95,7 +101,9 @@ describe('runRetention: pending 孤児と failed', () => {
     const database = new FakeRetentionDatabase([
       movie({ shortId: 'orphanFailAA', status: 'pending', createdAt: iso(-2 * DAY_MS) }),
     ]);
-    const bucket = new FakeRetentionBucket(new Set([movieKey('orphanFailAA')]));
+    const bucket = new FakeRetentionBucket(
+      new Set([movieKey('orphanFailAA'), temporaryUploadKey('orphanFailAA')])
+    );
     bucket.failingKeys.add(movieKey('orphanFailAA'));
 
     const first = await run(database, bucket);
@@ -111,7 +119,10 @@ describe('runRetention: pending 孤児と failed', () => {
 
     expect(second.deletedFailed).toBe(1);
     expect(second.deferredObjectDeletions).toBe(0);
-    expect(bucket.deleted).toEqual([movieKey('orphanFailAA')]);
+    expect(bucket.deleted).toEqual([
+      movieKey('orphanFailAA'),
+      temporaryUploadKey('orphanFailAA'),
+    ]);
     expect(database.movies.size).toBe(0);
   });
 
@@ -126,7 +137,10 @@ describe('runRetention: pending 孤児と failed', () => {
     expect(summary.recoveredPendingUploads).toBe(1);
     expect(summary.deletedFailed).toBe(0);
     expect(summary.sweptFailedObjects).toBe(1);
-    expect(bucket.deleted).toEqual([movieKey('noObjectAAAA')]);
+    expect(bucket.deleted).toEqual([
+      movieKey('noObjectAAAA'),
+      temporaryUploadKey('noObjectAAAA'),
+    ]);
     expect(database.movies.get('noObjectAAAA')?.status).toBe('failed');
   });
 
@@ -177,7 +191,7 @@ describe('runRetention: pending 孤児と failed', () => {
 
     expect(summary.deletedFailed).toBe(MAX_FAILED_DELETIONS_PER_RUN);
     expect(summary.sweepCapped).toBe(true);
-    expect(bucket.deleted).toHaveLength(MAX_FAILED_DELETIONS_PER_RUN);
+    expect(bucket.deleted).toHaveLength(MAX_FAILED_DELETIONS_PER_RUN * 2);
     expect(database.movies.size).toBe(overflow);
   });
 });

--- a/web/tests/services/retention.test.ts
+++ b/web/tests/services/retention.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { movieKey } from '../../src/lib/contracts/r2key';
+import { movieKey, temporaryUploadKey } from '../../src/lib/contracts/r2key';
 import { PRESIGN_TTL_MS } from '../../src/lib/infra/r2presign';
 import {
   MAX_EXPIRED_DELETIONS_PER_RUN,
@@ -28,7 +28,10 @@ describe('runRetention: 期限切れ動画', () => {
     const summary = await run(database, bucket);
 
     expect(summary.deletedMovies).toBe(1);
-    expect(bucket.deleted).toEqual([movieKey('expiredAAAAA')]);
+    expect(bucket.deleted).toEqual([
+      movieKey('expiredAAAAA'),
+      temporaryUploadKey('expiredAAAAA'),
+    ]);
     expect(database.movies.has('expiredAAAAA')).toBe(false);
   });
 
@@ -41,7 +44,10 @@ describe('runRetention: 期限切れ動画', () => {
     const summary = await run(database, bucket);
 
     expect(summary.deletedMovies).toBe(1);
-    expect(bucket.deleted).toEqual([movieKey('pinnedAAAAAA')]);
+    expect(bucket.deleted).toEqual([
+      movieKey('pinnedAAAAAA'),
+      temporaryUploadKey('pinnedAAAAAA'),
+    ]);
     expect(database.movies.has('pinnedAAAAAA')).toBe(false);
   });
 

--- a/web/tests/services/upload-object-publishing.test.ts
+++ b/web/tests/services/upload-object-publishing.test.ts
@@ -1,0 +1,435 @@
+import { Database, type SQLQueryBindings } from 'bun:sqlite';
+import { describe, expect, it } from 'bun:test';
+
+import { movieKey, temporaryUploadKey } from '../../src/lib/contracts/r2key';
+import { deleteMovie } from '../../src/lib/services/movies';
+import {
+  commitUpload,
+  createPendingUpload,
+  type UploadBucket,
+  type UploadDatabase,
+} from '../../src/lib/services/uploads';
+
+const USER_ID = 137;
+const SHORT_ID = 'Hardening137';
+const PUBLIC_BASE_URL = 'https://cdn.example';
+
+class SqliteD1Adapter implements UploadDatabase {
+  onReadyUpdate: (() => void) | undefined;
+
+  constructor(readonly sqlite: Database) {}
+
+  prepare(query: string) {
+    return {
+      bind: (...values: unknown[]) => ({
+        first: async <T>(): Promise<T | null> =>
+          (this.sqlite.query(query).get(...(values as SQLQueryBindings[])) as T | null) ?? null,
+        all: async <T>(): Promise<{ results: T[] }> => ({
+          results: this.sqlite.query(query).all(...(values as SQLQueryBindings[])) as T[],
+        }),
+        run: async (): Promise<{ meta: { changes: number } }> => {
+          const result = this.sqlite.query(query).run(...(values as SQLQueryBindings[]));
+          if (result.changes === 1 && query.includes("SET status = 'ready'")) {
+            this.onReadyUpdate?.();
+          }
+          return { meta: { changes: result.changes } };
+        },
+      }),
+    };
+  }
+}
+
+class RacingUploadBucket implements UploadBucket {
+  readonly objects = new Map<string, Uint8Array<ArrayBuffer>>();
+  private getCount = 0;
+  private putCount = 0;
+  private releaseSecondPut: (() => void) | undefined;
+  private readonly secondPutBarrier = new Promise<void>((resolve) => {
+    this.releaseSecondPut = resolve;
+  });
+
+  constructor(private readonly generations: [Uint8Array<ArrayBuffer>, Uint8Array<ArrayBuffer>]) {}
+
+  async get(): Promise<{ size: number; body: ReadableStream<Uint8Array> }> {
+    const generation = this.generations[this.getCount];
+    this.getCount += 1;
+    if (!generation) throw new Error('unexpected get');
+    return { size: generation.byteLength, body: new Blob([generation]).stream() };
+  }
+
+  async head(key: string): Promise<{ size: number } | null> {
+    const value = this.objects.get(key);
+    return value ? { size: value.byteLength } : null;
+  }
+
+  async put(
+    key: string,
+    body: ReadableStream<Uint8Array>,
+    options: {
+      httpMetadata: { contentType: string };
+      onlyIf: { etagDoesNotMatch: '*' };
+    }
+  ): Promise<{ size: number } | null> {
+    const call = this.putCount;
+    this.putCount += 1;
+    if (call === 1) await this.secondPutBarrier;
+    if (options.onlyIf.etagDoesNotMatch === '*' && this.objects.has(key)) return null;
+    const value = new Uint8Array(await new Response(body).arrayBuffer());
+    this.objects.set(key, value);
+    return { size: value.byteLength };
+  }
+
+  async delete(): Promise<void> {}
+
+  allowSecondPut(): void {
+    this.releaseSecondPut?.();
+  }
+}
+
+class MemoryUploadBucket implements UploadBucket {
+  readonly objects = new Map<string, Uint8Array<ArrayBuffer>>();
+  readonly deleted: string[] = [];
+  readonly contentTypes = new Map<string, string>();
+  readonly failingDeleteKeys = new Set<string>();
+  failPut = false;
+  onPut: (() => void) | undefined;
+
+  async head(key: string): Promise<{ size: number } | null> {
+    const value = this.objects.get(key);
+    return value ? { size: value.byteLength } : null;
+  }
+
+  async get(key: string): Promise<{ size: number; body: ReadableStream<Uint8Array> } | null> {
+    const value = this.objects.get(key);
+    if (!value) return null;
+    return {
+      size: value.byteLength,
+      body: new Blob([value]).stream(),
+    };
+  }
+
+  async put(
+    key: string,
+    body: ReadableStream<Uint8Array>,
+    options: {
+      httpMetadata: { contentType: string };
+      onlyIf: { etagDoesNotMatch: '*' };
+    }
+  ): Promise<{ size: number } | null> {
+    this.onPut?.();
+    if (this.failPut) throw new Error('R2 put failed');
+    if (options.onlyIf.etagDoesNotMatch === '*' && this.objects.has(key)) return null;
+    const value = new Uint8Array(await new Response(body).arrayBuffer());
+    this.objects.set(key, value);
+    this.contentTypes.set(key, options.httpMetadata.contentType);
+    return { size: value.byteLength };
+  }
+
+  async delete(keys: string | string[]): Promise<void> {
+    for (const key of Array.isArray(keys) ? keys : [keys]) {
+      if (this.failingDeleteKeys.has(key)) throw new Error('R2 delete failed');
+      this.objects.delete(key);
+      this.deleted.push(key);
+    }
+  }
+}
+
+async function createDatabase(): Promise<SqliteD1Adapter> {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(await Bun.file(new URL('../../migrations/0001_init.sql', import.meta.url)).text());
+  sqlite
+    .query('INSERT INTO users (id, discord_id, name) VALUES (?, ?, ?)')
+    .run(USER_ID, String(USER_ID), 'tester');
+  return new SqliteD1Adapter(sqlite);
+}
+
+async function reserve(database: UploadDatabase, signedKeys: string[]) {
+  return createPendingUpload({
+    database,
+    userId: USER_ID,
+    request: { filename: 'movie.mp4', sizeBytes: 100, kind: 'pdf' },
+    publicBaseUrl: PUBLIC_BASE_URL,
+    createUploadUrl: async (key) => {
+      signedKeys.push(key);
+      return `https://upload.example/${key}`;
+    },
+    generateId: () => SHORT_ID,
+  });
+}
+
+function bytes(...values: number[]): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(values);
+}
+
+async function captureWarnEvents(run: () => Promise<void>): Promise<string[]> {
+  const original = console.warn;
+  const events: string[] = [];
+  console.warn = ((entry: string) => events.push(JSON.parse(entry).event)) as typeof console.warn;
+  try {
+    await run();
+  } finally {
+    console.warn = original;
+  }
+  return events;
+}
+
+describe('署名 PUT の一時キー公開', () => {
+  it('tmp キーだけを署名し、publicUrl は movies キーのまま返す', async () => {
+    const database = await createDatabase();
+    const signedKeys: string[] = [];
+
+    const response = await reserve(database, signedKeys);
+
+    expect(signedKeys).toEqual([temporaryUploadKey(SHORT_ID)]);
+    expect(response.publicUrl).toBe(`${PUBLIC_BASE_URL}/${movieKey(SHORT_ID)}`);
+  });
+
+  it('commit は tmp の bytes を公開キーへコピーして tmp を消す', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+
+    await commitUpload({
+      database,
+      bucket,
+      userId: USER_ID,
+      shortId: SHORT_ID,
+      publicBaseUrl: PUBLIC_BASE_URL,
+    });
+
+    expect(bucket.objects.get(movieKey(SHORT_ID))).toEqual(bytes(1, 2, 3));
+    expect(bucket.contentTypes.get(movieKey(SHORT_ID))).toBe('video/mp4');
+    expect(bucket.objects.has(temporaryUploadKey(SHORT_ID))).toBe(false);
+  });
+
+  it('commit 後に元署名先へ巨大再 PUT しても公開 bytes と D1 size は変わらない', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+    await commitUpload({
+      database,
+      bucket,
+      userId: USER_ID,
+      shortId: SHORT_ID,
+      publicBaseUrl: PUBLIC_BASE_URL,
+    });
+
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), new Uint8Array(1_000));
+
+    expect(bucket.objects.get(movieKey(SHORT_ID))).toEqual(bytes(1, 2, 3));
+    expect(
+      database.sqlite.query('SELECT size_bytes FROM movies WHERE short_id = ?').get(SHORT_ID)
+    ).toEqual({ size_bytes: 3 });
+  });
+
+  it('異なる tmp 世代を読んだ並行 commit でも最初の公開 bytes と D1 size を揃える', async () => {
+    const database = await createDatabase();
+    const firstGeneration = bytes(1, 2, 3);
+    const secondGeneration = bytes(9, 9, 9, 9);
+    const bucket = new RacingUploadBucket([firstGeneration, secondGeneration]);
+    await reserve(database, []);
+    database.onReadyUpdate = () => bucket.allowSecondPut();
+
+    await Promise.all([
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_BASE_URL,
+      }),
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_BASE_URL,
+      }),
+    ]);
+
+    expect(bucket.objects.get(movieKey(SHORT_ID))).toEqual(firstGeneration);
+    expect(
+      database.sqlite.query('SELECT size_bytes FROM movies WHERE short_id = ?').get(SHORT_ID)
+    ).toEqual({ size_bytes: firstGeneration.byteLength });
+  });
+
+  it('曖昧失敗で公開 object だけ残っていても上書きせず、その実測サイズで ready 化する', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    const existingPublished = bytes(7, 7);
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+    bucket.objects.set(movieKey(SHORT_ID), existingPublished);
+
+    const result = await commitUpload({
+      database,
+      bucket,
+      userId: USER_ID,
+      shortId: SHORT_ID,
+      publicBaseUrl: PUBLIC_BASE_URL,
+    });
+
+    expect(result.sizeBytes).toBe(existingPublished.byteLength);
+    expect(bucket.objects.get(movieKey(SHORT_ID))).toEqual(existingPublished);
+    expect(
+      database.sqlite.query('SELECT status, size_bytes FROM movies WHERE short_id = ?').get(SHORT_ID)
+    ).toEqual({ status: 'ready', size_bytes: existingPublished.byteLength });
+  });
+
+  it('ready DELETE 後に元署名先へ再 PUT しても公開 movie は復活しない', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+    await commitUpload({
+      database,
+      bucket,
+      userId: USER_ID,
+      shortId: SHORT_ID,
+      publicBaseUrl: PUBLIC_BASE_URL,
+    });
+    await deleteMovie({
+      database,
+      bucket,
+      userId: USER_ID,
+      shortId: SHORT_ID,
+      cachePurge: {
+        publicBaseUrl: PUBLIC_BASE_URL,
+        zoneId: '',
+        apiToken: '',
+        source: 'test',
+      },
+    });
+
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(9, 9, 9));
+
+    expect(bucket.objects.has(movieKey(SHORT_ID))).toBe(false);
+    expect(database.sqlite.query('SELECT short_id FROM movies WHERE short_id = ?').get(SHORT_ID)).toBeNull();
+  });
+
+  it('公開 put が失敗したら pending と tmp を残し、公開 object を作らない', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+    bucket.failPut = true;
+
+    await expect(
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_BASE_URL,
+      })
+    ).rejects.toThrow('R2 put failed');
+
+    expect(bucket.objects.has(temporaryUploadKey(SHORT_ID))).toBe(true);
+    expect(bucket.objects.has(movieKey(SHORT_ID))).toBe(false);
+    expect(database.sqlite.query('SELECT status FROM movies WHERE short_id = ?').get(SHORT_ID)).toEqual({
+      status: 'pending',
+    });
+  });
+
+  it('公開コピー後に D1 の failed 確保と競合したら公開コピーだけを戻す', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+    bucket.onPut = () => {
+      database.sqlite
+        .query("UPDATE movies SET status = 'failed' WHERE short_id = ?")
+        .run(SHORT_ID);
+    };
+
+    await expect(
+      commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_BASE_URL,
+      })
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(bucket.objects.has(movieKey(SHORT_ID))).toBe(false);
+    expect(bucket.objects.has(temporaryUploadKey(SHORT_ID))).toBe(true);
+    expect(database.sqlite.query('SELECT status FROM movies WHERE short_id = ?').get(SHORT_ID)).toEqual({
+      status: 'failed',
+    });
+  });
+
+  it('ready 化後の tmp cleanup 失敗を記録し、ready DELETE で再回収する', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    const temporaryKey = temporaryUploadKey(SHORT_ID);
+    await reserve(database, []);
+    bucket.objects.set(temporaryKey, bytes(1, 2, 3));
+    bucket.failingDeleteKeys.add(temporaryKey);
+
+    const events = await captureWarnEvents(async () => {
+      await commitUpload({
+        database,
+        bucket,
+        userId: USER_ID,
+        shortId: SHORT_ID,
+        publicBaseUrl: PUBLIC_BASE_URL,
+      });
+    });
+
+    expect(events).toEqual(['upload_tmp_cleanup_failed']);
+    expect(bucket.objects.has(temporaryKey)).toBe(true);
+    expect(bucket.objects.has(movieKey(SHORT_ID))).toBe(true);
+
+    bucket.failingDeleteKeys.clear();
+    await deleteMovie({
+      database,
+      bucket,
+      userId: USER_ID,
+      shortId: SHORT_ID,
+      cachePurge: {
+        publicBaseUrl: PUBLIC_BASE_URL,
+        zoneId: '',
+        apiToken: '',
+        source: 'test',
+      },
+    });
+    expect(bucket.objects.has(temporaryKey)).toBe(false);
+    expect(bucket.objects.has(movieKey(SHORT_ID))).toBe(false);
+  });
+
+  it('競合時の公開 cleanup 失敗を記録し、failed sweep が両キーを追跡できる状態を残す', async () => {
+    const database = await createDatabase();
+    const bucket = new MemoryUploadBucket();
+    const publicKey = movieKey(SHORT_ID);
+    await reserve(database, []);
+    bucket.objects.set(temporaryUploadKey(SHORT_ID), bytes(1, 2, 3));
+    bucket.onPut = () => {
+      database.sqlite
+        .query("UPDATE movies SET status = 'failed' WHERE short_id = ?")
+        .run(SHORT_ID);
+    };
+    bucket.failingDeleteKeys.add(publicKey);
+
+    const events = await captureWarnEvents(async () => {
+      await expect(
+        commitUpload({
+          database,
+          bucket,
+          userId: USER_ID,
+          shortId: SHORT_ID,
+          publicBaseUrl: PUBLIC_BASE_URL,
+        })
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    expect(events).toEqual(['upload_public_cleanup_failed']);
+    expect(bucket.objects.has(publicKey)).toBe(true);
+    expect(bucket.objects.has(temporaryUploadKey(SHORT_ID))).toBe(true);
+    expect(database.sqlite.query('SELECT status FROM movies WHERE short_id = ?').get(SHORT_ID)).toEqual({
+      status: 'failed',
+    });
+  });
+});

--- a/web/tests/services/upload-recovery.test.ts
+++ b/web/tests/services/upload-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { movieKey } from '../../src/lib/contracts/r2key';
+import { movieKey, temporaryUploadKey } from '../../src/lib/contracts/r2key';
 import { PRESIGN_TTL_MS } from '../../src/lib/infra/r2presign';
 import type { CachePurgeSettings } from '../../src/lib/services/cache-purge';
 import { deleteMovie, type MoviesDatabase } from '../../src/lib/services/movies';
@@ -221,6 +221,23 @@ class RecoveryBucket implements UploadBucket, RetentionBucket {
     return size === undefined ? null : { size };
   }
 
+  async get(key: string): Promise<{ size: number; body: ReadableStream<Uint8Array> } | null> {
+    const size = this.objects.get(key);
+    return size === undefined
+      ? null
+      : { size, body: new Blob([new Uint8Array(Math.min(size, 1024))]).stream() };
+  }
+
+  async put(
+    key: string,
+    body: ReadableStream<Uint8Array>
+  ): Promise<{ size: number } | null> {
+    if (this.objects.has(key)) return null;
+    const size = (await new Response(body).arrayBuffer()).byteLength;
+    this.objects.set(key, size);
+    return { size };
+  }
+
   async delete(keys: string | string[]): Promise<void> {
     for (const key of Array.isArray(keys) ? keys : [keys]) {
       this.onDelete?.(key);
@@ -303,7 +320,7 @@ describe('upload recovery', () => {
     const database = new RecoveryDatabase(CREATED_AT.toISOString());
     const bucket = new RecoveryBucket();
     const first = await reserve(database, 'FirstUpload1', 1);
-    const key = movieKey(first.shortId);
+    const key = temporaryUploadKey(first.shortId);
     bucket.objects.set(key, 3);
 
     await expect(
@@ -335,7 +352,7 @@ describe('upload recovery', () => {
     const database = new RecoveryDatabase(CREATED_AT.toISOString());
     const bucket = new RecoveryBucket();
     const upload = await reserve(database, 'AbandonUp001', 1);
-    const key = movieKey(upload.shortId);
+    const key = temporaryUploadKey(upload.shortId);
 
     await abandonUpload({ database, userId: USER_ID, shortId: upload.shortId });
     bucket.objects.set(key, 3);
@@ -355,7 +372,7 @@ describe('upload recovery', () => {
     const database = new RecoveryDatabase(CREATED_AT.toISOString());
     const bucket = new RecoveryBucket();
     const upload = await reserve(database, 'PendingLrg01', 1);
-    const key = movieKey(upload.shortId);
+    const key = temporaryUploadKey(upload.shortId);
     bucket.objects.set(key, USER_STORAGE_QUOTA_BYTES);
 
     await retain(database, bucket);
@@ -376,7 +393,7 @@ describe('upload recovery', () => {
     const database = new RecoveryDatabase(CREATED_AT.toISOString());
     const bucket = new RecoveryBucket();
     const upload = await reserve(database, 'DeleteLate01', 1);
-    const key = movieKey(upload.shortId);
+    const key = temporaryUploadKey(upload.shortId);
 
     await expect(
       deleteMovie({

--- a/web/tests/services/uploads-quota.test.ts
+++ b/web/tests/services/uploads-quota.test.ts
@@ -8,6 +8,7 @@ import {
   validatePresignRequest,
   type PresignRequest,
 } from '../../src/lib/contracts/api';
+import { temporaryUploadKey } from '../../src/lib/contracts/r2key';
 import {
   MAX_PENDING_UPLOADS_PER_USER,
   USER_STORAGE_QUOTA_BYTES,
@@ -90,12 +91,32 @@ function uploadInput(database: UploadDatabase, shortId: string, sizeBytes = 100)
 }
 
 class SizedBucket implements UploadBucket {
+  private readonly publishedSizes = new Map<string, number>();
+
   constructor(private readonly sizes: ReadonlyMap<string, number>) {}
 
-  async head(key: string): Promise<{ size: number } | null> {
+  async get(key: string): Promise<{ size: number; body: ReadableStream<Uint8Array> } | null> {
     const size = this.sizes.get(key);
+    return size === undefined
+      ? null
+        : { size, body: new Blob([new Uint8Array(Math.min(size, 1024))]).stream() };
+  }
+
+  async head(key: string): Promise<{ size: number } | null> {
+    const size = this.publishedSizes.get(key);
     return size === undefined ? null : { size };
   }
+
+  async put(key: string): Promise<{ size: number } | null> {
+    if (this.publishedSizes.has(key)) return null;
+    const shortId = key.slice('movies/'.length, -'.mp4'.length);
+    const size = this.sizes.get(temporaryUploadKey(shortId));
+    if (size === undefined) throw new Error(`missing temporary object for ${key}`);
+    this.publishedSizes.set(key, size);
+    return { size };
+  }
+
+  async delete(): Promise<void> {}
 }
 
 async function releaseTogether<T>(operations: Array<() => Promise<T>>): Promise<PromiseSettledResult<T>[]> {
@@ -178,8 +199,8 @@ describe('アップロードのクォータと検証', () => {
     await insertMovie(database, { shortId: 'CommitTwo001', sizeBytes: declaredSize });
     const bucket = new SizedBucket(
       new Map([
-        ['movies/CommitOne001.mp4', actualSize],
-        ['movies/CommitTwo001.mp4', actualSize],
+        [temporaryUploadKey('CommitOne001'), actualSize],
+        [temporaryUploadKey('CommitTwo001'), actualSize],
       ])
     );
 

--- a/web/tests/services/uploads.test.ts
+++ b/web/tests/services/uploads.test.ts
@@ -115,19 +115,32 @@ class FakeUploadBucket implements UploadBucket {
   deletedKeys: string[] = [];
   /** delete を失敗させる（R2 障害の再現）。 */
   failDelete = false;
-  /** head の直後に走らせるフック（保持期間バッチの割り込みを再現する）。 */
+  /** get の直後に走らせるフック（保持期間バッチの割り込みを再現する）。 */
   onHead: (() => void) | undefined;
 
   constructor(private readonly objectSize: number | null) {}
 
-  async head(): Promise<{ size: number } | null> {
+  async get(): Promise<{ size: number; body: ReadableStream<Uint8Array> } | null> {
     this.onHead?.();
+    return this.objectSize === null
+      ? null
+      : {
+          size: this.objectSize,
+          body: new Blob([new Uint8Array(Math.min(this.objectSize, 1024))]).stream(),
+        };
+  }
+
+  async head(): Promise<{ size: number } | null> {
     return this.objectSize === null ? null : { size: this.objectSize };
   }
 
-  async delete(key: string): Promise<void> {
+  async put(): Promise<{ size: number } | null> {
+    return this.objectSize === null ? null : { size: this.objectSize };
+  }
+
+  async delete(keys: string | string[]): Promise<void> {
     if (this.failDelete) throw new Error('R2 unavailable');
-    this.deletedKeys.push(key);
+    this.deletedKeys.push(...(Array.isArray(keys) ? keys : [keys]));
   }
 }
 

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -64,6 +64,13 @@
       "name": "CLIENT_ERROR_LIMITER",
       "namespace_id": "1001",
       "simple": { "limit": 30, "period": 60 }
+    },
+    {
+      // pending 10 件上限とは別に、署名 URL 発行の時間当たりコストをユーザー単位で抑える。
+      // limit / period は services/presign-rate-limit.ts の応答定数と必ず同期する。
+      "name": "PRESIGN_LIMITER",
+      "namespace_id": "1002",
+      "simple": { "limit": 10, "period": 60 }
     }
   ],
   // Astro のセッション機能が既定で要求する KV。初回 deploy で wrangler が


### PR DESCRIPTION
## なぜこの変更が必要か

#130〜#132 のレビュー（codex sol high セキュリティレーン）で High 判定のまま残っていた 2 件を塞ぐ。いずれも認証済みユーザーによる容量検査の迂回・ストレージコスト攻撃の経路で、有料化（容量のプラン差）を見据えると先に構造を直しておく必要がある。

## 変更内容

- **#137**: 署名 PUT の宛先を公開キーから一時キー `tmp/{shortId}` に分離。commit 時に検証済み実体を公開キーへ stream コピー（create-only PUT で並行 commit の上書きも防止）→ tmp 削除。署名 URL の TTL 内再利用による「commit 後の上書き」「DELETE 後の再 PUT 孤児」が構造的に不可能になる
- **#138**: presign に Workers Rate Limiting binding（ユーザーあたり 10 回/60 秒）。超過は 429 + Retry-After、binding 欠落時は fail-closed
- tmp の掃除は既存 retention に統合。最終防衛線の R2 Lifecycle（tmp/ 1 日削除）は設定手順を docs に記載（要ダッシュボード操作）

## 意思決定

- R2 binding に copy が無いため get→put の stream コピー（50 MiB をメモリに展開しない）
- レートリミットは D1 カウンタではなく Rate Limiting binding を採用（本リポで CLIENT_ERROR_LIMITER の使用実績あり・追加依存なし）。PoP 単位の eventual consistency は許容（コスト攻撃の抑止が目的）

## デプロイ時の注意

- 切替の瞬間、旧版が発行済みの署名 URL（公開キー宛て・最大 5 分）は commit に失敗する。失敗したアップロードは再実行で回復する（脆弱性を残すフォールバックは入れていない）
- マージ後に R2 ダッシュボードで Lifecycle ルール（prefix `tmp/`・1 日で削除）を設定する

## テスト

- [x] bun test 640 pass / 1476 assertions（新規: tmp 分離・stream コピー・再 PUT 不変・DELETE 後の非復活・並行 commit・レートリミット一式）
- [x] 各再発防止テストが修正前に落ちることを確認済み
- [x] bun run typecheck 通過（メイン検収でも再実行）

Closes #137
Closes #138

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
