### PR TITLE
feat: R2 バケットを webscreen へ改名（参照切替）

### DIFF
--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -1,6 +1,6 @@
 # 動画配信（R2）の構成
 
-動画の実体は R2 バケット `webscreen-beta` にあり、**2 つの経路で公開されている**。URL は保存値ではなく毎回 `vars.R2_PUBLIC_BASE_URL` から組み立てる（`web/src/lib/contracts/r2key.ts` の `movieUrl()`）。入力は `web/wrangler.jsonc` の同 var で、保持期間バッチが同じ URL を purge するため `web/cron/wrangler.jsonc` にも同じ値を置いている（下の「削除とキャッシュ」節）。
+動画の実体は R2 バケット `webscreen` にあり、**2 つの経路で公開されている**。URL は保存値ではなく毎回 `vars.R2_PUBLIC_BASE_URL` から組み立てる（`web/src/lib/contracts/r2key.ts` の `movieUrl()`）。入力は `web/wrangler.jsonc` の同 var で、保持期間バッチが同じ URL を purge するため `web/cron/wrangler.jsonc` にも同じ値を置いている（下の「削除とキャッシュ」節）。
 
 | 経路 | URL | 用途 | 無効化してよいか |
 |---|---|---|---|
@@ -22,7 +22,7 @@ WebScreen では VRChat のワールド内で複数人が同時に同じ動画�
 
 | 設定 | 管理場所 | 内容 |
 |---|---|---|
-| R2 Custom Domain | ダッシュボード | バケット `webscreen-beta` に `cdn.web-screen.net` を接続（Active） |
+| R2 Custom Domain | ダッシュボード | バケット `webscreen` に `cdn.web-screen.net` を接続（Active） |
 | Transform Rule `cdn: noindex for media` | ダッシュボード | `http.host eq "cdn.web-screen.net"` のとき `X-Robots-Tag: noindex` を付与 |
 | **R2 の CORS** | **`web/r2-cors.json`** | 下記「CORS」節 |
 
@@ -39,8 +39,8 @@ WebScreen では VRChat のワールド内で複数人が同時に同じ動画�
 設定の正本は `web/r2-cors.json`。反映はこのコマンド:
 
 ```bash
-cd web && bunx wrangler r2 bucket cors set webscreen-beta --file r2-cors.json
-bunx wrangler r2 bucket cors list webscreen-beta   # 確認
+cd web && bunx wrangler r2 bucket cors set webscreen --file r2-cors.json
+bunx wrangler r2 bucket cors list webscreen   # 確認
 ```
 
 **サイトのオリジンが増減したら必ずここも直す。** 2026-08-27 の本番ドメイン切替では、`https://web-screen.net` の登録漏れで変換が全滅した（`presign` は 200 を返すのに R2 への PUT だけが CORS エラーになるため、原因が分かりにくい）。
@@ -69,7 +69,7 @@ PUT の署名 URL は 5 分有効。ブラウザから `Content-Length` を固�
 
 アプリの commit・abandon・保持期間バッチが `tmp/` の主掃除主体で、R2 Lifecycle は D1 行が消えた後の遅延 PUT や継続的な R2 障害に対する最終安全網にする。Cloudflare ダッシュボードで次のルールを設定する。
 
-1. R2 Object Storage から対象バケット `webscreen-beta` を開く。
+1. R2 Object Storage から対象バケット `webscreen` を開く。
 2. Settings → Object lifecycle rules → Add rule を選ぶ。
 3. prefix を `tmp/`、action を object expiration、期間を 1 day にする。
 4. 保存後、ルールが Enabled で prefix が `tmp/` に限定されていることを確認する。
@@ -80,7 +80,7 @@ PUT の署名 URL は 5 分有効。ブラウザから `Content-Length` を固�
 
 `captures/{uuid}/{index}.{png|jpg}`（web-capture が置く動画化の中間物。拡張子は web-capture の設定で決まる。撮影を速くするため JPEG へ移行中で、掃除も取り込みも拡張子を見ないので混在しても問題ない）を消すのは **WebScreen の cron だけ**（`web/cron/` の Worker が `web/src/lib/services/retention-captures.ts` を毎時 17 分に実行し、アップロードから 24 時間経過したものを 1 回あたり最大 1000 件・list 10 ページまで削除する。残りは次の実行が拾う）。`tmp/` 専用ルールと違い、**`captures/` に R2 Lifecycle rule は使わない**。掃除を別の場所へ移す時は、この節と `retention-captures.ts` の両方を同時に直すこと。
 
-掃除対象バケット名の正本は **`web/cron/wrangler.jsonc` の `r2_buckets`**（現在 `webscreen-beta`）。web-capture 側の書き込み先（Cloud Run の環境変数 `R2_BUCKET`）が**これと一致していることが契約**で、ずれると中間のキャプチャ画像は誰にも消されず増え続ける（気づけるのは請求だけ）。2026-08-30 に `gcloud run services describe web-capture` で一致を確認済み。どちらかを変える時は両方同時に変える。
+掃除対象バケット名の正本は **`web/cron/wrangler.jsonc` の `r2_buckets`**（現在 `webscreen`。2026-09-01 に webscreen-beta から改名）。web-capture 側の書き込み先（Cloud Run の環境変数 `R2_BUCKET`）が**これと一致していることが契約**で、ずれると中間のキャプチャ画像は誰にも消されず増え続ける（気づけるのは請求だけ）。2026-08-30 に `gcloud run services describe web-capture` で一致を確認済み。どちらかを変える時は両方同時に変える。
 
 ## 削除とキャッシュ
 

--- a/web/cron/wrangler.jsonc
+++ b/web/cron/wrangler.jsonc
@@ -46,7 +46,7 @@
   "r2_buckets": [
     {
       "binding": "BUCKET",
-      "bucket_name": "webscreen-beta"
+      "bucket_name": "webscreen"
     }
   ]
 }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -44,7 +44,7 @@ const seedCommand = [
   `bunx wrangler d1 migrations apply webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR}`,
   `bunx wrangler d1 execute webscreen-beta-db --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/seed.sql`,
   // ダウンロード経路は R2 の実体を読むため、seed した行に対応するオブジェクトも置く。
-  `bunx wrangler r2 object put webscreen-beta/movies/${E2E_FIXTURES.readyShortId}.mp4 --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/sample.mp4 --content-type=video/mp4`,
+  `bunx wrangler r2 object put webscreen/movies/${E2E_FIXTURES.readyShortId}.mp4 --local -c wrangler.jsonc --persist-to ${STATE_DIR} --file=e2e/fixtures/sample.mp4 --content-type=video/mp4`,
   `bunx wrangler dev -c dist/server/wrangler.json --persist-to ${STATE_DIR} --port ${PORT} --inspector-port ${INSPECTOR_PORT} --var SESSION_SIGNING_KEY:${E2E_SESSION_SIGNING_KEY}`,
 ].join(' && ');
 

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -18,7 +18,7 @@
   },
   "vars": {
     "R2_ACCOUNT_ID": "65850b2bd0055921bdcfbe42383c794a",
-    "R2_BUCKET_NAME": "webscreen-beta",
+    "R2_BUCKET_NAME": "webscreen",
     // 動画の配信元。r2.dev は Cloudflare が「rate-limited / non-production traffic」と
     // 明記する開発専用エンドポイントで、VRChat のワールド内で複数人が同時に取得する
     // 本番用途には耐えない。Custom Domain 経由にするとキャッシュが効き、WAF も使える。
@@ -49,7 +49,7 @@
   "r2_buckets": [
     {
       "binding": "BUCKET",
-      "bucket_name": "webscreen-beta"
+      "bucket_name": "webscreen"
     }
   ],
   // /api/health/ が自分のバージョンを名乗るために使う。デプロイ直後の疎通確認で


### PR DESCRIPTION
## なぜこの変更が必要か

バケット名 `webscreen-beta` を製品名に合わせて `webscreen` へ改名する（ユーザー指示・2026-09-01）。R2 に rename は無いため「新規作成 → コピー → 参照切替 → ドメイン付替え」で行う。

## 変更内容

- `bucket_name` / `R2_BUCKET_NAME`（web + cron）と playwright のローカル fixture、docs/r2-delivery.md を `webscreen` へ切替
- 新バケットは作成・CORS・Lifecycle（tmp/ 1 日）設定済み。全 81 オブジェクト（126 MB）を CopyObject（メタデータ COPY）でコピー済み

## 切替手順（マージ後に実施）

1. デプロイ完了 → web-capture の `R2_BUCKET` を gcloud で更新（producer/consumer 同時切替の契約）
2. 差分コピー → cdn.web-screen.net のカスタムドメインを新バケットへ付替え
3. 外形確認（既存動画の再生・新規変換の一気通貫）。旧バケットは数日並走後に削除判断

## テスト

- [x] bun test 694 pass / typecheck
- [x] コピー後の head-object で ContentType 維持を確認（aws s3 sync のマルチパートで一度欠落 → CopyObject でやり直し済み）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
