### PR TITLE
feat: /screen-share/ をブラウザだけで VRChat に画面共有できる機能ページへ置き換える（#128）

### DIFF
--- a/docs/streaming/requirements.md
+++ b/docs/streaming/requirements.md
@@ -79,7 +79,7 @@ Issue #93 で `stream.web-screen.net` に凍結後、実装着手前の 2026-09-
 | 劣化ポリシー | `degradationPreference = 'maintain-resolution'` | R10 |
 | コンテンツヒント | `track.contentHint = 'text'` | R10。**`'detail'` ではない** |
 | 解像度 | **1920x1080 固定**（省帯域でも下げない） | `maintain-resolution` が解像度を守り、足りなければ fps が落ちる。**720p / 480p の段は作らない**（[quality-tiers.md](quality-tiers.md)） |
-| 画面取得 | `getDisplayMedia({ preferCurrentTab: true })`（自タブ共有） | **画面全体の共有は macOS の画面収録許可が要り、未付与だとピッカーが解決しない。**自タブ共有はこれを回避でき 300ms で解決する |
+| 画面取得 | `getDisplayMedia({ video, audio: false })`（**既定ピッカー**。画面全体・ウィンドウ・タブから選ばせる） | 製品では自タブ共有に意味がないため `preferCurrentTab` は使わない（PoC の権限回避用だった）。**macOS は画面収録許可が未付与だと NotAllowedError になる**ので、エラー文言でシステム設定への導線を案内する |
 
 ### 対応ブラウザ
 

--- a/web/e2e/seo.spec.ts
+++ b/web/e2e/seo.spec.ts
@@ -126,6 +126,14 @@ test.describe('用途別ページのメタ情報', () => {
     });
   }
 
+  test('画面共有ページは確定した検索タイトルを出す', async ({ request }) => {
+    const ja = await (await request.get('/ja/screen-share/')).text();
+    const en = await (await request.get('/en/screen-share/')).text();
+
+    expect(ja).toContain('<title>VRChat で画面共有する方法 — OBS 不要・ブラウザだけ | WebScreen</title>');
+    expect(en).toContain('<title>How to share your screen in VRChat — no OBS, just your browser | WebScreen</title>');
+  });
+
   // パンくずを持たないページに出すと、階層の無いところに階層を主張することになる。
   for (const path of ['/ja/', '/en/', '/ja/privacy/', '/en/privacy/', '/ja/terms/', '/en/terms/'] as const) {
     test(`${path} にはパンくずを出さない`, async ({ request }) => {

--- a/web/src/components/ScreenSharePage.astro
+++ b/web/src/components/ScreenSharePage.astro
@@ -1,0 +1,179 @@
+---
+import { useTranslations, type Locale } from '../i18n';
+
+interface Props {
+  lang: Locale;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang).screenSharePage;
+const wizard = t.wizard;
+---
+
+<main class="mx-auto max-w-5xl px-4 py-12">
+  <section class="text-center">
+    <h1 class="text-3xl font-bold leading-tight tracking-tight text-slate-900 sm:text-5xl">{t.heading}</h1>
+    <p class="mx-auto mt-5 max-w-3xl text-lg leading-relaxed text-slate-700">{t.lead}</p>
+    <ul class="mt-6 flex flex-wrap justify-center gap-3" aria-label={t.heading}>
+      {
+        t.badges.map((badge) => (
+          <li class="rounded-full border border-brand-200 bg-brand-50 px-4 py-2 text-base font-semibold text-brand-700">
+            <i class="fa-solid fa-circle-check mr-2" aria-hidden="true" />
+            {badge}
+          </li>
+        ))
+      }
+    </ul>
+
+    <section
+      data-screen-share
+      data-label-select={wizard.select}
+      data-label-selecting={wizard.selecting}
+      data-label-copy={wizard.copy}
+      data-label-copied={wizard.copied}
+      data-label-extend={wizard.extend}
+      data-label-extending={wizard.extending}
+      data-label-stop={wizard.stop}
+      data-label-stopping={wizard.stopping}
+      data-msg-h264={wizard.errors.h264}
+      data-msg-display-denied={wizard.errors.displayDenied}
+      data-msg-stream-already-live={wizard.errors.streamAlreadyLive}
+      data-msg-rate-limited={wizard.errors.rateLimited}
+      data-msg-stream-ended={wizard.errors.streamEnded}
+      data-msg-whip={wizard.errors.whip}
+      data-msg-generic={wizard.errors.generic}
+      class="mx-auto mt-10 max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 text-left shadow-sm sm:p-10"
+    >
+      <div class="mb-8 flex justify-center gap-3" aria-label={t.howTo.heading}>
+        {
+          [1, 2, 3].map((step) => (
+            <span
+              data-screen-indicator={String(step)}
+              data-active={step === 1 ? 'true' : 'false'}
+              class="h-3 w-3 rounded-full bg-slate-300 data-[active=true]:bg-brand-500"
+              aria-hidden="true"
+            />
+          ))
+        }
+      </div>
+
+      <div data-screen-step="idle">
+        <button
+          type="button"
+          data-screen-start
+          class="flex w-full items-center justify-center gap-3 rounded-lg bg-brand-500 px-6 py-5 text-xl font-bold text-white hover:bg-brand-700"
+        >
+          <i class="fa-solid fa-display" aria-hidden="true" />
+          <span>{wizard.start}</span>
+        </button>
+      </div>
+
+      <div data-screen-step="select" hidden>
+        <h2 class="text-2xl font-bold text-slate-900">{wizard.selectHeading}</h2>
+        <p class="mt-3 text-base leading-relaxed text-slate-700">{wizard.selectBody}</p>
+        <button type="button" data-screen-select class="mt-7 inline-flex items-center gap-3 rounded-md bg-brand-500 px-6 py-4 text-lg font-semibold text-white hover:bg-brand-700">
+          <i class="fa-solid fa-display" aria-hidden="true" />
+          <span>{wizard.select}</span>
+        </button>
+      </div>
+
+      <div data-screen-step="login" hidden>
+        <h2 class="text-2xl font-bold text-slate-900">{wizard.loginHeading}</h2>
+        <p class="mt-3 text-base leading-relaxed text-slate-700">{wizard.loginBody}</p>
+        <a href="/api/auth/login/" class="mt-7 inline-flex items-center gap-3 rounded-md bg-brand-500 px-6 py-4 text-lg font-semibold text-white no-underline hover:bg-brand-700">
+          <i class="fa-brands fa-discord" aria-hidden="true" />
+          <span>{wizard.login}</span>
+        </a>
+      </div>
+
+      <div data-screen-step="url" hidden>
+        <h2 class="text-2xl font-bold text-slate-900">{wizard.urlHeading}</h2>
+        <p class="mt-3 text-base leading-relaxed text-slate-700">{wizard.urlBody}</p>
+        <input data-screen-url readonly aria-label={wizard.urlHeading} class="mt-6 w-full rounded-md border border-brand-300 bg-brand-50 px-4 py-4 font-mono text-lg font-bold text-slate-900 sm:text-2xl" />
+        <div class="mt-5 flex flex-wrap gap-3">
+          <button type="button" data-screen-copy class="inline-flex items-center gap-2 rounded-md border border-brand-500 px-5 py-3 text-base font-semibold text-brand-700 hover:bg-brand-50">
+            <i class="fa-solid fa-copy" aria-hidden="true" />
+            <span>{wizard.copy}</span>
+          </button>
+          <button type="button" data-screen-show-live class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-5 py-3 text-base font-semibold text-white hover:bg-brand-700">
+            <i class="fa-solid fa-tower-broadcast" aria-hidden="true" />
+            <span>{wizard.showLive}</span>
+          </button>
+        </div>
+      </div>
+
+      <div data-screen-step="live" hidden>
+        <h2 class="text-2xl font-bold text-slate-900">{wizard.liveHeading}</h2>
+        <video data-screen-preview aria-label={wizard.preview} autoplay playsinline muted class="mt-5 aspect-video w-full rounded-lg border border-slate-200 bg-slate-950" />
+        <dl class="mt-5 grid gap-3 text-base sm:grid-cols-2">
+          <div class="rounded-md bg-slate-50 p-4"><dt class="font-semibold text-slate-700">{wizard.elapsed}</dt><dd data-screen-elapsed class="mt-1 font-mono text-xl font-bold text-slate-900">0:00</dd></div>
+          <div class="rounded-md bg-slate-50 p-4"><dt class="font-semibold text-slate-700">{wizard.expires}</dt><dd data-screen-expires class="mt-1 font-mono text-xl font-bold text-slate-900">0:00</dd></div>
+        </dl>
+        <p data-screen-expiry-warning hidden role="alert" class="mt-5 rounded-md border border-amber-300 bg-amber-50 p-4 font-semibold text-amber-900">
+          <i class="fa-solid fa-triangle-exclamation mr-2" aria-hidden="true" />{wizard.expiryWarning}
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <button type="button" data-screen-extend class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-5 py-3 text-base font-semibold text-white hover:bg-brand-700"><i class="fa-solid fa-clock-rotate-left" aria-hidden="true" />{wizard.extend}</button>
+          <button type="button" data-screen-stop class="inline-flex items-center gap-2 rounded-md border border-red-300 px-5 py-3 text-base font-semibold text-red-700 hover:bg-red-50"><i class="fa-solid fa-stop" aria-hidden="true" />{wizard.stop}</button>
+        </div>
+      </div>
+
+      <div data-screen-step="error" hidden>
+        <h2 class="text-2xl font-bold text-slate-900">{wizard.errorHeading}</h2>
+        <p data-screen-error-message role="alert" class="mt-3 rounded-md border border-red-200 bg-red-50 p-4 text-base leading-relaxed text-red-800"></p>
+        <button type="button" data-screen-retry class="mt-7 inline-flex items-center gap-2 rounded-md bg-brand-500 px-5 py-3 text-base font-semibold text-white hover:bg-brand-700"><i class="fa-solid fa-arrow-rotate-right" aria-hidden="true" />{wizard.retry}</button>
+      </div>
+    </section>
+  </section>
+
+  <section class="mt-20 border-t border-slate-200 pt-12">
+    <h2 class="text-3xl font-bold tracking-tight text-slate-900">{t.howTo.heading}</h2>
+    <div class="mt-8 grid gap-6 md:grid-cols-3">
+      {
+        t.howTo.steps.map((step, index) => (
+          <article class="rounded-xl border border-slate-200 p-5">
+            <figure role="img" aria-label={step.placeholder} class="flex aspect-video items-center justify-center rounded-lg border-2 border-dashed border-slate-300 bg-slate-50 p-4 text-center text-base text-slate-600">{step.placeholder}</figure>
+            <h3 class="mt-5 text-xl font-bold text-slate-900">{index + 1}. {step.heading}</h3>
+            <p class="mt-2 leading-relaxed text-slate-700">{step.body}</p>
+          </article>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="mt-16">
+    <h2 class="text-3xl font-bold tracking-tight text-slate-900">{t.features.heading}</h2>
+    <ul class="mt-6 grid gap-4 sm:grid-cols-2">
+      {t.features.items.map((item) => <li class="flex gap-3 rounded-lg bg-brand-50 p-4 text-base font-semibold text-slate-800"><i class="fa-solid fa-circle-check mt-1 text-brand-500" aria-hidden="true" />{item}</li>)}
+    </ul>
+  </section>
+
+  <section class="mt-16">
+    <h2 class="text-3xl font-bold tracking-tight text-slate-900">{t.faq.heading}</h2>
+    <div class="mt-6 grid gap-3">
+      {t.faq.items.map((item) => <details class="rounded-lg border border-slate-200 p-5"><summary class="cursor-pointer text-lg font-bold text-slate-900">{item.question}</summary><p class="mt-3 leading-relaxed text-slate-700">{item.answer}</p></details>)}
+    </div>
+  </section>
+
+  <section class="mt-16 rounded-xl bg-slate-50 p-7">
+    <h2 class="text-3xl font-bold tracking-tight text-slate-900">{t.explainer.heading}</h2>
+    <p class="mt-4 max-w-3xl leading-relaxed text-slate-700">{t.explainer.body}</p>
+  </section>
+
+  <section class="mt-16 rounded-xl border border-slate-200 p-7">
+    <h2 class="text-3xl font-bold tracking-tight text-slate-900">{t.convert.heading}</h2>
+    <p class="mt-4 max-w-3xl leading-relaxed text-slate-700">{t.convert.body}</p>
+    <div class="mt-6 flex flex-wrap gap-5">
+      <a href={`/${lang}/`} class="font-semibold text-brand-700 underline hover:text-brand-500">{t.convert.home}</a>
+      <a href={`/${lang}/web/`} class="font-semibold text-brand-700 underline hover:text-brand-500">{t.convert.web}</a>
+    </div>
+  </section>
+</main>
+
+<script>
+  import { mountScreenSharePage } from '../lib/ui/screen-share';
+
+  for (const page of document.querySelectorAll<HTMLElement>('[data-screen-share]')) {
+    mountScreenSharePage(page);
+  }
+</script>

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -282,6 +282,69 @@
     "screenShareLink": "About screen sharing in VRChat",
     "comingSoon": "Screen recording and screen sharing are still on the way"
   },
+  "screenSharePage": {
+    "title": "How to share your screen in VRChat — no OBS, just your browser | WebScreen",
+    "description": "Share your screen in VRChat with no OBS or install. Pick it in your browser and paste the URL. Works on PC and Quest, with about 0.1 seconds of latency.",
+    "heading": "Share your screen in VRChat — browser only, no OBS",
+    "lead": "Pick a screen and get a streaming URL you can paste into a VRChat video player.",
+    "badges": ["No OBS", "No installation", "PC and Quest"],
+    "wizard": {
+      "start": "Start screen sharing",
+      "selectHeading": "Choose a screen to share",
+      "selectBody": "Choose the tab, window, or screen you want to show from your browser picker.",
+      "select": "Choose a screen",
+      "selecting": "Choosing a screen…",
+      "loginHeading": "Sign in with Discord to start",
+      "loginBody": "You need to sign in before creating a streaming URL. There is no password to create.",
+      "login": "Sign in with Discord",
+      "urlHeading": "Paste this streaming URL into VRChat",
+      "urlBody": "Paste it into a VRChat video player to show the screen you chose. On Quest, enter this URL manually.",
+      "copy": "Copy URL",
+      "copied": "Copied",
+      "showLive": "View the live stream",
+      "liveHeading": "Live now",
+      "preview": "Preview of the shared screen",
+      "elapsed": "Elapsed time",
+      "expires": "Time until extension expires",
+      "extend": "Extend",
+      "extending": "Extending…",
+      "stop": "End stream",
+      "stopping": "Ending…",
+      "expiryWarning": "This stream will end soon. Extend it to keep sharing.",
+      "errorHeading": "We could not start the stream",
+      "retry": "Try again",
+      "errors": {
+        "h264": "This browser cannot send H.264 video. Open this page in Chrome or Safari and try again.",
+        "displayDenied": "No screen was selected. Please try again. On macOS, sharing your entire screen requires allowing your browser under System Settings > Privacy & Security > Screen Recording.",
+        "streamAlreadyLive": "You already have a live stream. End it before starting another one.",
+        "rateLimited": "A new stream cannot be created yet. Wait a moment and try again.",
+        "streamEnded": "This stream has ended. Start a new stream instead.",
+        "whip": "We could not connect to the streaming server. Check your network and try again.",
+        "generic": "Something went wrong while preparing the stream. Try again."
+      }
+    },
+    "howTo": {
+      "heading": "How it works",
+      "steps": [
+        { "heading": "Choose a screen", "body": "Choose the tab, window, or screen you want to share.", "placeholder": "Screen selection preview" },
+        { "heading": "Copy the URL", "body": "Copy the short streaming URL that is created for you.", "placeholder": "Copying the URL preview" },
+        { "heading": "Paste it into VRChat", "body": "Paste the URL into a video player in a compatible world.", "placeholder": "Pasting into VRChat preview" }
+      ]
+    },
+    "features": { "heading": "Features", "items": ["No OBS: stream from your browser", "About 0.1 seconds of latency in Use Low Latency compatible worlds", "Quest uses the same URL", "Free to use"] },
+    "faq": {
+      "heading": "FAQ",
+      "items": [
+        { "question": "Which worlds work?", "answer": "Worlds with an AVPro video player that supports Stream mode." },
+        { "question": "Does it work on Quest?", "answer": "Yes. Paste the same URL. Expect about 2–3 seconds of latency." },
+        { "question": "Is there audio?", "answer": "Currently, video only." },
+        { "question": "Is it free?", "answer": "Yes. Press Extend every two hours to keep streaming." },
+        { "question": "What if I forget to stop?", "answer": "The stream ends automatically unless you extend it." }
+      ]
+    },
+    "explainer": { "heading": "How screen sharing works in VRChat", "body": "VRChat has no built-in screen sharing. This page turns your screen into a streaming URL that a video player in a world can play." },
+    "convert": { "heading": "Showing a recording instead?", "body": "If you only need to paste a recorded video, slides, or images, use the conversion tools to keep a URL you can play again later.", "home": "Convert from the home page", "web": "Convert a web page" }
+  },
   "useCases": {
     "stepsHeading": "How to use it",
     "relatedHeading": "Related pages",
@@ -341,7 +404,7 @@
     },
     "screenShare": {
       "title": "Screen sharing in VRChat, and what to use instead — WebScreen",
-      "navLabel": "Instead of screen sharing",
+      "navLabel": "Screen Share",
       "heading": "When you want to share your screen in VRChat",
       "lead": "Sharing your screen in VRChat usually means showing someone a web page, a slide deck or a photo. WebScreen turns that content into a video URL that plays in any world with a video player.",
       "description": "Want to share your screen in VRChat? For web pages and slides, converting them to video is the reliable way — no lag, no world requirements.",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -282,6 +282,69 @@
     "screenShareLink": "VRChat の画面共有について",
     "comingSoon": "画面録画・画面共有は対応中です"
   },
+  "screenSharePage": {
+    "title": "VRChat で画面共有する方法 — OBS 不要・ブラウザだけ | WebScreen",
+    "description": "VRChat に自分の画面をそのまま映せます。OBS もインストールも不要、ブラウザで画面を選んで URL を貼るだけ。PC・Quest 対応、対応ワールドなら遅延約 0.1 秒。",
+    "heading": "VRChat に画面共有 — ブラウザだけで、OBS 不要",
+    "lead": "見せたい画面を選ぶだけで、VRChat のビデオプレイヤーに貼れる配信 URL を作れます。",
+    "badges": ["OBS 不要", "インストール不要", "PC・Quest 対応"],
+    "wizard": {
+      "start": "画面共有をはじめる",
+      "selectHeading": "共有する画面を選ぶ",
+      "selectBody": "ブラウザの画面選択から、見せたいタブ・ウィンドウ・画面を選んでください。",
+      "select": "画面を選ぶ",
+      "selecting": "画面を選んでいます…",
+      "loginHeading": "Discord でログインすると始められます",
+      "loginBody": "配信 URL を作るにはログインが必要です。パスワードの登録はありません。",
+      "login": "Discord でログイン",
+      "urlHeading": "配信 URL を VRChat に貼る",
+      "urlBody": "VRChat のビデオプレイヤーに貼るだけで、選んだ画面を映せます。Quest ではこの URL を手入力してください。",
+      "copy": "URL をコピー",
+      "copied": "コピーしました",
+      "showLive": "配信中の画面を見る",
+      "liveHeading": "配信中",
+      "preview": "共有中の画面プレビュー",
+      "elapsed": "経過時間",
+      "expires": "延長期限まで",
+      "extend": "延長",
+      "extending": "延長しています…",
+      "stop": "配信を終了",
+      "stopping": "終了しています…",
+      "expiryWarning": "まもなく配信が自動終了します。続ける場合は延長してください。",
+      "errorHeading": "配信を開始できませんでした",
+      "retry": "もう一度試す",
+      "errors": {
+        "h264": "このブラウザでは H.264 映像を送れません。Chrome または Safari で開き直してください。",
+        "displayDenied": "画面が選択されませんでした。もう一度お試しください。Mac で画面全体を共有するには、システム設定の「プライバシーとセキュリティ > 画面収録」でブラウザを許可する必要があります。",
+        "streamAlreadyLive": "すでに配信中の画面があります。先にその配信を終了してください。",
+        "rateLimited": "短時間に配信を作り直せません。少し待ってから試してください。",
+        "streamEnded": "この配信は終了しました。新しい配信を始めてください。",
+        "whip": "配信サーバーに接続できませんでした。ネットワークを確認して、もう一度試してください。",
+        "generic": "配信の準備中に問題が起きました。もう一度試してください。"
+      }
+    },
+    "howTo": {
+      "heading": "使い方",
+      "steps": [
+        { "heading": "画面を選ぶ", "body": "共有したいタブ、ウィンドウ、または画面を選びます。", "placeholder": "画面選択のイメージ" },
+        { "heading": "URL をコピー", "body": "発行された短い配信 URL をコピーします。", "placeholder": "URL コピーのイメージ" },
+        { "heading": "VRChat に貼る", "body": "対応ワールドのビデオプレイヤーへ URL を貼り付けます。", "placeholder": "VRChat へ貼り付けるイメージ" }
+      ]
+    },
+    "features": { "heading": "特徴", "items": ["OBS 不要、ブラウザだけで配信", "Use Low Latency 対応ワールドなら遅延約 0.1 秒", "Quest も同じ URL で視聴", "無料で使える"] },
+    "faq": {
+      "heading": "よくある質問",
+      "items": [
+        { "question": "対応ワールドは？", "answer": "AVPro の Stream モードに対応したビデオプレイヤーがあるワールドです。" },
+        { "question": "Quest でも使える？", "answer": "使えます。同じ URL を貼り付けてください。遅延は 2〜3 秒ほどです。" },
+        { "question": "音は出る？", "answer": "現在は映像のみです。" },
+        { "question": "無料？", "answer": "無料です。2 時間ごとに延長ボタンを押せば継続できます。" },
+        { "question": "止め忘れたら？", "answer": "延長しなければ自動で終了します。" }
+      ]
+    },
+    "explainer": { "heading": "VRChat で画面を見せる仕組み", "body": "VRChat には標準の画面共有機能がありません。そこで、画面をビデオプレイヤーで再生できる配信 URL に変え、ワールド内のプレイヤーへ貼り付けます。" },
+    "convert": { "heading": "録画済みのものを見せるなら", "body": "録画済みの動画・スライド・画像を貼りたいだけなら、変換機能を使うと URL を残して何度でも再生できます。", "home": "トップで変換する", "web": "Web ページを変換する" }
+  },
   "useCases": {
     "stepsHeading": "使い方",
     "relatedHeading": "関連ページ",
@@ -341,7 +404,7 @@
     },
     "screenShare": {
       "title": "VRChat の画面共有と、代わりに使える動画変換 — WebScreen",
-      "navLabel": "画面共有の代わりに使う",
+      "navLabel": "画面共有",
       "heading": "VRChat で画面共有をしたいとき",
       "lead": "VRChat で画面を共有したい理由の多くは、Web ページ・スライド・写真を誰かに見せることです。WebScreen はその中身を動画に変換して、ワールドを選ばずに見せられる URL を発行します。",
       "description": "VRChat で画面共有したいとき、Web ページやスライドなら動画に変換するのが確実です。ワールドを選ばず、遅延も音ズレもありません。",

--- a/web/src/lib/contracts/streams.ts
+++ b/web/src/lib/contracts/streams.ts
@@ -2,6 +2,9 @@
 export const STREAM_SESSION_STATUSES = ['live', 'ended'] as const;
 export type StreamSessionStatus = (typeof STREAM_SESSION_STATUSES)[number];
 
+/** WHIP publisher が接続する、allowlist 固定済みの配信オリジン。 */
+export const STREAM_WHIP_BASE_URL = 'https://webscreen.tv/live';
+
 /** 配信が終了した理由。D1 の CHECK 制約と一致させる。 */
 export const STREAM_END_REASONS = [
   'extend_timeout',

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -1,0 +1,324 @@
+import { ERROR_CODES, type CreateStreamResponse, type ExtendStreamResponse } from '../contracts/api';
+import { copyToClipboard } from './clipboard';
+import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
+import { startWhipPublisher, WhipPublishError, type WhipPublisher } from './whip-publisher';
+
+export const HEARTBEAT_INTERVAL_MS = 25_000;
+export const EXPIRY_WARNING_SECONDS = 5 * 60;
+
+type ScreenSharePhase = 'idle' | 'select' | 'login' | 'url' | 'live' | 'error';
+type LiveStream = CreateStreamResponse & { publisher: WhipPublisher; media: MediaStream };
+
+/** DOM controller の外部境界。テストでは画面・API・WHIP を独立して差し替える。 */
+export interface ScreenShareDependencies {
+  requestJson: typeof requestJson;
+  startWhipPublisher: typeof startWhipPublisher;
+  getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
+  now: () => number;
+}
+
+const DEFAULT_DEPENDENCIES: ScreenShareDependencies = {
+  requestJson,
+  startWhipPublisher,
+  getDisplayMedia: (constraints) => navigator.mediaDevices.getDisplayMedia(constraints),
+  now: () => Date.now(),
+};
+
+/** ローカル配信を停止し、WHIP DELETE の成否を呼び出し元へ返す。 */
+export async function releaseScreenShare(
+  live: Pick<LiveStream, 'publisher' | 'media'>,
+  clearTimers: () => void
+): Promise<unknown | null> {
+  let closeError: unknown = null;
+  try {
+    await live.publisher.close();
+  } catch (error) {
+    closeError = error;
+  } finally {
+    stopMedia(live.media);
+    clearTimers();
+  }
+  return closeError;
+}
+
+/** ISO8601 の期限まで残る秒数を、表示に使える非負整数で返す。 */
+export function secondsUntil(expiresAt: string, now = Date.now()): number {
+  return Math.max(0, Math.ceil((Date.parse(expiresAt) - now) / 1000));
+}
+
+/** 延長期限の警告を出す残り時間かを判定する。 */
+export function isExpiryWarning(expiresAt: string, now = Date.now()): boolean {
+  return secondsUntil(expiresAt, now) <= EXPIRY_WARNING_SECONDS;
+}
+
+/** 配信開始後に URL 確認カードを経由してライブ画面へ進む順番を返す。 */
+export function nextStreamStep(phase: 'url' | 'live'): 'live' | null {
+  return phase === 'url' ? 'live' : null;
+}
+
+/** 画面共有カードへイベントと配信状態を配線する。 */
+export function mountScreenSharePage(root: HTMLElement): void {
+  new ScreenShareController(root).mount();
+}
+
+export class ScreenShareController {
+  private live: LiveStream | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private clockTimer: ReturnType<typeof setInterval> | null = null;
+  private phase: ScreenSharePhase = 'idle';
+
+  constructor(
+    private readonly root: HTMLElement,
+    private readonly deps: ScreenShareDependencies = DEFAULT_DEPENDENCIES
+  ) {}
+
+  mount(): void {
+    this.button('[data-screen-start]')?.addEventListener('click', () => this.show('select'));
+    this.button('[data-screen-select]')?.addEventListener('click', () => void this.selectScreen());
+    this.button('[data-screen-copy]')?.addEventListener('click', () => void this.copyUrl());
+    this.button('[data-screen-show-live]')?.addEventListener('click', () => this.show(nextStreamStep('url') ?? 'live'));
+    this.button('[data-screen-extend]')?.addEventListener('click', () => void this.extend());
+    this.button('[data-screen-stop]')?.addEventListener('click', () => void this.stop());
+    this.button('[data-screen-retry]')?.addEventListener('click', () => this.show('select'));
+    this.show('idle');
+  }
+
+  private async selectScreen(): Promise<void> {
+    this.setBusy('[data-screen-select]', true, 'labelSelecting');
+    try {
+      const media = await this.deps.getDisplayMedia(displayMediaConstraints());
+      const stream = await this.createAndPublish(media);
+      this.live = stream;
+      this.setUrl(stream.streamUrl);
+      this.preview(stream.media);
+      this.startTimers();
+      stream.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
+      this.show('url');
+    } catch (error) {
+      this.handleStartError(error);
+    } finally {
+      this.setBusy('[data-screen-select]', false, 'labelSelect');
+    }
+  }
+
+  private async createAndPublish(media: MediaStream): Promise<LiveStream> {
+    let created: CreateStreamResponse;
+    try {
+      created = asCreateStream(await this.deps.requestJson('/api/streams/', { method: 'POST' }));
+    } catch (error) {
+      stopMedia(media);
+      throw error;
+    }
+    try {
+      const publisher = await this.deps.startWhipPublisher({
+        stream: media,
+        streamId: created.id,
+        publishToken: created.publishToken,
+      });
+      return { ...created, publisher, media };
+    } catch (error) {
+      stopMedia(media);
+      await this.deps.requestJson(`/api/streams/${encodeURIComponent(created.id)}/stop/`, { method: 'POST' });
+      throw error;
+    }
+  }
+
+  private async copyUrl(): Promise<void> {
+    const input = this.root.querySelector<HTMLInputElement>('[data-screen-url]');
+    if (!input) return;
+    const copied = await copyToClipboard(input.value, input);
+    this.setButtonLabel('[data-screen-copy]', copied ? 'labelCopied' : 'labelCopy');
+  }
+
+  private async extend(): Promise<void> {
+    if (!this.live) return;
+    this.setBusy('[data-screen-extend]', true, 'labelExtending');
+    try {
+      const response = asExtendStream(
+        await this.deps.requestJson(`/api/streams/${encodeURIComponent(this.live.id)}/extend/`, { method: 'POST' })
+      );
+      this.live.extendExpiresAt = response.extendExpiresAt;
+      this.live.publishToken = response.publishToken;
+      this.live.publisher.setPublishToken(response.publishToken);
+      this.updateClock();
+    } catch (error) {
+      await this.handleRuntimeError(error);
+    } finally {
+      this.setBusy('[data-screen-extend]', false, 'labelExtend');
+    }
+  }
+
+  private async stop(): Promise<void> {
+    if (!this.live) return;
+    const live = this.live;
+    this.setBusy('[data-screen-stop]', true, 'labelStopping');
+    try {
+      await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/stop/`, { method: 'POST' });
+    } catch (error) {
+      await this.handleRuntimeError(error);
+      this.setBusy('[data-screen-stop]', false, 'labelStop');
+      return;
+    }
+
+    const closeError = await releaseScreenShare(live, () => this.clearTimers());
+    this.live = null;
+
+    if (closeError) {
+      this.showError(closeError);
+    } else {
+      this.show('idle');
+    }
+    this.setBusy('[data-screen-stop]', false, 'labelStop');
+  }
+
+  private startTimers(): void {
+    this.clearTimers();
+    this.updateClock();
+    this.heartbeatTimer = setInterval(() => void this.heartbeat(), HEARTBEAT_INTERVAL_MS);
+    this.clockTimer = setInterval(() => this.updateClock(), 1_000);
+  }
+
+  private async heartbeat(): Promise<void> {
+    if (!this.live) return;
+    try {
+      await this.deps.requestJson(`/api/streams/${encodeURIComponent(this.live.id)}/heartbeat/`, { method: 'POST' });
+    } catch (error) {
+      await this.handleRuntimeError(error);
+    }
+  }
+
+  private updateClock(): void {
+    if (!this.live) return;
+    const now = this.deps.now();
+    const remaining = secondsUntil(this.live.extendExpiresAt, now);
+    this.text('[data-screen-elapsed]', formatDuration((now - Date.parse(this.live.startedAt)) / 1000));
+    this.text('[data-screen-expires]', formatDuration(remaining));
+    const warning = this.root.querySelector<HTMLElement>('[data-screen-expiry-warning]');
+    if (warning) warning.hidden = !isExpiryWarning(this.live.extendExpiresAt, now);
+  }
+
+  private handleStartError(error: unknown): void {
+    if (isUnauthorizedRequestError(error)) return this.show('login');
+    this.showError(error);
+  }
+
+  private async handleRuntimeError(error: unknown): Promise<void> {
+    const live = this.live;
+    this.live = null;
+    if (live) await releaseScreenShare(live, () => this.clearTimers());
+    else this.clearTimers();
+    this.showError(error);
+  }
+
+  private showError(error: unknown): void {
+    this.text('[data-screen-error-message]', this.messageFor(error));
+    this.show('error');
+  }
+
+  private messageFor(error: unknown): string {
+    if (error instanceof WhipPublishError) {
+      return this.message(error.code === 'H264_UNAVAILABLE' ? 'msgH264' : 'msgWhip');
+    }
+    if (error instanceof JsonRequestError) {
+      if (error.errorCode === ERROR_CODES.streamAlreadyLive) return this.message('msgStreamAlreadyLive');
+      if (error.errorCode === ERROR_CODES.streamCreateRateLimited) return this.message('msgRateLimited');
+      if (error.errorCode === ERROR_CODES.streamEnded) return this.message('msgStreamEnded');
+    }
+    if (error instanceof DOMException && (error.name === 'NotAllowedError' || error.name === 'AbortError')) {
+      return this.message('msgDisplayDenied');
+    }
+    return this.message('msgGeneric');
+  }
+
+  private show(phase: ScreenSharePhase): void {
+    this.phase = phase;
+    for (const step of this.root.querySelectorAll<HTMLElement>('[data-screen-step]')) {
+      step.hidden = step.dataset['screenStep'] !== phase;
+    }
+    const active = phase === 'url' ? 2 : phase === 'live' ? 3 : 1;
+    for (const indicator of this.root.querySelectorAll<HTMLElement>('[data-screen-indicator]')) {
+      indicator.dataset['active'] = indicator.dataset['screenIndicator'] === String(active) ? 'true' : 'false';
+    }
+  }
+
+  private preview(media: MediaStream): void {
+    const video = this.root.querySelector<HTMLVideoElement>('[data-screen-preview]');
+    if (video) video.srcObject = media;
+  }
+
+  private clearTimers(): void {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    if (this.clockTimer) clearInterval(this.clockTimer);
+    this.heartbeatTimer = null;
+    this.clockTimer = null;
+  }
+
+  private setUrl(url: string): void {
+    const input = this.root.querySelector<HTMLInputElement>('[data-screen-url]');
+    if (input) input.value = url;
+  }
+
+  private setBusy(selector: string, busy: boolean, label: string): void {
+    const button = this.button(selector);
+    if (!button) return;
+    button.disabled = busy;
+    this.setButtonLabel(selector, label);
+  }
+
+  private setButtonLabel(selector: string, label: string): void {
+    const button = this.button(selector);
+    if (button) button.textContent = this.message(label);
+  }
+
+  private message(key: string): string {
+    return this.root.dataset[key] ?? '';
+  }
+
+  private text(selector: string, value: string): void {
+    const element = this.root.querySelector<HTMLElement>(selector);
+    if (element) element.textContent = value;
+  }
+
+  private button(selector: string): HTMLButtonElement | null {
+    return this.root.querySelector<HTMLButtonElement>(selector);
+  }
+}
+
+function displayMediaConstraints(): MediaStreamConstraints {
+  return {
+    // ピッカーは既定のまま（画面全体・ウィンドウ・タブから選ばせる）。PoC の
+    // preferCurrentTab は macOS 権限回避用で、自タブ共有は製品では意味がない。
+    // macOS の画面収録が未許可だと NotAllowedError になる（displayDenied 文言で案内）
+    video: { width: { ideal: 1920 }, height: { ideal: 1080 } },
+    audio: false,
+  };
+}
+
+function asCreateStream(value: unknown): CreateStreamResponse {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.streamUrl !== 'string' || typeof value.publishToken !== 'string' || typeof value.startedAt !== 'string' || typeof value.extendExpiresAt !== 'string') {
+    throw new Error('Invalid create stream response');
+  }
+  return value as unknown as CreateStreamResponse;
+}
+
+function asExtendStream(value: unknown): ExtendStreamResponse {
+  if (!isRecord(value) || typeof value.extendExpiresAt !== 'string' || typeof value.publishToken !== 'string') {
+    throw new Error('Invalid extend stream response');
+  }
+  return value as unknown as ExtendStreamResponse;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stopMedia(media: MediaStream): void {
+  for (const track of media.getTracks()) track.stop();
+}
+
+function formatDuration(seconds: number): string {
+  const rounded = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(rounded / 60);
+  const remaining = String(rounded % 60).padStart(2, '0');
+  return `${minutes}:${remaining}`;
+}

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -15,6 +15,8 @@ export interface ScreenShareDependencies {
   startWhipPublisher: typeof startWhipPublisher;
   getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
   now: () => number;
+  sendBeacon: (url: string) => boolean;
+  onPageHide: (handler: () => void) => void;
 }
 
 const DEFAULT_DEPENDENCIES: ScreenShareDependencies = {
@@ -22,23 +24,18 @@ const DEFAULT_DEPENDENCIES: ScreenShareDependencies = {
   startWhipPublisher,
   getDisplayMedia: (constraints) => navigator.mediaDevices.getDisplayMedia(constraints),
   now: () => Date.now(),
+  sendBeacon: (url) => navigator.sendBeacon(url),
+  onPageHide: (handler) => window.addEventListener('pagehide', handler),
 };
 
-/** ローカル配信を停止し、WHIP DELETE の成否を呼び出し元へ返す。 */
-export async function releaseScreenShare(
+/** タイマー・画面共有・PeerConnection をこの順に同期で解放する。 */
+export function releaseScreenShare(
   live: Pick<LiveStream, 'publisher' | 'media'>,
   clearTimers: () => void
-): Promise<unknown | null> {
-  let closeError: unknown = null;
-  try {
-    await live.publisher.close();
-  } catch (error) {
-    closeError = error;
-  } finally {
-    stopMedia(live.media);
-    clearTimers();
-  }
-  return closeError;
+): void {
+  clearTimers();
+  stopMedia(live.media);
+  live.publisher.close();
 }
 
 /** ISO8601 の期限まで残る秒数を、表示に使える非負整数で返す。 */
@@ -66,6 +63,8 @@ export class ScreenShareController {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private clockTimer: ReturnType<typeof setInterval> | null = null;
   private phase: ScreenSharePhase = 'idle';
+  private stopping = false;
+  private startGeneration = 0;
 
   constructor(
     private readonly root: HTMLElement,
@@ -80,14 +79,27 @@ export class ScreenShareController {
     this.button('[data-screen-extend]')?.addEventListener('click', () => void this.extend());
     this.button('[data-screen-stop]')?.addEventListener('click', () => void this.stop());
     this.button('[data-screen-retry]')?.addEventListener('click', () => this.show('select'));
+    this.deps.onPageHide(() => this.stopForPageHide());
     this.show('idle');
   }
 
   private async selectScreen(): Promise<void> {
+    const generation = ++this.startGeneration;
+    this.stopping = false;
     this.setBusy('[data-screen-select]', true, 'labelSelecting');
     try {
       const media = await this.deps.getDisplayMedia(displayMediaConstraints());
-      const stream = await this.createAndPublish(media);
+      if (!this.isActiveStart(generation)) {
+        stopMedia(media);
+        return;
+      }
+      const stream = await this.createAndPublish(media, generation);
+      if (!stream) return;
+      if (!this.isActiveStart(generation)) {
+        releaseScreenShare(stream, () => this.clearTimers());
+        this.notifyRemoteStop(stream);
+        return;
+      }
       this.live = stream;
       this.setUrl(stream.streamUrl);
       this.preview(stream.media);
@@ -95,13 +107,13 @@ export class ScreenShareController {
       stream.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
       this.show('url');
     } catch (error) {
-      this.handleStartError(error);
+      if (this.isActiveStart(generation)) this.handleStartError(error);
     } finally {
       this.setBusy('[data-screen-select]', false, 'labelSelect');
     }
   }
 
-  private async createAndPublish(media: MediaStream): Promise<LiveStream> {
+  private async createAndPublish(media: MediaStream, generation: number): Promise<LiveStream | null> {
     let created: CreateStreamResponse;
     try {
       created = asCreateStream(await this.deps.requestJson('/api/streams/', { method: 'POST' }));
@@ -109,16 +121,27 @@ export class ScreenShareController {
       stopMedia(media);
       throw error;
     }
+    if (!this.isActiveStart(generation)) {
+      stopMedia(media);
+      void this.notifyServerStop(created.id);
+      return null;
+    }
     try {
       const publisher = await this.deps.startWhipPublisher({
         stream: media,
         streamId: created.id,
         publishToken: created.publishToken,
       });
-      return { ...created, publisher, media };
+      const stream = { ...created, publisher, media };
+      if (!this.isActiveStart(generation)) {
+        releaseScreenShare(stream, () => this.clearTimers());
+        this.notifyRemoteStop(stream);
+        return null;
+      }
+      return stream;
     } catch (error) {
       stopMedia(media);
-      await this.deps.requestJson(`/api/streams/${encodeURIComponent(created.id)}/stop/`, { method: 'POST' });
+      void this.notifyServerStop(created.id);
       throw error;
     }
   }
@@ -131,44 +154,28 @@ export class ScreenShareController {
   }
 
   private async extend(): Promise<void> {
-    if (!this.live) return;
+    const live = this.live;
+    if (!live || this.stopping) return;
     this.setBusy('[data-screen-extend]', true, 'labelExtending');
     try {
       const response = asExtendStream(
-        await this.deps.requestJson(`/api/streams/${encodeURIComponent(this.live.id)}/extend/`, { method: 'POST' })
+        await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/extend/`, { method: 'POST' })
       );
-      this.live.extendExpiresAt = response.extendExpiresAt;
-      this.live.publishToken = response.publishToken;
-      this.live.publisher.setPublishToken(response.publishToken);
+      if (this.stopping || this.live !== live) return;
+      live.extendExpiresAt = response.extendExpiresAt;
+      live.publishToken = response.publishToken;
+      live.publisher.setPublishToken(response.publishToken);
       this.updateClock();
     } catch (error) {
-      await this.handleRuntimeError(error);
+      if (!this.stopping && this.live === live) this.handleRuntimeError(error);
     } finally {
       this.setBusy('[data-screen-extend]', false, 'labelExtend');
     }
   }
 
-  private async stop(): Promise<void> {
-    if (!this.live) return;
-    const live = this.live;
-    this.setBusy('[data-screen-stop]', true, 'labelStopping');
-    try {
-      await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/stop/`, { method: 'POST' });
-    } catch (error) {
-      await this.handleRuntimeError(error);
-      this.setBusy('[data-screen-stop]', false, 'labelStop');
-      return;
-    }
-
-    const closeError = await releaseScreenShare(live, () => this.clearTimers());
-    this.live = null;
-
-    if (closeError) {
-      this.showError(closeError);
-    } else {
-      this.show('idle');
-    }
-    this.setBusy('[data-screen-stop]', false, 'labelStop');
+  private stop(): void {
+    const live = this.finishLocally('idle');
+    if (live) this.notifyRemoteStop(live);
   }
 
   private startTimers(): void {
@@ -179,11 +186,12 @@ export class ScreenShareController {
   }
 
   private async heartbeat(): Promise<void> {
-    if (!this.live) return;
+    const live = this.live;
+    if (!live || this.stopping) return;
     try {
-      await this.deps.requestJson(`/api/streams/${encodeURIComponent(this.live.id)}/heartbeat/`, { method: 'POST' });
+      await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/heartbeat/`, { method: 'POST' });
     } catch (error) {
-      await this.handleRuntimeError(error);
+      if (!this.stopping && this.live === live) this.handleRuntimeError(error);
     }
   }
 
@@ -202,12 +210,59 @@ export class ScreenShareController {
     this.showError(error);
   }
 
-  private async handleRuntimeError(error: unknown): Promise<void> {
+  private handleRuntimeError(error: unknown): void {
+    const live = this.finishLocally('error', error);
+    if (live) this.notifyRemoteStop(live);
+  }
+
+  private finishLocally(phase: 'idle' | 'error', error?: unknown): LiveStream | null {
+    if (this.stopping || !this.live) return null;
+    this.stopping = true;
+    this.startGeneration += 1;
     const live = this.live;
     this.live = null;
-    if (live) await releaseScreenShare(live, () => this.clearTimers());
-    else this.clearTimers();
-    this.showError(error);
+    releaseScreenShare(live, () => this.clearTimers());
+    if (phase === 'error') this.showError(error);
+    else this.show('idle');
+    return live;
+  }
+
+  private stopForPageHide(): void {
+    const live = this.finishLocally('idle');
+    this.startGeneration += 1;
+    this.stopping = true;
+    if (!live) return;
+    const stopUrl = streamStopUrl(live.id);
+    try {
+      if (!this.deps.sendBeacon(stopUrl)) void this.notifyServerStop(live.id);
+    } catch (error) {
+      console.warn('Failed to queue stream stop beacon', error);
+      void this.notifyServerStop(live.id);
+    }
+    this.notifyWhipDeletion(live);
+  }
+
+  private notifyRemoteStop(live: LiveStream): void {
+    void this.notifyServerStop(live.id);
+    this.notifyWhipDeletion(live);
+  }
+
+  private async notifyServerStop(id: string): Promise<void> {
+    try {
+      await this.deps.requestJson(streamStopUrl(id), { method: 'POST' });
+    } catch (error) {
+      console.warn('Failed to stop stream session remotely', error);
+    }
+  }
+
+  private notifyWhipDeletion(live: LiveStream): void {
+    void live.publisher.deleteResource().catch((error) => {
+      console.warn('Failed to delete WHIP resource', error);
+    });
+  }
+
+  private isActiveStart(generation: number): boolean {
+    return !this.stopping && this.startGeneration === generation;
   }
 
   private showError(error: unknown): void {
@@ -314,6 +369,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stopMedia(media: MediaStream): void {
   for (const track of media.getTracks()) track.stop();
+}
+
+function streamStopUrl(id: string): string {
+  return `/api/streams/${encodeURIComponent(id)}/stop/`;
 }
 
 function formatDuration(seconds: number): string {

--- a/web/src/lib/ui/whip-publisher.ts
+++ b/web/src/lib/ui/whip-publisher.ts
@@ -35,7 +35,10 @@ export function prioritizeH264(codecs: readonly RTCRtpCodec[]): RTCRtpCodec[] | 
 
 /** WHIP 接続を終了するために必要な操作を返す。 */
 export interface WhipPublisher {
-  close(): Promise<void>;
+  /** ローカルの RTCPeerConnection を同期的に閉じる。 */
+  close(): void;
+  /** WHIP resource を best-effort で削除する。 */
+  deleteResource(): Promise<void>;
   setPublishToken(publishToken: string): void;
 }
 
@@ -74,7 +77,9 @@ export async function startWhipPublisher(input: StartWhipPublisherInput): Promis
     return publisherFor(peerConnection, resourceUrl, input.publishToken, input.fetchImpl ?? fetch);
   } catch (error) {
     peerConnection.close();
-    if (resourceUrl) await deleteWhipResource(resourceUrl, input.publishToken, input.fetchImpl ?? fetch);
+    if (resourceUrl) {
+      void deleteWhipResource(resourceUrl, input.publishToken, input.fetchImpl ?? fetch);
+    }
     throw error;
   }
 }
@@ -149,17 +154,24 @@ function publisherFor(
   fetchImpl: typeof fetch
 ): WhipPublisher {
   let currentPublishToken = publishToken;
+  let closed = false;
+  let deletePromise: Promise<void> | null = null;
   return {
-    async close(): Promise<void> {
-      try {
-        const response = await fetchImpl(resourceUrl, {
+    close(): void {
+      if (closed) return;
+      closed = true;
+      peerConnection.close();
+    },
+    deleteResource(): Promise<void> {
+      if (!deletePromise) {
+        deletePromise = fetchImpl(resourceUrl, {
           method: 'DELETE',
           headers: { Authorization: `Bearer ${currentPublishToken}` },
+        }).then((response) => {
+          if (!response.ok) throw new WhipPublishError('WHIP_REQUEST_FAILED');
         });
-        if (!response.ok) throw new WhipPublishError('WHIP_REQUEST_FAILED');
-      } finally {
-        peerConnection.close();
       }
+      return deletePromise;
     },
     setPublishToken(nextPublishToken: string): void {
       currentPublishToken = nextPublishToken;

--- a/web/src/lib/ui/whip-publisher.ts
+++ b/web/src/lib/ui/whip-publisher.ts
@@ -1,0 +1,168 @@
+import { STREAM_WHIP_BASE_URL } from '../contracts/streams';
+
+/** WHIP publish 時にユーザーへ意味のある対処を示すための失敗種別。 */
+export type WhipPublishErrorCode = 'H264_UNAVAILABLE' | 'WHIP_REQUEST_FAILED' | 'WHIP_RESPONSE_INVALID';
+
+/** WHIP publish が開始できなかった理由を保持する。 */
+export class WhipPublishError extends Error {
+  constructor(readonly code: WhipPublishErrorCode) {
+    super('WHIP publish failed');
+  }
+}
+
+/** WHIP のセッション URL を、固定した配信オリジンから組み立てる。 */
+export function buildWhipUrl(streamId: string): string {
+  return `${STREAM_WHIP_BASE_URL}/${encodeURIComponent(streamId)}/whip`;
+}
+
+/** WHIP 応答の resource URL が、要求した同一配信オリジン配下か検証する。 */
+export function resolveWhipResourceUrl(location: string, streamId: string): string | null {
+  const endpoint = new URL(buildWhipUrl(streamId));
+  const resource = new URL(location, endpoint);
+  const resourcePrefix = `${endpoint.pathname}/`;
+  if (resource.origin !== endpoint.origin || !resource.pathname.startsWith(resourcePrefix)) {
+    return null;
+  }
+  return resource.toString();
+}
+
+/** WebRTC capability から H.264 を先頭にした優先順を返す。 */
+export function prioritizeH264(codecs: readonly RTCRtpCodec[]): RTCRtpCodec[] | null {
+  const h264 = codecs.filter((codec) => /\/h264$/i.test(codec.mimeType));
+  if (h264.length === 0) return null;
+  return [...h264, ...codecs.filter((codec) => !/\/h264$/i.test(codec.mimeType))];
+}
+
+/** WHIP 接続を終了するために必要な操作を返す。 */
+export interface WhipPublisher {
+  close(): Promise<void>;
+  setPublishToken(publishToken: string): void;
+}
+
+interface StartWhipPublisherInput {
+  stream: MediaStream;
+  streamId: string;
+  publishToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+const MAX_BITRATE = 1_500_000;
+const ICE_GATHERING_TIMEOUT_MS = 15_000;
+
+/** 選択済みの画面を H.264 固定で WHIP endpoint へ publish する。 */
+export async function startWhipPublisher(input: StartWhipPublisherInput): Promise<WhipPublisher> {
+  const track = input.stream.getVideoTracks()[0];
+  if (!track) throw new WhipPublishError('WHIP_RESPONSE_INVALID');
+
+  const preferredCodecs = videoCodecPreferences();
+  if (!preferredCodecs) throw new WhipPublishError('H264_UNAVAILABLE');
+
+  const peerConnection = new RTCPeerConnection({ iceServers: [] });
+  let resourceUrl: string | null = null;
+  try {
+    const transceiver = peerConnection.addTransceiver(track, { direction: 'sendonly' });
+    transceiver.setCodecPreferences(preferredCodecs);
+    await configureVideoSender(transceiver.sender);
+    // AVPro は Opus を再生できない。AAC 変換を持たない今回は音声を送出しない。
+    track.contentHint = 'text';
+
+    await peerConnection.setLocalDescription(await peerConnection.createOffer());
+    await waitForIceGathering(peerConnection);
+    const response = await publishOffer(peerConnection, input, input.fetchImpl ?? fetch);
+    resourceUrl = response.resourceUrl;
+    await peerConnection.setRemoteDescription({ type: 'answer', sdp: response.answerSdp });
+    return publisherFor(peerConnection, resourceUrl, input.publishToken, input.fetchImpl ?? fetch);
+  } catch (error) {
+    peerConnection.close();
+    if (resourceUrl) await deleteWhipResource(resourceUrl, input.publishToken, input.fetchImpl ?? fetch);
+    throw error;
+  }
+}
+
+function videoCodecPreferences(): RTCRtpCodec[] | null {
+  return prioritizeH264(RTCRtpSender.getCapabilities('video')?.codecs ?? []);
+}
+
+async function configureVideoSender(sender: RTCRtpSender): Promise<void> {
+  const parameters = sender.getParameters();
+  parameters.encodings = parameters.encodings?.length ? parameters.encodings : [{}];
+  parameters.encodings[0]!.maxBitrate = MAX_BITRATE;
+  parameters.degradationPreference = 'maintain-resolution';
+  await sender.setParameters(parameters);
+}
+
+async function waitForIceGathering(peerConnection: RTCPeerConnection): Promise<void> {
+  if (peerConnection.iceGatheringState === 'complete') return;
+
+  await new Promise<void>((resolve) => {
+    const timeout = globalThis.setTimeout(done, ICE_GATHERING_TIMEOUT_MS);
+    function done(): void {
+      globalThis.clearTimeout(timeout);
+      peerConnection.removeEventListener('icegatheringstatechange', onChange);
+      resolve();
+    }
+    function onChange(): void {
+      if (peerConnection.iceGatheringState === 'complete') done();
+    }
+    peerConnection.addEventListener('icegatheringstatechange', onChange);
+  });
+}
+
+async function publishOffer(
+  peerConnection: RTCPeerConnection,
+  input: StartWhipPublisherInput,
+  fetchImpl: typeof fetch
+): Promise<{ resourceUrl: string; answerSdp: string }> {
+  const response = await fetchImpl(buildWhipUrl(input.streamId), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${input.publishToken}`,
+      'Content-Type': 'application/sdp',
+    },
+    body: peerConnection.localDescription?.sdp,
+  });
+  if (response.status !== 201) throw new WhipPublishError('WHIP_REQUEST_FAILED');
+
+  const location = response.headers.get('Location');
+  const resourceUrl = location ? resolveWhipResourceUrl(location, input.streamId) : null;
+  if (!resourceUrl) throw new WhipPublishError('WHIP_RESPONSE_INVALID');
+  return { resourceUrl, answerSdp: await response.text() };
+}
+
+/** 後続の失敗で残った WHIP resource を best-effort で破棄する。 */
+async function deleteWhipResource(
+  resourceUrl: string,
+  publishToken: string,
+  fetchImpl: typeof fetch
+): Promise<void> {
+  try {
+    await fetchImpl(resourceUrl, { method: 'DELETE', headers: { Authorization: `Bearer ${publishToken}` } });
+  } catch {
+    // 元の publish 失敗を隠さず、PeerConnection は必ず閉じる。
+  }
+}
+
+function publisherFor(
+  peerConnection: RTCPeerConnection,
+  resourceUrl: string,
+  publishToken: string,
+  fetchImpl: typeof fetch
+): WhipPublisher {
+  let currentPublishToken = publishToken;
+  return {
+    async close(): Promise<void> {
+      try {
+        const response = await fetchImpl(resourceUrl, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${currentPublishToken}` },
+        });
+        if (!response.ok) throw new WhipPublishError('WHIP_REQUEST_FAILED');
+      } finally {
+        peerConnection.close();
+      }
+    },
+    setPublishToken(nextPublishToken: string): void {
+      currentPublishToken = nextPublishToken;
+    },
+  };
+}

--- a/web/src/pages/en/screen-share.astro
+++ b/web/src/pages/en/screen-share.astro
@@ -1,5 +1,5 @@
 ---
-import UseCaseArticle from '../../components/UseCaseArticle.astro';
+import ScreenSharePage from '../../components/ScreenSharePage.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { useTranslations } from '../../i18n';
 import { useCasePath } from '../../lib/use-cases';
@@ -11,9 +11,9 @@ const t = useTranslations(lang);
 
 <BaseLayout
   lang={lang}
-  title={t.useCases[page].title}
-  description={t.useCases[page].description}
+  title={t.screenSharePage.title}
+  description={t.screenSharePage.description}
   breadcrumb={[{ name: t.useCases[page].navLabel, path: useCasePath(lang, page) }]}
 >
-  <UseCaseArticle lang={lang} page={page} />
+  <ScreenSharePage lang={lang} />
 </BaseLayout>

--- a/web/src/pages/ja/screen-share.astro
+++ b/web/src/pages/ja/screen-share.astro
@@ -1,5 +1,5 @@
 ---
-import UseCaseArticle from '../../components/UseCaseArticle.astro';
+import ScreenSharePage from '../../components/ScreenSharePage.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { useTranslations } from '../../i18n';
 import { useCasePath } from '../../lib/use-cases';
@@ -11,9 +11,9 @@ const t = useTranslations(lang);
 
 <BaseLayout
   lang={lang}
-  title={t.useCases[page].title}
-  description={t.useCases[page].description}
+  title={t.screenSharePage.title}
+  description={t.screenSharePage.description}
   breadcrumb={[{ name: t.useCases[page].navLabel, path: useCasePath(lang, page) }]}
 >
-  <UseCaseArticle lang={lang} page={page} />
+  <ScreenSharePage lang={lang} />
 </BaseLayout>

--- a/web/tests/ui/screen-share.test.ts
+++ b/web/tests/ui/screen-share.test.ts
@@ -37,90 +37,299 @@ describe('配信のタイマー', () => {
 });
 
 describe('配信の後始末', () => {
-  test('WHIP の DELETE が失敗してもローカルの画面共有とタイマーを必ず止める', async () => {
-    let stopped = 0;
-    let timersCleared = 0;
-    const closeError = await releaseScreenShare(
+  test('ネットワークを待たずにタイマー・画面共有・PeerConnection をこの順で止める', () => {
+    const released: string[] = [];
+    releaseScreenShare(
       {
         publisher: {
-          close: async () => { throw new Error('network failure'); },
+          close: () => { released.push('peerConnection'); },
+          deleteResource: async () => undefined,
           setPublishToken: () => undefined,
         },
-        media: { getTracks: () => [{ stop: () => { stopped += 1; } }] } as unknown as MediaStream,
+        media: { getTracks: () => [{ stop: () => { released.push('media'); } }] } as unknown as MediaStream,
       },
-      () => { timersCleared += 1; }
+      () => { released.push('timers'); }
     );
 
-    expect(closeError).toBeInstanceOf(Error);
-    expect(stopped).toBe(1);
-    expect(timersCleared).toBe(1);
+    expect(released).toEqual(['timers', 'media', 'peerConnection']);
   });
 });
 
 describe('画面共有 controller', () => {
-  test('heartbeat・延長・通信失敗時の後始末を API 応答に従って実行する', async () => {
+  test('開始クリックから URL・配信中を経て停止クリックでローカル資源を解放する', async () => {
     const calls: string[] = [];
-    let token = '';
     let stopped = 0;
     let closed = 0;
-    const controls = new Map<string, { disabled?: boolean; textContent?: string; hidden?: boolean }>();
-    for (const selector of [
-      '[data-screen-extend]',
-      '[data-screen-stop]',
-      '[data-screen-elapsed]',
-      '[data-screen-expires]',
-      '[data-screen-expiry-warning]',
-      '[data-screen-error-message]',
-    ]) controls.set(selector, {});
-    const root = {
-      dataset: { labelExtending: 'extending', labelExtend: 'extend', msgGeneric: 'error' },
-      querySelector: (selector: string) => controls.get(selector) ?? null,
-      querySelectorAll: () => [],
-    } as unknown as HTMLElement;
+    let deleted = 0;
+    const page = fakeScreenSharePage();
     const publisher: WhipPublisher = {
-      close: async () => { closed += 1; },
-      setPublishToken: (value) => { token = value; },
+      close: () => { closed += 1; },
+      deleteResource: async () => { deleted += 1; },
+      setPublishToken: () => undefined,
     };
+    const videoTrack = {
+      addEventListener: () => undefined,
+      stop: () => { stopped += 1; },
+    };
+    const media = {
+      getTracks: () => [videoTrack],
+      getVideoTracks: () => [videoTrack],
+    } as unknown as MediaStream;
     const dependencies: ScreenShareDependencies = {
       requestJson: (async (path: string) => {
         calls.push(path);
-        if (path.endsWith('/extend/')) {
+        if (path === '/api/streams/') {
           return {
-            id: 'Ab12Cd34Ef56', status: 'live', publishToken: 'extended-token',
-            publishTokenExpiresAt: '2026-09-01T02:00:00.000Z',
-            extendExpiresAt: '2026-09-01T02:00:00.000Z',
+            id: 'Ab12Cd34Ef56', streamUrl: 'rtspt://webscreen.tv/live/Ab12Cd34Ef56',
+            status: 'live', publishToken: 'initial-token',
+            publishTokenExpiresAt: '2026-09-01T01:00:00.000Z',
+            extendExpiresAt: '2026-09-01T01:00:00.000Z',
+            startedAt: '2026-09-01T00:00:00.000Z', lastHeartbeatAt: '2026-09-01T00:00:00.000Z',
+            endedAt: null, endReason: null,
           };
         }
-        if (path.endsWith('/heartbeat/')) throw new Error('network failure');
-        return undefined;
+        return null;
       }) as unknown as ScreenShareDependencies['requestJson'],
       startWhipPublisher: async () => publisher,
-      getDisplayMedia: async () => ({ getTracks: () => [] }) as unknown as MediaStream,
+      getDisplayMedia: async () => media,
       now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+      sendBeacon: () => true,
+      onPageHide: () => undefined,
     };
-    const controller = new ScreenShareController(root, dependencies);
-    const live = {
-      id: 'Ab12Cd34Ef56', streamUrl: 'rtspt://webscreen.tv/live/Ab12Cd34Ef56',
-      publishToken: 'initial-token', publishTokenExpiresAt: '2026-09-01T01:00:00.000Z',
-      extendExpiresAt: '2026-09-01T01:00:00.000Z', status: 'live' as const,
-      startedAt: '2026-09-01T00:00:00.000Z', lastHeartbeatAt: '2026-09-01T00:00:00.000Z',
-      endedAt: null, endReason: null,
-      publisher,
-      media: { getTracks: () => [{ stop: () => { stopped += 1; } }] } as unknown as MediaStream,
-    };
-    (controller as unknown as { live: typeof live }).live = live;
+    const controller = new ScreenShareController(page.root, dependencies);
+    controller.mount();
 
-    await (controller as unknown as { extend: () => Promise<void> }).extend();
-    expect(token).toBe('extended-token');
-    expect(live.extendExpiresAt).toBe('2026-09-01T02:00:00.000Z');
+    page.button('[data-screen-start]').click();
+    expect(page.step('select').hidden).toBe(false);
 
-    await (controller as unknown as { heartbeat: () => Promise<void> }).heartbeat();
-    expect(calls).toEqual([
-      '/api/streams/Ab12Cd34Ef56/extend/',
-      '/api/streams/Ab12Cd34Ef56/heartbeat/',
-    ]);
+    page.button('[data-screen-select]').click();
+    await waitFor(() => !page.step('url').hidden);
+    expect(page.url.value).toBe('rtspt://webscreen.tv/live/Ab12Cd34Ef56');
+
+    page.button('[data-screen-show-live]').click();
+    expect(page.step('live').hidden).toBe(false);
+
+    page.button('[data-screen-stop]').click();
+    page.button('[data-screen-stop]').click();
     expect(closed).toBe(1);
     expect(stopped).toBe(1);
-    expect((controller as unknown as { live: unknown }).live).toBeNull();
+    expect(deleted).toBe(1);
+    expect(page.step('idle').hidden).toBe(false);
+    expect(calls).toEqual(['/api/streams/', '/api/streams/Ab12Cd34Ef56/stop/']);
+  });
+
+  test('pagehide では空 body の sendBeacon で停止を通知する', async () => {
+    const page = fakeScreenSharePage();
+    const beaconUrls: string[] = [];
+    let pageHide: (() => void) | undefined;
+    let stopped = 0;
+    const publisher: WhipPublisher = {
+      close: () => undefined,
+      deleteResource: async () => undefined,
+      setPublishToken: () => undefined,
+    };
+    const videoTrack = { addEventListener: () => undefined, stop: () => { stopped += 1; } };
+    const media = {
+      getTracks: () => [videoTrack],
+      getVideoTracks: () => [videoTrack],
+    } as unknown as MediaStream;
+    const dependencies: ScreenShareDependencies = {
+      requestJson: (async () => createResponse()) as unknown as ScreenShareDependencies['requestJson'],
+      startWhipPublisher: async () => publisher,
+      getDisplayMedia: async () => media,
+      now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+      sendBeacon: (url) => { beaconUrls.push(url); return true; },
+      onPageHide: (handler) => { pageHide = handler; },
+    };
+    new ScreenShareController(page.root, dependencies).mount();
+
+    page.button('[data-screen-start]').click();
+    page.button('[data-screen-select]').click();
+    await waitFor(() => !page.step('url').hidden);
+    pageHide?.();
+
+    expect(beaconUrls).toEqual(['/api/streams/Ab12Cd34Ef56/stop/']);
+    expect(stopped).toBe(1);
+  });
+
+  test('停止後に遅延した延長失敗が届いても error カードへ戻さない', async () => {
+    const page = fakeScreenSharePage();
+    const calls: string[] = [];
+    const delayedExtend = deferred<never>();
+    let closed = 0;
+    let deleted = 0;
+    let stopped = 0;
+    const publisher: WhipPublisher = {
+      close: () => { closed += 1; },
+      deleteResource: async () => { deleted += 1; },
+      setPublishToken: () => undefined,
+    };
+    const track = { addEventListener: () => undefined, stop: () => { stopped += 1; } };
+    const media = { getTracks: () => [track], getVideoTracks: () => [track] } as unknown as MediaStream;
+    const dependencies: ScreenShareDependencies = {
+      requestJson: ((path: string) => {
+        calls.push(path);
+        if (path === '/api/streams/') return Promise.resolve(createResponse());
+        if (path.endsWith('/extend/')) return delayedExtend.promise;
+        return Promise.resolve(null);
+      }) as unknown as ScreenShareDependencies['requestJson'],
+      startWhipPublisher: async () => publisher,
+      getDisplayMedia: async () => media,
+      now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+      sendBeacon: () => true,
+      onPageHide: () => undefined,
+    };
+    const controller = new ScreenShareController(page.root, dependencies);
+    controller.mount();
+    page.button('[data-screen-start]').click();
+    page.button('[data-screen-select]').click();
+    await waitFor(() => !page.step('url').hidden);
+    page.button('[data-screen-show-live]').click();
+    page.button('[data-screen-extend]').click();
+    await waitFor(() => calls.some((path) => path.endsWith('/extend/')));
+
+    page.button('[data-screen-stop]').click();
+    delayedExtend.reject(new Error('late failure'));
+    await flushMicrotasks();
+
+    expect(page.step('idle').hidden).toBe(false);
+    expect(page.step('error').hidden).toBe(true);
+    expect(closed).toBe(1);
+    expect(deleted).toBe(1);
+    expect(stopped).toBe(1);
+  });
+
+  test('pagehide が画面選択中でも後から取得された track を即座に停止する', async () => {
+    const page = fakeScreenSharePage();
+    const pendingMedia = deferred<MediaStream>();
+    let pageHide: (() => void) | undefined;
+    let stopped = 0;
+    let createRequests = 0;
+    let publisherStarts = 0;
+    const track = { addEventListener: () => undefined, stop: () => { stopped += 1; } };
+    const media = { getTracks: () => [track], getVideoTracks: () => [track] } as unknown as MediaStream;
+    const dependencies: ScreenShareDependencies = {
+      requestJson: (async () => {
+        createRequests += 1;
+        return createResponse();
+      }) as unknown as ScreenShareDependencies['requestJson'],
+      startWhipPublisher: async () => {
+        publisherStarts += 1;
+        throw new Error('publisher should not start');
+      },
+      getDisplayMedia: () => pendingMedia.promise,
+      now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+      sendBeacon: () => true,
+      onPageHide: (handler) => { pageHide = handler; },
+    };
+    new ScreenShareController(page.root, dependencies).mount();
+
+    page.button('[data-screen-start]').click();
+    page.button('[data-screen-select]').click();
+    pageHide?.();
+    pendingMedia.resolve(media);
+    await flushMicrotasks();
+
+    expect(stopped).toBe(1);
+    expect(createRequests).toBe(0);
+    expect(publisherStarts).toBe(0);
   });
 });
+
+function createResponse(): Record<string, unknown> {
+  return {
+    id: 'Ab12Cd34Ef56', streamUrl: 'rtspt://webscreen.tv/live/Ab12Cd34Ef56', status: 'live',
+    publishToken: 'initial-token', publishTokenExpiresAt: '2026-09-01T01:00:00.000Z',
+    extendExpiresAt: '2026-09-01T01:00:00.000Z', startedAt: '2026-09-01T00:00:00.000Z',
+    lastHeartbeatAt: '2026-09-01T00:00:00.000Z', endedAt: null, endReason: null,
+  };
+}
+
+function fakeScreenSharePage(): {
+  root: HTMLElement;
+  button: (selector: string) => FakeElement;
+  step: (phase: string) => FakeElement;
+  url: FakeElement;
+} {
+  const elements = new Map<string, FakeElement>();
+  for (const selector of [
+    '[data-screen-start]', '[data-screen-select]', '[data-screen-copy]', '[data-screen-show-live]',
+    '[data-screen-extend]', '[data-screen-stop]', '[data-screen-retry]', '[data-screen-url]',
+    '[data-screen-preview]', '[data-screen-elapsed]', '[data-screen-expires]',
+    '[data-screen-expiry-warning]', '[data-screen-error-message]',
+  ]) elements.set(selector, new FakeElement());
+  const steps = ['idle', 'select', 'login', 'url', 'live', 'error'].map((phase) => {
+    const step = new FakeElement();
+    step.dataset.screenStep = phase;
+    return step;
+  });
+  const indicators = ['1', '2', '3'].map((value) => {
+    const indicator = new FakeElement();
+    indicator.dataset.screenIndicator = value;
+    return indicator;
+  });
+  const root = {
+    dataset: {
+      labelSelect: 'select', labelSelecting: 'selecting', labelCopy: 'copy', labelCopied: 'copied',
+      labelExtend: 'extend', labelExtending: 'extending', labelStop: 'stop', labelStopping: 'stopping',
+      msgGeneric: 'error', msgH264: 'h264', msgWhip: 'whip', msgDisplayDenied: 'denied',
+      msgStreamAlreadyLive: 'already-live', msgRateLimited: 'rate-limited', msgStreamEnded: 'ended',
+    },
+    querySelector: (selector: string) => elements.get(selector) ?? null,
+    querySelectorAll: (selector: string) => {
+      if (selector === '[data-screen-step]') return steps;
+      if (selector === '[data-screen-indicator]') return indicators;
+      return [];
+    },
+  } as unknown as HTMLElement;
+  return {
+    root,
+    button: (selector) => elements.get(selector)!,
+    step: (phase) => steps.find((step) => step.dataset.screenStep === phase)!,
+    url: elements.get('[data-screen-url]')!,
+  };
+}
+
+class FakeElement {
+  dataset: Record<string, string> = {};
+  disabled = false;
+  hidden = false;
+  srcObject: MediaProvider | null = null;
+  textContent = '';
+  value = '';
+  private readonly listeners: Array<() => void> = [];
+
+  addEventListener(event: string, listener: () => void): void {
+    if (event === 'click') this.listeners.push(listener);
+  }
+
+  click(): void {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+type MediaProvider = MediaStream | null;
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (condition()) return;
+    await Promise.resolve();
+  }
+  throw new Error('Expected asynchronous UI update');
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/web/tests/ui/screen-share.test.ts
+++ b/web/tests/ui/screen-share.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  EXPIRY_WARNING_SECONDS,
+  HEARTBEAT_INTERVAL_MS,
+  isExpiryWarning,
+  nextStreamStep,
+  releaseScreenShare,
+  ScreenShareController,
+  secondsUntil,
+} from '../../src/lib/ui/screen-share';
+import type { ScreenShareDependencies } from '../../src/lib/ui/screen-share';
+import type { WhipPublisher } from '../../src/lib/ui/whip-publisher';
+
+describe('画面共有ウィザードの状態', () => {
+  test('配信 URL の確認後だけライブ画面へ進める', () => {
+    expect(nextStreamStep('url')).toBe('live');
+    expect(nextStreamStep('live')).toBeNull();
+  });
+});
+
+describe('配信のタイマー', () => {
+  test('heartbeat はサーバーの 60 秒タイムアウトより短い 25 秒間隔で送る', () => {
+    expect(HEARTBEAT_INTERVAL_MS).toBe(25_000);
+    expect(HEARTBEAT_INTERVAL_MS).toBeLessThan(60_000);
+  });
+
+  test('延長期限の残り時間と5分前の警告を境界どおり計算する', () => {
+    const now = Date.parse('2026-09-01T00:00:00.000Z');
+    const warningAt = new Date(now + EXPIRY_WARNING_SECONDS * 1000).toISOString();
+    const later = new Date(now + (EXPIRY_WARNING_SECONDS + 1) * 1000).toISOString();
+
+    expect(secondsUntil(warningAt, now)).toBe(EXPIRY_WARNING_SECONDS);
+    expect(isExpiryWarning(warningAt, now)).toBe(true);
+    expect(isExpiryWarning(later, now)).toBe(false);
+  });
+});
+
+describe('配信の後始末', () => {
+  test('WHIP の DELETE が失敗してもローカルの画面共有とタイマーを必ず止める', async () => {
+    let stopped = 0;
+    let timersCleared = 0;
+    const closeError = await releaseScreenShare(
+      {
+        publisher: {
+          close: async () => { throw new Error('network failure'); },
+          setPublishToken: () => undefined,
+        },
+        media: { getTracks: () => [{ stop: () => { stopped += 1; } }] } as unknown as MediaStream,
+      },
+      () => { timersCleared += 1; }
+    );
+
+    expect(closeError).toBeInstanceOf(Error);
+    expect(stopped).toBe(1);
+    expect(timersCleared).toBe(1);
+  });
+});
+
+describe('画面共有 controller', () => {
+  test('heartbeat・延長・通信失敗時の後始末を API 応答に従って実行する', async () => {
+    const calls: string[] = [];
+    let token = '';
+    let stopped = 0;
+    let closed = 0;
+    const controls = new Map<string, { disabled?: boolean; textContent?: string; hidden?: boolean }>();
+    for (const selector of [
+      '[data-screen-extend]',
+      '[data-screen-stop]',
+      '[data-screen-elapsed]',
+      '[data-screen-expires]',
+      '[data-screen-expiry-warning]',
+      '[data-screen-error-message]',
+    ]) controls.set(selector, {});
+    const root = {
+      dataset: { labelExtending: 'extending', labelExtend: 'extend', msgGeneric: 'error' },
+      querySelector: (selector: string) => controls.get(selector) ?? null,
+      querySelectorAll: () => [],
+    } as unknown as HTMLElement;
+    const publisher: WhipPublisher = {
+      close: async () => { closed += 1; },
+      setPublishToken: (value) => { token = value; },
+    };
+    const dependencies: ScreenShareDependencies = {
+      requestJson: (async (path: string) => {
+        calls.push(path);
+        if (path.endsWith('/extend/')) {
+          return {
+            id: 'Ab12Cd34Ef56', status: 'live', publishToken: 'extended-token',
+            publishTokenExpiresAt: '2026-09-01T02:00:00.000Z',
+            extendExpiresAt: '2026-09-01T02:00:00.000Z',
+          };
+        }
+        if (path.endsWith('/heartbeat/')) throw new Error('network failure');
+        return undefined;
+      }) as unknown as ScreenShareDependencies['requestJson'],
+      startWhipPublisher: async () => publisher,
+      getDisplayMedia: async () => ({ getTracks: () => [] }) as unknown as MediaStream,
+      now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+    };
+    const controller = new ScreenShareController(root, dependencies);
+    const live = {
+      id: 'Ab12Cd34Ef56', streamUrl: 'rtspt://webscreen.tv/live/Ab12Cd34Ef56',
+      publishToken: 'initial-token', publishTokenExpiresAt: '2026-09-01T01:00:00.000Z',
+      extendExpiresAt: '2026-09-01T01:00:00.000Z', status: 'live' as const,
+      startedAt: '2026-09-01T00:00:00.000Z', lastHeartbeatAt: '2026-09-01T00:00:00.000Z',
+      endedAt: null, endReason: null,
+      publisher,
+      media: { getTracks: () => [{ stop: () => { stopped += 1; } }] } as unknown as MediaStream,
+    };
+    (controller as unknown as { live: typeof live }).live = live;
+
+    await (controller as unknown as { extend: () => Promise<void> }).extend();
+    expect(token).toBe('extended-token');
+    expect(live.extendExpiresAt).toBe('2026-09-01T02:00:00.000Z');
+
+    await (controller as unknown as { heartbeat: () => Promise<void> }).heartbeat();
+    expect(calls).toEqual([
+      '/api/streams/Ab12Cd34Ef56/extend/',
+      '/api/streams/Ab12Cd34Ef56/heartbeat/',
+    ]);
+    expect(closed).toBe(1);
+    expect(stopped).toBe(1);
+    expect((controller as unknown as { live: unknown }).live).toBeNull();
+  });
+});

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+
+import { STREAM_WHIP_BASE_URL } from '../../src/lib/contracts/streams';
+import {
+  buildWhipUrl,
+  prioritizeH264,
+  resolveWhipResourceUrl,
+  startWhipPublisher,
+} from '../../src/lib/ui/whip-publisher';
+
+describe('WHIP publisher', () => {
+  test('固定済みの配信オリジンから stream ID ごとの WHIP URL を作る', () => {
+    expect(buildWhipUrl('Ab12Cd34Ef56')).toBe(`${STREAM_WHIP_BASE_URL}/Ab12Cd34Ef56/whip`);
+  });
+
+  test('H.264 を最優先にし、H.264 が無ければ開始不可を示す', () => {
+    const codecs = [
+      { mimeType: 'video/VP8' },
+      { mimeType: 'video/H264' },
+      { mimeType: 'video/rtx' },
+    ] as RTCRtpCodec[];
+
+    expect(prioritizeH264(codecs)?.map((codec) => codec.mimeType)).toEqual([
+      'video/H264',
+      'video/VP8',
+      'video/rtx',
+    ]);
+    expect(prioritizeH264([{ mimeType: 'video/VP9' }] as RTCRtpCodec[])).toBeNull();
+  });
+
+  test('WHIP resource は要求した配信オリジンとパス配下だけを許可する', () => {
+    expect(resolveWhipResourceUrl('/live/Ab12Cd34Ef56/whip/resource', 'Ab12Cd34Ef56')).toBe(
+      'https://webscreen.tv/live/Ab12Cd34Ef56/whip/resource'
+    );
+    expect(resolveWhipResourceUrl('https://attacker.example/resource', 'Ab12Cd34Ef56')).toBeNull();
+    expect(resolveWhipResourceUrl('/live/other/whip/resource', 'Ab12Cd34Ef56')).toBeNull();
+  });
+
+  test('WHIP の POST と DELETE は最新 publish token を Authorization に使う', async () => {
+    const previousSender = globalThis.RTCRtpSender;
+    const previousConnection = globalThis.RTCPeerConnection;
+    const requests: RequestInit[] = [];
+    class Sender {
+      static getCapabilities() {
+        return { codecs: [{ mimeType: 'video/H264' }] };
+      }
+    }
+    class Connection {
+      iceGatheringState: RTCIceGatheringState = 'complete';
+      localDescription = { sdp: 'offer', type: 'offer' } as RTCSessionDescription;
+      addTransceiver() {
+        return {
+          setCodecPreferences: () => undefined,
+          sender: {
+            getParameters: () => ({}),
+            setParameters: async () => undefined,
+          },
+        } as unknown as RTCRtpTransceiver;
+      }
+      async createOffer() { return { sdp: 'offer', type: 'offer' } as RTCSessionDescriptionInit; }
+      async setLocalDescription() {}
+      async setRemoteDescription() {}
+      close() {}
+      addEventListener() {}
+      removeEventListener() {}
+    }
+    Object.defineProperty(globalThis, 'RTCRtpSender', { configurable: true, value: Sender });
+    Object.defineProperty(globalThis, 'RTCPeerConnection', { configurable: true, value: Connection });
+    try {
+      const publisher = await startWhipPublisher({
+        stream: { getVideoTracks: () => [{ contentHint: '', stop() {} }] } as unknown as MediaStream,
+        streamId: 'Ab12Cd34Ef56',
+        publishToken: 'first-token',
+        fetchImpl: (async (_url, options) => {
+          requests.push(options ?? {});
+          if (options?.method === 'POST') {
+            return new Response('answer', {
+              status: 201,
+              headers: { Location: '/live/Ab12Cd34Ef56/whip/resource' },
+            });
+          }
+          return new Response(null, { status: 204 });
+        }) as typeof fetch,
+      });
+      publisher.setPublishToken('extended-token');
+      await publisher.close();
+      expect(requests[0]?.headers).toMatchObject({ Authorization: 'Bearer first-token' });
+      expect(requests[1]?.headers).toMatchObject({ Authorization: 'Bearer extended-token' });
+    } finally {
+      Object.defineProperty(globalThis, 'RTCRtpSender', { configurable: true, value: previousSender });
+      Object.defineProperty(globalThis, 'RTCPeerConnection', { configurable: true, value: previousConnection });
+    }
+  });
+});

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -36,13 +36,22 @@ describe('WHIP publisher', () => {
     expect(resolveWhipResourceUrl('/live/other/whip/resource', 'Ab12Cd34Ef56')).toBeNull();
   });
 
-  test('WHIP の POST と DELETE は最新 publish token を Authorization に使う', async () => {
+  test('H.264 と映像送出パラメータを設定し、DELETE は最新 token を1回だけ使う', async () => {
     const previousSender = globalThis.RTCRtpSender;
     const previousConnection = globalThis.RTCPeerConnection;
     const requests: RequestInit[] = [];
+    let codecPreferences: RTCRtpCodec[] | undefined;
+    let senderParameters: RTCRtpSendParameters | undefined;
+    let closed = 0;
     class Sender {
       static getCapabilities() {
-        return { codecs: [{ mimeType: 'video/H264' }] };
+        return {
+          codecs: [
+            { mimeType: 'video/VP8' },
+            { mimeType: 'video/H264' },
+            { mimeType: 'video/rtx' },
+          ],
+        };
       }
     }
     class Connection {
@@ -50,17 +59,17 @@ describe('WHIP publisher', () => {
       localDescription = { sdp: 'offer', type: 'offer' } as RTCSessionDescription;
       addTransceiver() {
         return {
-          setCodecPreferences: () => undefined,
+          setCodecPreferences: (codecs: RTCRtpCodec[]) => { codecPreferences = codecs; },
           sender: {
             getParameters: () => ({}),
-            setParameters: async () => undefined,
+            setParameters: async (parameters: RTCRtpSendParameters) => { senderParameters = parameters; },
           },
         } as unknown as RTCRtpTransceiver;
       }
       async createOffer() { return { sdp: 'offer', type: 'offer' } as RTCSessionDescriptionInit; }
       async setLocalDescription() {}
       async setRemoteDescription() {}
-      close() {}
+      close() { closed += 1; }
       addEventListener() {}
       removeEventListener() {}
     }
@@ -83,9 +92,24 @@ describe('WHIP publisher', () => {
         }) as typeof fetch,
       });
       publisher.setPublishToken('extended-token');
-      await publisher.close();
+      publisher.close();
+      await publisher.deleteResource();
+      await publisher.deleteResource();
+
+      expect(codecPreferences?.[0]?.mimeType).toBe('video/H264');
+      expect(codecPreferences?.map((codec) => codec.mimeType)).toEqual([
+        'video/H264',
+        'video/VP8',
+        'video/rtx',
+      ]);
+      expect(senderParameters).toMatchObject({
+        encodings: [{ maxBitrate: 1_500_000 }],
+        degradationPreference: 'maintain-resolution',
+      });
       expect(requests[0]?.headers).toMatchObject({ Authorization: 'Bearer first-token' });
       expect(requests[1]?.headers).toMatchObject({ Authorization: 'Bearer extended-token' });
+      expect(requests).toHaveLength(2);
+      expect(closed).toBe(1);
     } finally {
       Object.defineProperty(globalThis, 'RTCRtpSender', { configurable: true, value: previousSender });
       Object.defineProperty(globalThis, 'RTCPeerConnection', { configurable: true, value: previousConnection });


### PR DESCRIPTION
## なぜこの変更が必要か

「vrc 画面共有」系クエリは 3 か月で表示 1,831 回・CTR 約 2.5% と伸びしろが最大級で、旧 `/streaming/`（クリック数サイト 1 位）の 301 評価も `/screen-share/` に集まっている。しかし現在のページは「画面共有はできないので動画変換で代替」という記事で、検索意図に応えられていない。MediaMTX 本番サーバー（#126）と配信セッション API（#127 / PR #142）が揃ったため、実際に「ブラウザだけで VRChat に画面共有」できる機能ページへ置き換える。

## 変更内容

- `/{lang}/screen-share/`（ja / en）をカード切替型ウィザードの機能ページへ置換: 開始 → 画面選択 → URL コピー → 配信中（プレビュー・残り時間・延長・停止・期限 5 分前警告）。未ログイン時は Discord ログイン誘導
- WHIP publisher を lib 化（`web/src/lib/ui/whip-publisher.ts`）: H.264 最優先固定（R1/R2）・contentHint='text' + maintain-resolution（R10）・1080p・1.5Mbps。音声は送らない（WebRTC は Opus で AVPro が再生不可のため。→ #145）
- heartbeat 25 秒間隔 / pagehide で stop beacon / 停止はローカル解放先行 + 冪等化
- SEO: title「VRChat で画面共有する方法 — OBS 不要・ブラウザだけ」、使い方 3 ステップ（画像プレースホルダ）・特徴・FAQ・旧記事の解説統合・動画変換への導線。文言はすべて i18n 辞書
- `docs/streaming/requirements.md` の画面取得を「既定ピッカー」に更新（preferCurrentTab は PoC 用だったため）

## 意思決定

### 採用アプローチ
- カード切替型（Hero のカード内だけが遷移）を採用。理由: 1 画面 1 目的と SEO コンテンツ常時表示を両立し、実装も最小（ユーザー選択 2026-09-01）

### 却下した代替案
- フルスクリーンウィザード → 却下: 配信中に SEO コンテンツが見えなくなる
- 新 URL（/live/ 等） → 却下: 旧 /streaming/ の 301 評価継承を失う
- 音声の同時対応 → 却下: サーバー側 AAC 変換が未実装（#145 へ分離）

### トレードオフ
- 検索意図への一致 > 変換記事の温存: 旧記事の解説は FAQ 下へ要約統合し、変換への導線は残した

## テスト

- [x] bun test 692 pass / typecheck / architecture gate 違反 0
- [x] SEO E2E（e2e/seo.spec.ts）55 pass（新タイトルへ更新）
- [x] レビューゲート: codex sol 2 レーン（セキュリティ指摘なし / 通常 5 件 → high 1 + medium 3 修正、1 件は #144 へ分離）
- [ ] 本番での実配信 E2E（マージ後に webscreen.tv で実施）

## Screenshot

| Before | After |
|--------|-------|
| ![before-ja-screen-share](https://agent-toolbox-assets.kaisha3.com/uploads/2026/09/e17ec2860d6a-before-ja-screen-share.avif) | ![after-ja-screen-share](https://agent-toolbox-assets.kaisha3.com/uploads/2026/09/580bbac69698-after-ja-screen-share.avif) |

Closes #128

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
