### PR TITLE
docs(streaming): rollback実測をA12へ反映

### DIFF
--- a/docs/streaming/acceptance-test.md
+++ b/docs/streaming/acceptance-test.md
@@ -30,7 +30,7 @@
 | **A9** | Chrome でタブと「タブの音声を共有」を選ぶ | UI が音声ありと表示し、出口が H.264 + AAC になる | audio track、relay の ffmpeg、egress の順に切り分ける |
 | **A10** | ingress または relay を一時的に未到達にして開始する | 同じ画面で 1 回自動再接続し、失敗時だけ再接続ボタンを出す | 一律の「再起動してください」案内へ逃げず、health bytes を確認する |
 | **A11** | actual YouTube を開始して直後のカクつきを観察する | 約 30 秒待って安定すること。継続時は ingress / egress bytes を確認し、relay 未到達の場合だけ再接続する | 到達済みなら再接続を合格手順にしない。無条件の再起動は勧めない |
-| **A12** | MP3 relayを本番候補として昇格判定する | `?stream-profile=mp3-beta` を重複なく指定し、PCとQuestでMP3音声を実聴して各1秒未満を確認する。30分・20 relay・20 reader・codec gateは合格済み。残る実Mac動的映像の30 / 24 fps比較を完了する | 「音声が聞こえた」「めっちゃ速い」は有力な手動観測だが、PC/Questを分けた統制済みA12測定ではない。1項目でも未確認ならAACを維持する |
+| **A12** | MP3 relayを本番候補として昇格判定する | `?stream-profile=mp3-beta` を重複なく指定し、PCとQuestでMP3音声を実聴して各1秒未満を確認する。30分・20 relay・20 reader・codec gate・旧AACへの隔離rollbackは合格済み。残る実Mac動的映像の30 / 24 fps比較を完了する | rollbackはlocal v1.15.5での経路復旧までで、本番cutoverではない。「音声が聞こえた」「めっちゃ速い」はPC/Questを分けた統制済みA12測定ではない。1項目でも未確認ならAACを維持する |
 
 ## 測定の方法
 

--- a/docs/streaming/verification.md
+++ b/docs/streaming/verification.md
@@ -436,6 +436,8 @@ YamaStreamの `Use Low Latency` 実値はログから直接確認できない。
 - Chromeの単純な720p30 / 1.2 Mbps上限では、通常8秒が237 kbps / key 1、500 ms要求が456 kbps / key 16、quality limitationなし。24/30 fpsのsequential合成値は24設定が20.5 fps / 342.834 kbps / key 15、30設定が29.875 fps / 422.682 kbps / key 16。24設定はheadlessでunder-deliveryしたため実Mac比較には使わない。
 - exact one `stream-profile=mp3-beta` のChromeだけ500 ms要求を有効化する。unknown/duplicate/通常アクセスは無効で、任意interval不可。非対応UAでは第2引数が無視されno-op loopになる可能性がある。
 - 手動では初動カクつき後約30秒で安定、音声可、PCモード + Mac配信は安定し、今回は「めっちゃ速い」と観測された。ただしA12のPC/Quest別MP3実聴・1秒未満と実Mac 24/30 fps比較は未完。再起動を常設回避策にしない。
+- rollback rehearsalはlocal Mac arm64 / MediaMTX v1.15.5の隔離高番ポートで実施。同じ1280x720 / 30 fps H.264 + AAC入力を維持し、candidateのH.264 + MP3 48 kHz stereoをcodec gateで確認後、SIGINT停止とpath停止を確認した。pre-PR main `e2369d0` の旧relayへ戻すとH.264 + AAC 48 kHz stereoが復旧し、`ffmpeg -xerror` の10秒decodeも合格した。終了後は4ポート閉鎖・残留processなし。本番Indigo / Workerと製品configは未変更で、検証configだけv1.15.5互換のためIPv6 CIDRを引用し未対応MoQキーを外した。
+- 本番Indigoはread-onlyで確認し、`/opt/webscreen/streaming/relay.sh` のSHA-256がpre-PR main `e2369d0` と一致した。ingress / egressはactive、candidate用`audio-profile.sh`は未配置でlegacy AACを維持し、RTSP 554もlisten中だった。秘密値は取得・出力していない。
 
 ## 検証できていないこと
 

--- a/web/streaming/README.md
+++ b/web/streaming/README.md
@@ -23,6 +23,8 @@ After publishing to the candidate environment, run `./verify-codecs.sh rtspt://y
 
 Do not use the candidate test as production cutover approval. Stage and test `0.2.0-beta` away from the production service while production continues to use AAC. The 30-minute stability, capacity, and codec gates have passed; promotion still requires controlled PC and Quest audio listening, sub-second Quest playback, and an actual-Mac 24/30 fps comparison.
 
+An isolated Mac arm64 rehearsal also passed candidate MP3 shutdown and restoration to the pre-PR H.264 + AAC relay, including a 10-second `ffmpeg -xerror` decode. It did not exercise the production Indigo service, Worker, or product configuration.
+
 For the browser-side recovery candidate, open the screen-share page with exactly one `stream-profile=mp3-beta` query value in Chrome. It requests the next keyframe every 500 ms; normal, unknown, and duplicate values keep the existing behavior. The request does not guarantee that a new reader's first packet is an IDR, because MediaMTX has no GOP cache. Unsupported browsers may ignore the optional `setParameters` argument and keep a no-op request loop. Do not expose an arbitrary interval in the URL.
 
 After A12 passes, the VPS must be ready before any Worker version containing the split settings is deployed.


### PR DESCRIPTION
## 変更内容

- MP3候補を停止し、pre-PRの旧AAC relayへ戻す隔離rollback rehearsalをA12へ記録
- H.264 + MP3確認後、H.264 + AAC 48 kHz stereo復旧と10秒decode成功を記録
- 高番ポート閉鎖・残留processなし、本番Indigo / Worker未操作の境界を明記
- 本番はpre-PR relayのSHA一致、両service active、legacy AAC、RTSP 554 listenをread-only確認

## 検証

- `git diff --check`
- file-size-guard 3ファイル合格
- streaming docsローカルリンク切れ0件

## 残るA12

- PC / Quest別のMP3実聴・1秒未満
- actual Mac 24 / 30 fps比較

Refs #169

---
Generated with Codex
