### PR TITLE
docs: セッション知見の暗黙値を coding-conventions / local-dev に正本化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ bunx playwright test # E2E（wrangler dev を立てて実行）
 
 `web/.dev.vars` にローカル用の環境変数が要る（`.dev.vars.example` を参照）。
 
-- dev サーバーは常駐型。多重起動の警告が出たら `bunx astro dev stop`。ページが vite の deps_ssr エラーを返す時は `rm -rf node_modules/.vite` してから再起動
+- ローカル環境・E2E の落とし穴（dev サーバー復旧・ポート分離・Claude Code サンドボックス）は [docs/local-dev.md](docs/local-dev.md)
 
 ## デプロイ
 
@@ -71,6 +71,8 @@ main への push で GitHub Actions が本番へ反映する（`.github/workflow
 | 動画のエンコード条件（VRChat 互換） | [docs/encode-contract.md](docs/encode-contract.md) |
 | R2 の配信とキャッシュ | [docs/r2-delivery.md](docs/r2-delivery.md) |
 | 表示文言 | `web/src/i18n/ja.json` / `en.json` |
+| 実装コンベンション（D1 条件付き更新・R2 etag・Workers 間通信・SSG の時刻） | [docs/coding-conventions.md](docs/coding-conventions.md) |
+| ローカル開発・E2E（ポート分離・サンドボックス） | [docs/local-dev.md](docs/local-dev.md) |
 | ライブ配信の設計・検証 | [docs/streaming/](docs/streaming/) |
 | 配信サーバーの本番構成・運用（サーバー実体・secrets・移設・cron 検証） | [docs/streaming/operations.md](docs/streaming/operations.md) |
 
@@ -81,6 +83,7 @@ main への push で GitHub Actions が本番へ反映する（`.github/workflow
 - **VRChat 互換のエンコード条件を変えない**（全キーフレーム `-g 1 -bf 0`。変えると再生できなくなる）
 - 変換した動画とキャプチャ画像は**公開**（認証なしで取得できる）。保護は 12 文字のランダム ID だけ
 - ブラウザ内変換は FFmpeg.wasm を使うため COOP/COEP ヘッダーが要る（`web/src/middleware.ts`）
+- **D1 の条件付き更新（期限・容量・上限）は事前 SELECT で判定せず WHERE で守る**（詳細: [docs/coding-conventions.md](docs/coding-conventions.md)）
 
 ## Review guidelines
 

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -1,0 +1,39 @@
+# 実装コンベンション
+
+レビューの往復で確立した、このリポ固有の書き方の規約。API の契約は [`web/src/lib/contracts/api.ts`](../web/src/lib/contracts/api.ts)、R2 の配信設計は [r2-delivery.md](r2-delivery.md) が正本で、ここには「同じ指摘を二度受けないための書き方」だけを置く。
+
+## D1 の条件付き更新
+
+期限・容量・件数上限など「条件を満たす時だけ書き込む」処理は、**事前 SELECT で判定してから無条件に書き込む形にしない**。判定と書き込みの間に条件が変わる（保持期間バッチとユーザー操作が同じ行を触るため、実際に競合が再現している）。
+
+- 条件は UPDATE / INSERT の **WHERE に集約**し、`meta.changes === 0` で拒否を判定する。容量予約は `INSERT ... SELECT ... WHERE` の 0 行判定で行う
+- 時刻の条件は **`datetime('now')`（DB の実行時刻）で評価**する。アプリ側で取った `now` をバインドすると、バインド時刻と実行時刻の間の窓が残る（実 SQL で再現済み）
+- **更新 0 件を必ず分岐**する。0 件を成功として返すと、画面は成功なのに実体が変わらない。0 件の理由は複数ある（期限切れ / 行が消えた / 上限超過）ので、その稀な経路でだけ読み直して 4xx を出し分ける
+- 事前 SELECT は消さなくてよいが、役割は「エラー理由の優先順位付け」であって競合防止ではない。競合を防ぐのは WHERE の方だと分けて書く
+
+テストの注意: フェイク DB は SQL の中身を見ないと回帰を検出できない（`datetime('now')` をバインド値に戻しても緑のまま）。時刻またぎのテストは `expires_at` を書き換えるのではなく DB 側の時計を進める形にし、直したら一度実装を戻してテストが落ちることを確認する。並行系は bun:sqlite に実 migration を適用した薄型 adapter + await barrier で「片方だけ通る」を固定する。
+
+## R2 の条件付き操作
+
+- `R2GetOptions.onlyIf` に渡す etag は**引用符なしの `R2Object.etag`**。引用符付きの `httpEtag` を渡すと実行時に `TypeError: Conditional ETag should not be wrapped in quotes` で落ちる（公式ドキュメントに引用符の扱いの記載はない）
+
+| フィールド | 形 | 用途 |
+|---|---|---|
+| `etag` | 引用符なし | `onlyIf.etagMatches` / `etagDoesNotMatch` |
+| `httpEtag` | 引用符付き | 応答の `ETag` ヘッダー / `If-Range`・`If-Match` との比較 |
+
+- Range 要求は先に `head()` で総量を取り、満たせる `{offset, length}` だけを `range` に渡す（開始位置が総量を超えた場合の挙動は未規定で、miniflare と本番で揃わない。416 の `Content-Range: bytes */{size}` にも総量が要る）
+- Astro のエンドポイントは **`HEAD` を明示 export** する。しないと GET が呼ばれて本文だけ捨てられ、Range 対応を入れると HEAD + Range が 206 になる（RFC 9110 は GET 以外の Range を無視させる）
+- 公開キーへの put を create-only（`etagDoesNotMatch: '*'`）にする規約は [r2-delivery.md](r2-delivery.md) が正本
+
+## Workers 間通信
+
+同一アカウントでも、Worker から別 Worker の **public URL（workers.dev / カスタムドメイン）への `fetch()` は error 1042 で届かない**（相手側にリクエスト自体が来ない）。Worker 同士をつなぐなら Service Bindings（`env.BINDING.fetch()`）、外部サービス前提の実装に差し込むなら相手を Cloudflare 外のホストに置く。
+
+## Astro SSG と時刻
+
+静的生成のテンプレートで評価した `new Date()` は**ビルド時刻で固定**され、デプロイし直すまで変わらない。期限・時刻の判定をテンプレートに書かない。
+
+- 期限は `data-*` 属性でテンプレートから渡し、判定は**クライアント側 JS** で行う（境界は UTC）
+- JS 無効環境では消えないため、期限を過ぎたらコードごと削除する運用とセットにする（削除タスクを Issue 化）
+- リクエストヘッダー（`Accept-Language` 等）が要るルートだけ `export const prerender = false` にする

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,22 @@
+# ローカル開発・E2E の環境注意
+
+基本コマンドは [CLAUDE.md](../CLAUDE.md) の「開発」節。ここには環境起因のハマりどころと復旧手順を置く。
+
+## dev サーバー
+
+- 常駐型。多重起動の警告が出たら `bunx astro dev stop`
+- ページが vite の deps_ssr エラーを返す時は `rm -rf node_modules/.vite` してから再起動
+
+## E2E のポートは worktree ごとに分ける
+
+Playwright の `reuseExistingServer`（ローカルでは有効）は、**同じポートで待ち受けていれば別セッション・別 worktree のサーバーでも再利用**する。ビルドが走らないため、テストが自分の変更を含まない古いビルドに対して通る / 落ちる。
+
+- 並行 worktree・並行セッションで E2E を回す時は **`E2E_PORT` でポートをずらす**（既定 4322。`web/playwright.config.ts`）
+- **テスト全体が数秒で終わったら再利用を疑う**（ビルドもサーバー起動も走っていない印）
+- 切り分けは結果ではなくプロセスを見る: `lsof -nP -iTCP:{port} -sTCP:LISTEN` → `ps -o pid,lstart,command -p {PID}` で誰がどのディレクトリから起動したか分かる
+- 他人のプロセスは kill せず自分のポートをずらす。自分の残骸は wrangler の親（node プロセス）から落とす（子の workerd だけ kill しても親が再生成する）
+
+## Claude Code サンドボックスとの相性
+
+- **E2E（wrangler dev / Playwright webServer）はサンドボックス内 Bash では動かない**。miniflare が内部で張る接続がネットワーク遮断に当たり `read ECONNRESET` → `webServer was not able to start` で落ちる。環境変数では直らないので、その呼び出しだけサンドボックス外で実行する
+- **build の EPERM** は別問題: wrangler が `~/Library/Preferences/.wrangler` 等へ書けないだけなので、`MINIFLARE_REGISTRY_PATH=/private/tmp/{name}` と `WRANGLER_LOG_PATH=/private/tmp/{name}.log`（必要なら `XDG_CONFIG_HOME` も）を指定すればサンドボックス内で通る


### PR DESCRIPTION
## なぜこの変更が必要か

過去セッションで確立した実装コンベンションや環境の落とし穴（D1 の条件付き更新の書き方、R2 の etag の扱い、E2E のポート分離など）が AI のノート（lifelog）にしか残っておらず、リポ内では暗黙値になっていた。新しいセッション・レビューのたびに同じ指摘・同じハマりを繰り返さないよう、リポの docs に正本化する。

## 変更内容

- `docs/coding-conventions.md` を新規作成: D1 の条件付き更新（WHERE 集約・`datetime('now')`・0 行判定）/ R2 の `etag` と `httpEtag` の使い分け・Range・HEAD export / Workers 間 fetch の error 1042 / Astro SSG の時刻判定
- `docs/local-dev.md` を新規作成: dev サーバー復旧・E2E のポート分離（`E2E_PORT` / `reuseExistingServer` の罠）・Claude Code サンドボックスとの相性（ECONNRESET / EPERM）
- `CLAUDE.md`: dev サーバー復旧手順を local-dev.md への参照に置換し、「変更するときに見る正本」表に 2 行追加、「気をつけること」に D1 条件付き更新の 1 行を追加

## 意思決定

### 採用アプローチ
- CLAUDE.md に直接列挙せず docs に構造化し、CLAUDE.md は参照だけ持つ形を採用。理由: CLAUDE.md は「判断に効く情報だけ置く地図」であり、1概念1正本を保つため

### 却下した代替案
- CLAUDE.md へ全項目を直接追記 → 却下: 地図が肥大化し、既存 docs（r2-delivery.md 等）との正本二重化リスクがある
- 配信系の暗黙値（H.264 明示・URL ハイフン禁止）の再記載 → 却下: docs/streaming/requirements.md に既出で、正本表から到達可能

### トレードオフ
- 参照の 1 ホップ増 > 正本の一元化: 詳細は 1 クリック先になるが、更新箇所が 1 つに定まる

## テスト

- [x] ドキュメントのみの変更（コード変更なし）
- [x] CLAUDE.md からのリンク先（docs/coding-conventions.md / docs/local-dev.md）の存在を確認
- [x] 既存 docs（r2-delivery.md / streaming/requirements.md）と内容が重複しないことを通読確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
