### PR TITLE
feat(streaming): 配信排他エラーから他の配信を終了して開始できるようにする

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -33,6 +33,7 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `DELETE /api/movies/{shortId}/` | `ready` 動画の削除（R2 の実体 → D1 の行の順） | 本人（所有者） | `pending` / `failed` は 409 `INVALID_REQUEST`。`pending` の破棄は abandon を使う |
 | `POST /api/client-error/` | クライアント側の失敗報告（識別子だけを受けて `client_error` として構造化ログに残す。応答は 204） | 任意（Cookie があれば `userId` を添える） | `ClientErrorReport` |
 | `POST /api/streams/` | 新しい 12 文字 path ID と publish JWT を発行 | 本人 | `CreateStreamResponse`。本人の同時配信は 409 `STREAM_ALREADY_LIVE`、全体 20 本到達は 429 `STREAM_CAPACITY_REACHED`、作成間隔内は 429 `STREAM_CREATE_RATE_LIMITED` |
+| `POST /api/streams/stop-live/` | 本人の live 配信をすべて `user_stop` で終了し、cron の kick 対象にする | 本人 | `StopLiveStreamsResponse`（`stopped` と `retryAfterSeconds`）。冪等 200 |
 | `POST /api/streams/{id}/extend/` | 延長期限を更新し、同じ期限の新 publish JWT を発行 | 本人（所有者） | `ExtendStreamResponse`。終了済みは 409 `STREAM_ENDED` |
 | `POST /api/streams/{id}/heartbeat/` | 配信ブラウザの生存時刻を更新 | 本人（所有者） | 成功は 204。終了済みは 409 `STREAM_ENDED` |
 | `POST /api/streams/{id}/stop/` | 配信を `user_stop` で終了し、cron の kick 対象にする | 本人（所有者） | 冪等 204 |

--- a/web/src/components/ScreenSharePage.astro
+++ b/web/src/components/ScreenSharePage.astro
@@ -35,6 +35,8 @@ const wizard = t.wizard;
       data-label-extending={wizard.extending}
       data-label-stop={wizard.stop}
       data-label-stopping={wizard.stopping}
+      data-label-stop-others={wizard.stopOthers}
+      data-label-stopping-others={wizard.stoppingOthers}
       data-label-retry={wizard.retry}
       data-label-reconnect={wizard.reconnect}
       data-label-reconnecting={wizard.reconnecting}
@@ -122,6 +124,7 @@ const wizard = t.wizard;
       <div data-screen-step="error" hidden>
         <h2 class="text-2xl font-bold text-slate-900">{wizard.errorHeading}</h2>
         <p data-screen-error-message role="alert" class="mt-3 rounded-md border border-red-200 bg-red-50 p-4 text-base leading-relaxed text-red-800"></p>
+        <button type="button" data-screen-stop-others hidden class="mt-5 inline-flex items-center gap-2 rounded-md border border-brand-500 px-5 py-3 text-base font-semibold text-brand-700 hover:bg-brand-50"><i class="fa-solid fa-stop" aria-hidden="true" /><span>{wizard.stopOthers}</span></button>
         <button type="button" data-screen-retry class="mt-7 inline-flex items-center gap-2 rounded-md bg-brand-500 px-5 py-3 text-base font-semibold text-white hover:bg-brand-700"><i class="fa-solid fa-arrow-rotate-right" aria-hidden="true" /><span>{wizard.retry}</span></button>
       </div>
     </section>

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -311,6 +311,8 @@
       "extending": "Extending…",
       "stop": "End stream",
       "stopping": "Ending…",
+      "stopOthers": "End other streams and start",
+      "stoppingOthers": "Stopping…",
       "expiryWarning": "This stream will end soon. Extend it to keep sharing.",
       "errorHeading": "We could not start the stream",
       "retry": "Try again",

--- a/web/src/i18n/ja.json
+++ b/web/src/i18n/ja.json
@@ -311,6 +311,8 @@
       "extending": "延長しています…",
       "stop": "配信を終了",
       "stopping": "終了しています…",
+      "stopOthers": "他の配信を終了して開始",
+      "stoppingOthers": "停止中…",
       "expiryWarning": "まもなく配信が自動終了します。続ける場合は延長してください。",
       "errorHeading": "配信を開始できませんでした",
       "retry": "もう一度試す",

--- a/web/src/lib/contracts/api.ts
+++ b/web/src/lib/contracts/api.ts
@@ -8,11 +8,11 @@
  * 外部公開フィールドは camelCase（~/.claude/rules/api-design.md）。
  * D1 のカラム名（short_id など）は snake_case なので、境界で変換する。
  */
-
 import { isShortId } from './r2key';
 export type {
   CreateStreamResponse,
   ExtendStreamResponse,
+  StopLiveStreamsResponse,
   StreamEndReason,
   StreamHealthResponse,
   StreamSessionStatus,

--- a/web/src/lib/contracts/streams.ts
+++ b/web/src/lib/contracts/streams.ts
@@ -41,6 +41,12 @@ export interface ExtendStreamResponse {
   extendExpiresAt: string;
 }
 
+/** `POST /api/streams/stop-live/` の停止件数と再作成までの待機秒数。 */
+export interface StopLiveStreamsResponse {
+  stopped: number;
+  retryAfterSeconds: number;
+}
+
 /** `GET /api/streams/{id}/health/` の relay 到達状態。 */
 export interface StreamHealthResponse {
   state: 'starting' | 'ready';

--- a/web/src/lib/services/streams.ts
+++ b/web/src/lib/services/streams.ts
@@ -3,6 +3,7 @@ import {
   type CreateStreamResponse,
   type ErrorCode,
   type ExtendStreamResponse,
+  type StopLiveStreamsResponse,
   type StreamEndReason,
   type StreamStatusResponse,
 } from '../contracts/api';
@@ -155,6 +156,33 @@ export async function stopStream(input: {
   if (result.meta.changes === 0) await requireOwnedStream(input.database, input.userId, input.id);
 }
 
+/** 所有する live セッションをすべて終了し、次回作成までの待機秒数を返す。 */
+export async function stopAllLiveStreams(input: {
+  database: StreamDatabase;
+  userId: number;
+  settings: StreamSettings;
+  now?: Date;
+}): Promise<StopLiveStreamsResponse> {
+  const now = input.now ?? new Date();
+  const latest = await input.database
+    .prepare('SELECT MAX(started_at) AS started_at FROM stream_sessions WHERE user_id = ?')
+    .bind(input.userId)
+    .first<{ started_at: string | null }>();
+  const result = await input.database
+    .prepare(
+      `UPDATE stream_sessions
+       SET status = 'ended', ended_at = ?, end_reason = 'user_stop', kick_pending = 1
+       WHERE user_id = ? AND status = 'live'`
+    )
+    .bind(now.toISOString(), input.userId)
+    .run();
+
+  return {
+    stopped: result.meta.changes,
+    retryAfterSeconds: retryAfterSeconds(latest?.started_at ?? null, now, input.settings),
+  };
+}
+
 /** 所有するセッションの状態を返す。他人の ID は不存在と同じ 404。 */
 export async function getStreamStatus(input: {
   database: StreamDatabase;
@@ -298,6 +326,16 @@ function streamUrl(id: string): string {
 
 function addSeconds(date: Date, seconds: number): Date {
   return new Date(date.getTime() + seconds * 1000);
+}
+
+function retryAfterSeconds(
+  latestStartedAt: string | null,
+  now: Date,
+  settings: StreamSettings
+): number {
+  if (!latestStartedAt) return 0;
+  const elapsedSeconds = (now.getTime() - Date.parse(latestStartedAt)) / 1000;
+  return Math.max(0, Math.ceil(settings.createIntervalSeconds - elapsedSeconds));
 }
 
 function toNumericDate(date: Date): number {

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -2,6 +2,7 @@ import {
   ERROR_CODES,
   type CreateStreamResponse,
   type ExtendStreamResponse,
+  type StopLiveStreamsResponse,
 } from '../contracts/api';
 import { copyToClipboard } from './clipboard';
 import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
@@ -28,6 +29,7 @@ export interface ScreenShareDependencies {
   startWhipPublisher: typeof startWhipPublisher;
   waitForStreamReady: (streamId: string) => Promise<boolean>;
   getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
+  delay?: (ms: number) => Promise<void>;
   now: () => number;
   sendBeacon: (url: string) => boolean;
   onPageHide: (handler: () => void) => void;
@@ -38,6 +40,7 @@ const DEFAULT_DEPENDENCIES: ScreenShareDependencies = {
   startWhipPublisher,
   waitForStreamReady: (streamId) => waitForStreamReady(streamId, requestJson),
   getDisplayMedia: (constraints) => navigator.mediaDevices.getDisplayMedia(constraints),
+  delay: (ms) => new Promise((resolve) => window.setTimeout(resolve, ms)),
   now: () => Date.now(),
   sendBeacon: (url) => navigator.sendBeacon(url),
   onPageHide: (handler) => window.addEventListener('pagehide', handler),
@@ -94,6 +97,7 @@ export class ScreenShareController {
     this.button('[data-screen-extend]')?.addEventListener('click', () => void this.extend());
     this.button('[data-screen-stop]')?.addEventListener('click', () => void this.stop());
     this.button('[data-screen-retry]')?.addEventListener('click', () => void this.retry());
+    this.button('[data-screen-stop-others]')?.addEventListener('click', () => void this.stopOthersAndStart());
     this.deps.onPageHide(() => this.stopForPageHide());
     this.show('idle');
   }
@@ -112,28 +116,70 @@ export class ScreenShareController {
         stopMedia(media);
         return;
       }
-      const started = await this.createAndPublish(media, generation);
-      if (!started) return;
-      const stream = started.live;
-      if (!this.isActiveStart(generation)) {
-        releaseScreenShare(stream, () => this.clearTimers());
-        void this.notifyRemoteStop(stream);
-        return;
-      }
-      this.live = stream;
-      this.setUrl(stream.streamUrl);
-      this.setAudioStatus(stream.media);
-      this.preview(stream.media);
-      this.startTimers();
-      stream.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
-      if (started.ready) this.show('url');
-      else this.showError(new StreamHealthError());
+      await this.continueStart(media, generation);
     } catch (error) {
       if (this.isActiveStart(generation)) this.handleStartError(error);
     } finally {
       this.setBusy('[data-screen-start]', false, 'labelStart');
       if (retry) retry.disabled = false;
     }
+  }
+
+  private async stopOthersAndStart(): Promise<void> {
+    const generation = ++this.startGeneration;
+    let media: MediaStream | null = null;
+    this.stopping = false;
+    this.setBusy('[data-screen-stop-others]', true, 'labelStopOthers');
+    const retry = this.button('[data-screen-retry]');
+    if (retry) retry.disabled = true;
+    try {
+      media = await this.deps.getDisplayMedia(displayMediaConstraints());
+      if (!this.isActiveStart(generation)) {
+        stopMedia(media);
+        return;
+      }
+      const stopped = asStopLiveStreams(
+        await this.deps.requestJson('/api/streams/stop-live/', { method: 'POST' })
+      );
+      if (!this.isActiveStart(generation)) {
+        stopMedia(media);
+        return;
+      }
+      this.text('[data-screen-error-message]', this.message('labelStoppingOthers'));
+      this.setButtonLabel('[data-screen-stop-others]', 'labelStoppingOthers');
+      await (this.deps.delay ?? delay)(Math.max(stopped.retryAfterSeconds, 3) * 1000);
+      if (!this.isActiveStart(generation)) {
+        stopMedia(media);
+        return;
+      }
+      await this.continueStart(media, generation);
+      media = null;
+    } catch (error) {
+      if (media) stopMedia(media);
+      if (this.isActiveStart(generation)) this.handleStartError(error);
+    } finally {
+      this.setBusy('[data-screen-stop-others]', false, 'labelStopOthers');
+      if (retry) retry.disabled = false;
+    }
+  }
+
+  private async continueStart(media: MediaStream, generation: number): Promise<void> {
+    const started = await this.createAndPublish(media, generation);
+    if (!started) return;
+    const stream = started.live;
+    if (!this.isActiveStart(generation)) {
+      releaseScreenShare(stream, () => this.clearTimers());
+      void this.notifyRemoteStop(stream);
+      return;
+    }
+    this.live = stream;
+    this.setUrl(stream.streamUrl);
+    this.setAudioStatus(stream.media);
+    this.preview(stream.media);
+    this.startTimers();
+    stream.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
+    if (started.ready) this.show('url');
+    else this.showError(new StreamHealthError());
   }
 
   private async createAndPublish(media: MediaStream, generation: number): Promise<StartedStream | null> {
@@ -367,6 +413,12 @@ export class ScreenShareController {
   private showError(error: unknown): void {
     this.text('[data-screen-error-message]', this.messageFor(error));
     this.setButtonLabel('[data-screen-retry]', this.live ? 'labelReconnect' : 'labelRetry');
+    const stopOthers = this.button('[data-screen-stop-others]');
+    if (stopOthers) {
+      stopOthers.hidden = !isStreamAlreadyLiveError(error);
+      stopOthers.disabled = false;
+      this.setButtonLabel('[data-screen-stop-others]', 'labelStopOthers');
+    }
     this.show('error');
   }
 
@@ -478,8 +530,31 @@ function asExtendStream(value: unknown): ExtendStreamResponse {
   return value as unknown as ExtendStreamResponse;
 }
 
+function asStopLiveStreams(value: unknown): StopLiveStreamsResponse {
+  if (
+    !isRecord(value) ||
+    !isNonNegativeInteger(value.stopped) ||
+    !isNonNegativeInteger(value.retryAfterSeconds)
+  ) {
+    throw new Error('Invalid stop live streams response');
+  }
+  return value as unknown as StopLiveStreamsResponse;
+}
+
+function isStreamAlreadyLiveError(error: unknown): boolean {
+  return error instanceof JsonRequestError && error.errorCode === ERROR_CODES.streamAlreadyLive;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 function stopMedia(media: MediaStream): void {

--- a/web/src/pages/api/streams/stop-live.ts
+++ b/web/src/pages/api/streams/stop-live.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+
+import { stopAllLiveStreams } from '../../../lib/services/streams';
+import {
+  json,
+  runStreamApi,
+  type StreamApiBindings,
+} from '../../../lib/services/stream-api';
+
+export const prerender = false;
+
+/** 所有する live 配信をすべて終了し、再作成までの待機秒数を返す。 */
+export const POST: APIRoute = ({ request }) =>
+  runStreamApi(request, env as unknown as StreamApiBindings, async (context) =>
+    json(await stopAllLiveStreams(context))
+  );

--- a/web/tests/services/streams.test.ts
+++ b/web/tests/services/streams.test.ts
@@ -6,6 +6,7 @@ import {
   extendStream,
   getStreamStatus,
   heartbeatStream,
+  stopAllLiveStreams,
   stopStream,
   type StreamSettings,
 } from '../../src/lib/services/streams';
@@ -227,5 +228,74 @@ describe('配信セッション service', () => {
     expect(
       database.sqlite.query('SELECT kick_pending FROM stream_sessions').get()
     ).toEqual({ kick_pending: 1 });
+  });
+
+  it('live 配信をすべて user_stop と kick_pending で終了し、停止件数を返す', async () => {
+    const database = await createStreamDatabase();
+    const settings = { ...SETTINGS, maxLiveStreamsPerUser: 2 };
+    await createStream({ ...input(database, 'AbCdEf123456'), settings });
+    await createStream({
+      ...input(database, 'ZyXwVu987654', new Date(NOW.getTime() + 11_000)),
+      settings,
+    });
+
+    const response = await stopAllLiveStreams({
+      database,
+      userId: 10,
+      settings,
+      now: new Date(NOW.getTime() + 15_000),
+    });
+
+    expect(response).toEqual({ stopped: 2, retryAfterSeconds: 6 });
+    expect(
+      database.sqlite.query(
+        "SELECT status, ended_at, end_reason, kick_pending FROM stream_sessions WHERE user_id = 10 ORDER BY id"
+      ).all()
+    ).toEqual([
+      {
+        status: 'ended',
+        ended_at: '2026-09-01T00:00:15.000Z',
+        end_reason: 'user_stop',
+        kick_pending: 1,
+      },
+      {
+        status: 'ended',
+        ended_at: '2026-09-01T00:00:15.000Z',
+        end_reason: 'user_stop',
+        kick_pending: 1,
+      },
+    ]);
+  });
+
+  it('最新の開始から間隔を過ぎた時とセッションがない時は待機不要にする', async () => {
+    const database = await createStreamDatabase();
+    await createStream(input(database, 'AbCdEf123456'));
+    const afterInterval = await stopAllLiveStreams({
+      database,
+      userId: 10,
+      settings: SETTINGS,
+      now: new Date(NOW.getTime() + 10_000),
+    });
+    const noSessions = await stopAllLiveStreams({
+      database,
+      userId: 20,
+      settings: SETTINGS,
+      now: NOW,
+    });
+
+    expect(afterInterval.retryAfterSeconds).toBe(0);
+    expect(noSessions).toEqual({ stopped: 0, retryAfterSeconds: 0 });
+  });
+
+  it('別ユーザーの live 配信は終了しない', async () => {
+    const database = await createStreamDatabase();
+    await createStream(input(database, 'AbCdEf123456'));
+    await createStream({ ...input(database, 'ZyXwVu987654'), userId: 20 });
+
+    await stopAllLiveStreams({ database, userId: 10, settings: SETTINGS, now: NOW });
+
+    expect(
+      database.sqlite.query('SELECT status FROM stream_sessions WHERE user_id = 20').get()
+    ).toEqual({ status: 'live' });
   });
 });

--- a/web/tests/ui/screen-share-stop-live.test.ts
+++ b/web/tests/ui/screen-share-stop-live.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ERROR_CODES } from '../../src/lib/contracts/api';
+import { ScreenShareController, type ScreenShareDependencies } from '../../src/lib/ui/screen-share';
+import { JsonRequestError } from '../../src/lib/ui/request-json';
+import type { WhipPublisher } from '../../src/lib/ui/whip-publisher';
+
+describe('他の配信を終了して開始', () => {
+  test('STREAM_ALREADY_LIVE の時だけ終了ボタンを表示する', async () => {
+    const liveError = await pageAfterStartError(
+      new JsonRequestError(409, ERROR_CODES.streamAlreadyLive)
+    );
+    const otherError = await pageAfterStartError(new JsonRequestError(429, ERROR_CODES.streamCreateRateLimited));
+
+    expect(liveError.button('[data-screen-stop-others]').hidden).toBe(false);
+    expect(otherError.button('[data-screen-stop-others]').hidden).toBe(true);
+  });
+
+  test('画面選択後に停止、待機、配信開始の順で URL 表示まで進む', async () => {
+    const page = fakePage();
+    const events: string[] = [];
+    let creates = 0;
+    const controller = new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path === '/api/streams/') {
+          creates += 1;
+          if (creates === 1) throw new JsonRequestError(409, ERROR_CODES.streamAlreadyLive);
+          events.push('create');
+          return createResponse();
+        }
+        events.push('stop-live');
+        return { stopped: 1, retryAfterSeconds: 0 };
+      },
+      getDisplayMedia: async () => {
+        events.push('media');
+        return media();
+      },
+      delay: async (ms) => { events.push(`delay:${ms}`); },
+    }));
+    controller.mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    events.length = 0;
+    page.button('[data-screen-stop-others]').click();
+    await waitFor(() => !page.step('url').hidden);
+
+    expect(events).toEqual(['media', 'stop-live', 'delay:3000', 'create']);
+  });
+
+  test('待機中にページ離脱すると取得済み画面を止め、新しい配信を作らない', async () => {
+    const page = fakePage();
+    let creates = 0;
+    let pageHide: (() => void) | undefined;
+    let stopped = 0;
+    let resolveDelay: (() => void) | undefined;
+    const controller = new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path === '/api/streams/') {
+          creates += 1;
+          if (creates === 1) throw new JsonRequestError(409, ERROR_CODES.streamAlreadyLive);
+          return createResponse();
+        }
+        return { stopped: 1, retryAfterSeconds: 0 };
+      },
+      getDisplayMedia: async () => media(() => { stopped += 1; }),
+      delay: () => new Promise<void>((resolve) => { resolveDelay = resolve; }),
+      onPageHide: (handler) => { pageHide = handler; },
+    }));
+    controller.mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-stop-others]').click();
+    await waitFor(() => resolveDelay !== undefined);
+    expect(page.button('[data-screen-retry]').disabled).toBe(true);
+    pageHide?.();
+    resolveDelay?.();
+    await flushMicrotasks();
+
+    expect(creates).toBe(1);
+    expect(stopped).toBeGreaterThanOrEqual(2);
+    expect(page.button('[data-screen-retry]').disabled).toBe(false);
+  });
+
+  test('stop-live API の失敗時は取得済み画面を停止してエラー表示へ戻る', async () => {
+    const page = fakePage();
+    let selections = 0;
+    let stopLiveTrackStopped = false;
+    const controller = new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path === '/api/streams/') {
+          throw new JsonRequestError(409, ERROR_CODES.streamAlreadyLive);
+        }
+        throw new Error('stop-live failed');
+      },
+      getDisplayMedia: async () => {
+        selections += 1;
+        return media(() => { if (selections === 2) stopLiveTrackStopped = true; });
+      },
+    }));
+    controller.mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-stop-others]').click();
+    await waitFor(() => stopLiveTrackStopped);
+
+    expect(page.step('error').hidden).toBe(false);
+    expect(page.button('[data-screen-stop-others]').hidden).toBe(true);
+    expect(page.button('[data-screen-retry]').disabled).toBe(false);
+  });
+});
+
+async function pageAfterStartError(error: Error): Promise<ReturnType<typeof fakePage>> {
+  const page = fakePage();
+  new ScreenShareController(page.root, dependencies({
+    requestJson: async () => { throw error; },
+    getDisplayMedia: async () => media(),
+  })).mount();
+  page.button('[data-screen-start]').click();
+  await waitFor(() => !page.step('error').hidden);
+  return page;
+}
+
+function dependencies(overrides: Partial<ScreenShareDependencies>): ScreenShareDependencies {
+  return {
+    requestJson: async () => createResponse(),
+    startWhipPublisher: async () => publisher(),
+    waitForStreamReady: async () => true,
+    getDisplayMedia: async () => media(),
+    delay: async () => undefined,
+    now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+    sendBeacon: () => true,
+    onPageHide: () => undefined,
+    ...overrides,
+  };
+}
+
+function createResponse(): Record<string, unknown> {
+  return {
+    id: 'Ab12Cd34Ef56', streamUrl: 'rtspt://webscreen.tv/live/Ab12Cd34Ef56', status: 'live',
+    publishToken: 'token', publishTokenExpiresAt: '2026-09-01T01:00:00.000Z',
+    extendExpiresAt: '2026-09-01T01:00:00.000Z', startedAt: '2026-09-01T00:00:00.000Z',
+    lastHeartbeatAt: '2026-09-01T00:00:00.000Z', endedAt: null, endReason: null,
+  };
+}
+
+function media(onStop = () => undefined): MediaStream {
+  const track = { addEventListener: () => undefined, stop: onStop };
+  return { getTracks: () => [track], getVideoTracks: () => [track], getAudioTracks: () => [] } as unknown as MediaStream;
+}
+
+function publisher(): WhipPublisher {
+  return {
+    close: () => undefined,
+    deleteResource: async () => undefined,
+    stop: async () => undefined,
+    republish: async () => publisher(),
+    setPublishToken: () => undefined,
+  };
+}
+
+function fakePage(): {
+  root: HTMLElement;
+  button: (selector: string) => FakeElement;
+  step: (phase: string) => FakeElement;
+} {
+  const elements = new Map<string, FakeElement>();
+  for (const selector of [
+    '[data-screen-start]', '[data-screen-stop-others]', '[data-screen-retry]',
+    '[data-screen-error-message]', '[data-screen-url]', '[data-screen-audio-status]',
+    '[data-screen-preview]', '[data-screen-expiry-warning]', '[data-screen-indicators]',
+  ]) elements.set(selector, new FakeElement());
+  const steps = ['idle', 'login', 'url', 'live', 'error'].map((phase) => {
+    const step = new FakeElement();
+    step.dataset.screenStep = phase;
+    return step;
+  });
+  const root = {
+    dataset: {
+      labelStart: 'start', labelSelecting: 'selecting', labelRetry: 'retry', labelReconnect: 'reconnect',
+      labelStopOthers: 'stop-others', labelStoppingOthers: 'stopping', msgStreamAlreadyLive: 'already-live',
+      msgGeneric: 'error', msgH264: 'h264', msgWhip: 'whip', msgDisplayDenied: 'denied',
+      msgStreamCapacity: 'capacity', msgRateLimited: 'rate-limited', msgStreamEnded: 'ended',
+      msgStreamUnhealthy: 'unhealthy', msgAudioIncluded: 'audio', msgVideoOnly: 'video',
+    },
+    querySelector: (selector: string) => elements.get(selector) ?? null,
+    querySelectorAll: (selector: string) => selector === '[data-screen-step]' ? steps : [],
+  } as unknown as HTMLElement;
+  return { root, button: (selector) => elements.get(selector)!, step: (phase) => steps.find((step) => step.dataset.screenStep === phase)! };
+}
+
+class FakeElement {
+  dataset: Record<string, string> = {};
+  disabled = false;
+  hidden = false;
+  textContent = '';
+  value = '';
+  srcObject: MediaStream | null = null;
+  private readonly listeners: Array<() => void> = [];
+
+  querySelector(): null { return null; }
+  addEventListener(event: string, listener: () => void): void { if (event === 'click') this.listeners.push(listener); }
+  click(): void { for (const listener of this.listeners) listener(); }
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (condition()) return;
+    await Promise.resolve();
+  }
+  throw new Error('Expected asynchronous UI update');
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}


### PR DESCRIPTION
## なぜこの変更が必要か

配信開始時に 409 `STREAM_ALREADY_LIVE`（すでに配信中の画面があります）が出ると、どのウィンドウ・タブが配信中なのか探し出して手動で終了するしかなかった。エラーが出た画面から他の配信を終了して、そのまま配信を開始できるようにする。

## 変更内容

- `POST /api/streams/stop-live/` を新設: 本人の live 配信を全件 `user_stop` + `kick_pending=1` で終了し、`createIntervalSeconds` 由来の `retryAfterSeconds` を返す（`StopLiveStreamsResponse`）
- エラー画面に「他の配信を終了して開始」ボタンを追加（`STREAM_ALREADY_LIVE` の時のみ表示）
- クリック1回で「画面選択 → stop-live → 停止中…を `max(retryAfterSeconds, 3)` 秒表示 → 配信開始」まで完結
- i18n ja/en に文言追加、docs/api-contracts.md の API 表に stop-live 行を追記

## 意思決定

### 採用アプローチ
- 一括終了型 API（stop-live）を採用。理由: 一覧提示型（GET /api/streams）より ID をクライアントへ渡す必要がなく、往復1回で済む
- 画面選択（getDisplayMedia）は**クリック直後・待機前**に実行。理由: transient user activation が必要で、10秒待機後に呼ぶと NotAllowedError になるため
- 待機秒数はサーバーが返す（`retryAfterSeconds`）。理由: `STREAM_CREATE_INTERVAL_SECONDS` の設定変更にクライアント改修不要（1概念1正本）

### 却下した代替案
- 自分の live 一覧を返す API + 個別 stop → 却下: 往復増・クライアント側の状態管理が増える
- 待機後に自動で画面ピッカーを開く → 却下: transient activation 切れで失敗する

### トレードオフ
- 旧配信の実停止は相手ブラウザの heartbeat 409 検知（最大約25秒）と cron kick に委ねる > stop-live での同期 kick: 既存 `/stop/` と同じ設計で、新規開始は D1 の排他で守られるため衝突しない。同期 kick は noricha-vr/choicast#24 で別途検討

## テスト

- [x] `bun run typecheck` pass
- [x] `bun test` 726 pass / 0 fail（stopAllLiveStreams の権限境界・retryAfterSeconds 算出、UI のボタン表示条件・media 解放・待機順序の新規テスト含む）
- [x] `check-architecture.py` 新規違反なし
- [x] Playwright でエラー画面のボタン表示・停止中状態を目視確認（下記スクショ）

## Screenshot

| STREAM_ALREADY_LIVE 時（ボタン表示） | 停止中…（待機状態） |
|--------|-------|
| ![stop-others](https://agent-toolbox-assets.kaisha3.com/uploads/2026/09/45de6e28cd4b-01-stream-already-live-stop-others-20260902.avif) | ![stopping](https://agent-toolbox-assets.kaisha3.com/uploads/2026/09/2bcc1b92f9f1-02-stopping-others-wait-20260902.avif) |

## 関連 Issue

レビューゲートで defer した改善は Issue 化済み: noricha-vr/WebScreen#164（Origin 検証）/ noricha-vr/WebScreen#165（screen-share.ts 分割）/ noricha-vr/choicast#24（同期 kick）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
