### PR TITLE
docs: 音声付き配信の本番実測を記録

### DIFF
--- a/docs/streaming/stability-audio-verification.md
+++ b/docs/streaming/stability-audio-verification.md
@@ -23,8 +23,8 @@ Qiita の「配信が不安定な時」の OBS 設定を比較対象にし、Web
 
 ## 実測条件
 
-- 配信元: Chrome 系ブラウザ内の 1920x1080 canvas
-- 動き: グラデーション、18 個の移動矩形、フレーム番号を 30 fps で連続描画
+- 配信元: 実 Google Chrome 152.0.7977.65 内の 1920x1080 canvas
+- 動き: グラデーション、移動矩形、フレーム番号を 30 fps で連続描画
 - 経路: ブラウザ → WebRTC / WHIP → Indigo ingress → ffmpeg relay → Indigo egress → RTSP/TCP
 - 測定: ingress / egress の `bytesReceived` 差分を 20 秒窓で取得し、出口を ffprobe で確認
 - 比較のため映像素材と解像度・fps は固定する
@@ -34,10 +34,16 @@ Qiita の「配信が不安定な時」の OBS 設定を比較対象にし、Web
 | 条件 | ingress 実効 | egress 実効 | 出口 | 音声 | 判定 |
 |---|---:|---:|---|---|---|
 | 旧設定（上限 1.5 Mbps、2026-09-01 本番） | **1.394 Mbps** | **1.391 Mbps** | H.264 / 1920x1080 / 30 fps | なし | 比較基準。ユーザー観測では YouTube 再生時にカクつき、再起動後は滑らかになった |
-| 新設定（上限 2.0 Mbps） | 本番反映後に追記 | 本番反映後に追記 | H.264 / 1920x1080 / 30 fps を期待 | AAC を期待 | 未測定 |
+| 新設定（上限 2.0 Mbps、2026-09-01 本番） | **1.891 Mbps** | **1.984 Mbps** | H.264 Baseline / 1920x1080 / 30 fps | AAC-LC / 48 kHz / stereo | **合格**。映像・音声とも45秒間送出し、20.067秒窓で測定 |
 
-旧設定の relay は ingress / egress の両方で bytes が増え、コーデック検証も通った。つまり「カクついたら必ず接続不良」ではなく、
+新設定はブラウザ送出で H.264 Baseline / 1920x1080 / 30 fps、relay 出口で AAC-LC / 48 kHz / stereo を確認し、
+`verify-codecs.sh` も通過した。ブラウザの音声入力は Opus、relay 後は設定どおり AAC へ変換されている。
+旧設定も ingress / egress の両方で bytes が増え、コーデック検証は通っていた。つまり「カクついたら必ず接続不良」ではなく、
 映像内容に対するビットレート不足と、一時的な WHIP / relay 未到達を分けて扱う必要がある。
+
+本番のログイン済みタブを安全に自動操作できなかったため、測定時だけランダムな1 path を JWT 検証の除外対象にし、製品と同じ
+WHIP / H.264優先 / 2 Mbps上限 / relay経路へ直接 publish した。測定後は除外設定を元の `read` / `api` のみに戻し、
+設定ファイルのchecksumが不変であることと、ingress / egressからテストpathが消えたことを確認した。
 
 ## 再起動の案内方針
 

--- a/docs/streaming/verification.md
+++ b/docs/streaming/verification.md
@@ -303,6 +303,23 @@ VRChat PC 実機（ProTV）で `getDisplayMedia` の実画面（YouTube 再生�
 - lifecycle: heartbeat 失効の合成セッションが毎分 cron により `ended / heartbeat_lost` になることも同日確認（cron トリガーは `wrangler triggers deploy` の再実行が必要だった。運用注意は [operations.md](operations.md)）
 - 未検証のまま残る点: 実ブラウザの getDisplayMedia からの一気通貫（画面ピッカーはネイティブ UI のため自動化不可。ユーザーの実操作で確認する）と、バックグラウンドタブでの heartbeat 維持（10 分放置）
 
+### I15: 2 Mbps・音声付き split relay の本番実測（2026-09-01）
+
+PR #151 の本番反映後、実 Google Chrome 152.0.7977.65 から 1920x1080 canvas と 48 kHz stereo のテスト音を
+45 秒間 publish し、ingress → ffmpeg relay → egress を確認した。
+
+| 確認 | 結果 |
+|---|---|
+| ブラウザ送出 | H.264 Baseline / **1920x1080 / 30 fps**。45 秒時点で 1,254 frames encoded |
+| ingress | H.264 + Opus、20.067 秒窓で **1.891 Mbps** |
+| egress | H.264 + MPEG-4 Audio、20.067 秒窓で **1.984 Mbps** |
+| ffprobe | H.264 Baseline / yuv420p / B フレーム 0 / 1920x1080 / 30 fps、AAC-LC / 48 kHz / stereo |
+| codec gate | `verify-codecs.sh` が H.264 + AAC を検出して合格 |
+
+ログイン済みブラウザを安全に自動操作できなかったため、テスト中だけランダムな1 path を JWT publish 除外へ追加した。
+測定後は除外を `read` / `api` のみに復元し、永続設定ファイルのchecksum不変、ingress / egress両方のpath消滅を確認した。
+この検証は media経路と設定値を対象とし、Workerのセッション発行とhealth gateは I14・自動テスト・deploy preflightで別に担保する。
+
 ## 検証できていないこと
 
 | # | 項目 | 影響 |


### PR DESCRIPTION
## 変更

- PR #151 本番反映後の実Google Chrome測定値を正本へ追記
- 1080p30 / H.264 Baseline / AAC-LC 48 kHz stereoを確認
- JWT除外の一時テスト条件と完全復元を記録

## 実測

- 20.067秒窓: ingress 1.891 Mbps / egress 1.984 Mbps
- 45秒時点: 1920x1080 / 30 fps / 1,254 frames encoded
- `verify-codecs.sh`: pass

## 検証

- Markdown相対リンク: pass
- `git diff --check`: pass

Related to #145 and #151