### PR TITLE
feat(streaming): audio-profile=raw で音声処理を切りステレオ Opus を試せるようにする

### DIFF
--- a/docs/streaming/requirements.md
+++ b/docs/streaming/requirements.md
@@ -66,6 +66,8 @@ Issue #93 で `stream.web-screen.net` に凍結後、実装着手前の 2026-09-
 
 MP3 betaだけは、ChromeでURL queryに `stream-profile=mp3-beta` が**ちょうど1個**ある時、ブラウザから500 ms周期で次キーフレームを要求する。通常アクセス、unknown値、重複値では無効で、任意intervalは受け付けない。これは生成完了やreaderのfirst-packet IDRを保証せず、MediaMTXにGOP cacheもない。非対応ブラウザでは第2引数が無視され、要求がno-opになる可能性がある。本番AACの2秒GOP契約は変更しない。
 
+同じ判定意味論で、URL queryに `audio-profile=raw` が**ちょうど1個**ある時だけ、画面取得の音声制約を `echoCancellation / noiseSuppression / autoGainControl = false` にし、音声トラックに `contentHint = 'music'`、answer SDPのOpus fmtpに `stereo=1;maxaveragebitrate=128000` を補い、audio senderの上限を128 kbpsにする。これはモノラル化の仮説を比較するための候補で、既定経路の制約・SDPは変えない（[stability-audio-verification.md](stability-audio-verification.md) の A/B 手順）。
+
 ### キーフレーム 2 秒固定が連鎖させる制約
 
 これは設定で回避できないため、仕様として受け入れるか、MediaMTX をフォークするかの二択になる。
@@ -86,7 +88,7 @@ MP3 betaだけは、ChromeでURL queryに `stream-profile=mp3-beta` が**ちょ�
 | コンテンツヒント | `track.contentHint = 'detail'` | R10。I18で動画像・文字可読性とも合格 |
 | スケール | `encodings[0].scaleResolutionDownBy = 1` | R10。I18で動画像・文字可読性とも合格 |
 | 解像度 / fps | **入力 1280x720 / 最大 30 fps** | I18で動画像のRTSP出力は1280x720 / 30.00〜30.06 fps。24 fpsの旧代表素材比較は変更しない |
-| 画面取得 | `getDisplayMedia({ video, audio: true })`（**既定ピッカー**。画面全体・ウィンドウ・タブから選ばせる） | Chrome のタブ共有で「タブの音声を共有」をオンにした時だけ音声が付く。macOS の画面収録未許可はエラー文言でシステム設定へ案内する |
+| 画面取得 | `getDisplayMedia({ video, audio: true })`（`audio-profile=raw` 時だけ音声制約オブジェクト。**既定ピッカー**。画面全体・ウィンドウ・タブから選ばせる） | Chrome のタブ共有で「タブの音声を共有」をオンにした時だけ音声が付く。macOS の画面収録未許可はエラー文言でシステム設定へ案内する |
 | 開始判定 | ingress / egress bytes を最大 10 秒、1 秒間隔で監視 | 両方が連続観測で増えた時だけ URL を表示する。未到達なら 1 回自動再 publish する |
 
 ### 対応ブラウザ

--- a/docs/streaming/stability-audio-verification.md
+++ b/docs/streaming/stability-audio-verification.md
@@ -114,6 +114,7 @@ MP3 48 kHz stereo 128 kbpsは30分・非無音・A/V 7〜15 msまで自動確認
 - 選択結果に音声トラックがあれば「音声を含めて配信しています」、なければ「映像のみ」と表示する。
 - relay 出口は現行でH.264 + AAC、MP3 beta候補でH.264 + MP3を `verify-codecs.sh` で検証する。
 - 表示文言は **「検証時に音声が出ることを確認済み」** とし、PoC という表現は使わない。
-- `?audio-profile=raw` は、Chromeの音声処理がモノラル化・高域減衰の一因かもしれないという仮説を比較する候補（既定では無効）。
-- A/Bでは同じ共有元で既定とrawを各5秒測り、`ffmpeg -rtsp_transport tcp -i rtsp://webscreen.tv/live/{id} -t 5 -vn -af "pan=mono|c0=0.5*c0-0.5*c1,volumedetect" -f null -` を実行する。
-- L−R差分が -91 dB ならモノラル。取得側ログのchannelCountと音声処理設定も併せて比較する。
+- `?audio-profile=raw` は、Chromeの音声処理（EC / NS / AGC）がモノラル化・高域減衰の一因かもしれないという仮説を比較する候補（既定では無効。ブラウザ取得側の設定で、relay の `audio-profile.sh` とは別物）。
+- A/Bでは同じ共有元で既定とrawを各5秒測り、`ffmpeg -rtsp_transport tcp -i rtsp://webscreen.tv/live/{id} -t 5 -vn -af "pan=mono|c0=0.5*c0-0.5*c1,volumedetect" -f null -` を実行する。L−R差分が本体（`volumedetect` 単独）より 40 dB 以上低ければモノラルとみなす（2026-09-02 の実測は本体 −21 dB に対し L−R −91 dB）。
+- 測定境界: 出口は relay が `-ac 2 -b:a 128k` で再エンコードした後なので、判定できるのは**モノラルかどうか**まで。Opus の `maxaveragebitrate` や高域の差は出口に届かないため、高域比較は ingress（`rtsp://127.0.0.1:8554`、サーバー内）で測る。
+- 取得側の `audio_capture_settings` ログ（channelCount / EC / NS / AGC）は既定・rawの両方で出るので、A/Bではこれも並べて比較する。raw で `raw_audio_sender_bitrate_failed` が出た時は 128 kbps 未適用として記録する。

--- a/docs/streaming/stability-audio-verification.md
+++ b/docs/streaming/stability-audio-verification.md
@@ -114,3 +114,6 @@ MP3 48 kHz stereo 128 kbpsは30分・非無音・A/V 7〜15 msまで自動確認
 - 選択結果に音声トラックがあれば「音声を含めて配信しています」、なければ「映像のみ」と表示する。
 - relay 出口は現行でH.264 + AAC、MP3 beta候補でH.264 + MP3を `verify-codecs.sh` で検証する。
 - 表示文言は **「検証時に音声が出ることを確認済み」** とし、PoC という表現は使わない。
+- `?audio-profile=raw` は、Chromeの音声処理がモノラル化・高域減衰の一因かもしれないという仮説を比較する候補（既定では無効）。
+- A/Bでは同じ共有元で既定とrawを各5秒測り、`ffmpeg -rtsp_transport tcp -i rtsp://webscreen.tv/live/{id} -t 5 -vn -af "pan=mono|c0=0.5*c0-0.5*c1,volumedetect" -f null -` を実行する。
+- L−R差分が -91 dB ならモノラル。取得側ログのchannelCountと音声処理設定も併せて比較する。

--- a/web/src/lib/ui/audio-profile.ts
+++ b/web/src/lib/ui/audio-profile.ts
@@ -1,0 +1,94 @@
+import { hasSingleExactQueryValue } from './stream-profile';
+
+export const RAW_AUDIO_MAX_BITRATE = 128_000;
+
+const RAW_AUDIO_CONSTRAINTS = {
+  echoCancellation: false,
+  noiseSuppression: false,
+  autoGainControl: false,
+} as const satisfies MediaTrackConstraints;
+
+/** URL query で raw 音声プロファイルが明示的に有効かを判定する。 */
+export function isRawAudioProfileForSearch(search: string): boolean {
+  return hasSingleExactQueryValue(search, 'audio-profile', 'raw');
+}
+
+/** raw 音声プロファイルに応じた画面共有の音声制約を返す。 */
+export function displayAudioConstraintForRawProfile(rawAudioProfile: boolean): boolean | MediaTrackConstraints {
+  return rawAudioProfile ? { ...RAW_AUDIO_CONSTRAINTS } : true;
+}
+
+/** raw 音声プロファイル向けに、取得済み音声トラックを診断可能な状態へ整える。 */
+export function configureRawAudioTracks(media: MediaStream): void {
+  for (const track of media.getAudioTracks()) {
+    track.contentHint = 'music';
+    const settings = track.getSettings();
+    console.info('raw_audio_capture_settings', {
+      event: 'raw_audio_capture_settings',
+      channelCount: settings.channelCount,
+      echoCancellation: settings.echoCancellation,
+      noiseSuppression: settings.noiseSuppression,
+      autoGainControl: settings.autoGainControl,
+      sampleRate: settings.sampleRate,
+    });
+  }
+}
+
+/** raw 音声プロファイル向けに、audio sender の送出上限をベストエフォートで設定する。 */
+export async function configureRawAudioSender(sender: RTCRtpSender): Promise<void> {
+  try {
+    const parameters = sender.getParameters();
+    parameters.encodings = parameters.encodings?.length ? parameters.encodings : [{}];
+    parameters.encodings[0]!.maxBitrate = RAW_AUDIO_MAX_BITRATE;
+    await sender.setParameters(parameters);
+  } catch (error) {
+    console.warn('raw_audio_sender_bitrate_failed', {
+      event: 'raw_audio_sender_bitrate_failed',
+      maxBitrate: RAW_AUDIO_MAX_BITRATE,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Opus の fmtp 行へ raw 音声プロファイル用のパラメータを補完する。 */
+export function withRawAudioOpusParameters(answerSdp: string): string {
+  const lineEnding = answerSdp.includes('\r\n') ? '\r\n' : '\n';
+  const lines = answerSdp.split(lineEnding);
+  const opusPayloadTypes = new Set<string>();
+  const fmtpPayloadTypes = new Set<string>();
+
+  for (const line of lines) {
+    const rtpmap = /^a=rtpmap:(\d+)\s+opus\/\d+(?:\/\d+)?\s*$/i.exec(line);
+    if (rtpmap) opusPayloadTypes.add(rtpmap[1]!);
+    const fmtp = /^a=fmtp:(\d+)(?:\s|$)/i.exec(line);
+    if (fmtp) fmtpPayloadTypes.add(fmtp[1]!);
+  }
+  if (opusPayloadTypes.size === 0) return answerSdp;
+
+  return lines.flatMap((line) => {
+    const rtpmap = /^a=rtpmap:(\d+)\s+opus\/\d+(?:\/\d+)?\s*$/i.exec(line);
+    if (rtpmap && !fmtpPayloadTypes.has(rtpmap[1]!)) {
+      return [line, `a=fmtp:${rtpmap[1]} ${rawAudioOpusParameters('')}`];
+    }
+
+    const fmtp = /^a=fmtp:(\d+)\s*(.*)$/i.exec(line);
+    if (fmtp && opusPayloadTypes.has(fmtp[1]!)) {
+      return [`a=fmtp:${fmtp[1]} ${rawAudioOpusParameters(fmtp[2] ?? '')}`];
+    }
+    return [line];
+  }).join(lineEnding);
+}
+
+function rawAudioOpusParameters(existingParameters: string): string {
+  const requiredParameters = [
+    'stereo=1',
+    'sprop-stereo=1',
+    `maxaveragebitrate=${RAW_AUDIO_MAX_BITRATE}`,
+  ];
+  const requiredNames = new Set(requiredParameters.map((parameter) => parameter.split('=')[0]!));
+  const preserved = existingParameters.split(';').map((parameter) => parameter.trim()).filter((parameter) => {
+    if (!parameter) return false;
+    return !requiredNames.has(parameter.split('=', 1)[0]!.trim().toLowerCase());
+  });
+  return [...preserved, ...requiredParameters].join(';');
+}

--- a/web/src/lib/ui/audio-profile.ts
+++ b/web/src/lib/ui/audio-profile.ts
@@ -18,13 +18,17 @@ export function displayAudioConstraintForRawProfile(rawAudioProfile: boolean): b
   return rawAudioProfile ? { ...RAW_AUDIO_CONSTRAINTS } : true;
 }
 
-/** raw 音声プロファイル向けに、取得済み音声トラックを診断可能な状態へ整える。 */
-export function configureRawAudioTracks(media: MediaStream): void {
+/**
+ * 取得済み音声トラックの設定を既定・raw の両方でログに残し（A/B で並べて比較するため）、
+ * raw の時だけ contentHint を 'music' にして音声向けの処理を避ける。
+ */
+export function configureCaptureAudioTracks(media: MediaStream, rawAudioProfile: boolean): void {
   for (const track of media.getAudioTracks()) {
-    track.contentHint = 'music';
+    if (rawAudioProfile) track.contentHint = 'music';
     const settings = track.getSettings();
-    console.info('raw_audio_capture_settings', {
-      event: 'raw_audio_capture_settings',
+    console.info('audio_capture_settings', {
+      event: 'audio_capture_settings',
+      profile: rawAudioProfile ? 'raw' : 'default',
       channelCount: settings.channelCount,
       echoCancellation: settings.echoCancellation,
       noiseSuppression: settings.noiseSuppression,

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -7,6 +7,11 @@ import {
 import { copyToClipboard } from './clipboard';
 import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
 import { waitForStreamReady } from './stream-health';
+import {
+  configureRawAudioTracks,
+  displayAudioConstraintForRawProfile,
+  isRawAudioProfileForSearch,
+} from './audio-profile';
 import { keyframeRequestIntervalForSearch } from './stream-profile';
 import {
   SCREEN_SHARE_VIDEO_SETTINGS,
@@ -112,7 +117,9 @@ export class ScreenShareController {
     const retry = this.button('[data-screen-retry]');
     if (retry) retry.disabled = true;
     try {
-      const media = await this.deps.getDisplayMedia(displayMediaConstraints());
+      const rawAudioProfile = hasRawAudioProfile();
+      const media = await this.deps.getDisplayMedia(displayMediaConstraints(rawAudioProfile));
+      if (rawAudioProfile) configureRawAudioTracks(media);
       if (!this.isActiveStart(generation)) {
         stopMedia(media);
         return;
@@ -134,7 +141,9 @@ export class ScreenShareController {
     const retry = this.button('[data-screen-retry]');
     if (retry) retry.disabled = true;
     try {
-      media = await this.deps.getDisplayMedia(displayMediaConstraints());
+      const rawAudioProfile = hasRawAudioProfile();
+      media = await this.deps.getDisplayMedia(displayMediaConstraints(rawAudioProfile));
+      if (rawAudioProfile) configureRawAudioTracks(media);
       if (!this.isActiveStart(generation)) {
         stopMedia(media);
         return;
@@ -212,6 +221,7 @@ export class ScreenShareController {
         streamId: created.id,
         publishToken: created.publishToken,
         keyframeRequestIntervalMs: keyframeRequestIntervalForSearch(globalThis.window?.location?.search ?? ''),
+        rawAudioProfile: hasRawAudioProfile(),
       });
       stream = { ...created, publisher, media };
       if (!this.isActiveStart(generation)) {
@@ -504,7 +514,7 @@ export class ScreenShareController {
   }
 }
 
-function displayMediaConstraints(): MediaStreamConstraints {
+function displayMediaConstraints(rawAudioProfile: boolean): MediaStreamConstraints {
   return {
     // ピッカーは既定のまま（画面全体・ウィンドウ・タブから選ばせる）。検証時の
     // preferCurrentTab は macOS 権限回避用で、自タブ共有は製品では意味がない。
@@ -514,8 +524,12 @@ function displayMediaConstraints(): MediaStreamConstraints {
       height: { ideal: SCREEN_SHARE_VIDEO_SETTINGS.height },
       frameRate: { ideal: SCREEN_SHARE_VIDEO_SETTINGS.frameRate, max: SCREEN_SHARE_VIDEO_SETTINGS.frameRate },
     },
-    audio: true,
+    audio: displayAudioConstraintForRawProfile(rawAudioProfile),
   };
+}
+
+function hasRawAudioProfile(): boolean {
+  return isRawAudioProfileForSearch(globalThis.window?.location?.search ?? '');
 }
 
 function asCreateStream(value: unknown): CreateStreamResponse {

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -8,7 +8,7 @@ import { copyToClipboard } from './clipboard';
 import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
 import { waitForStreamReady } from './stream-health';
 import {
-  configureRawAudioTracks,
+  configureCaptureAudioTracks,
   displayAudioConstraintForRawProfile,
   isRawAudioProfileForSearch,
 } from './audio-profile';
@@ -119,7 +119,7 @@ export class ScreenShareController {
     try {
       const rawAudioProfile = hasRawAudioProfile();
       const media = await this.deps.getDisplayMedia(displayMediaConstraints(rawAudioProfile));
-      if (rawAudioProfile) configureRawAudioTracks(media);
+      configureCaptureAudioTracks(media, rawAudioProfile);
       if (!this.isActiveStart(generation)) {
         stopMedia(media);
         return;
@@ -143,7 +143,7 @@ export class ScreenShareController {
     try {
       const rawAudioProfile = hasRawAudioProfile();
       media = await this.deps.getDisplayMedia(displayMediaConstraints(rawAudioProfile));
-      if (rawAudioProfile) configureRawAudioTracks(media);
+      configureCaptureAudioTracks(media, rawAudioProfile);
       if (!this.isActiveStart(generation)) {
         stopMedia(media);
         return;

--- a/web/src/lib/ui/stream-profile.ts
+++ b/web/src/lib/ui/stream-profile.ts
@@ -1,11 +1,17 @@
-import { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from './whip-publisher';
+/** MP3 beta 配信だけで許可するkeyframe要求の固定間隔。 */
+export const MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS = 500;
+
+/** URL query に指定された値が重複なく完全一致するかを判定する。 */
+export function hasSingleExactQueryValue(search: string, name: string, expectedValue: string): boolean {
+  const values = new URLSearchParams(search).getAll(name);
+  return values.length === 1 && values[0] === expectedValue;
+}
 
 /** URL queryで許可されたMP3 beta配信だけに固定keyframe要求を有効化する。 */
 export function keyframeRequestIntervalForSearch(
   search: string
 ): typeof MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS | undefined {
-  const profiles = new URLSearchParams(search).getAll('stream-profile');
-  return profiles.length === 1 && profiles[0] === 'mp3-beta'
+  return hasSingleExactQueryValue(search, 'stream-profile', 'mp3-beta')
     ? MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS
     : undefined;
 }

--- a/web/src/lib/ui/whip-publisher.ts
+++ b/web/src/lib/ui/whip-publisher.ts
@@ -1,4 +1,8 @@
 import { STREAM_WHIP_BASE_URL } from '../contracts/streams';
+import { configureRawAudioSender, withRawAudioOpusParameters } from './audio-profile';
+import { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from './stream-profile';
+
+export { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from './stream-profile';
 
 /** WHIP publish 時にユーザーへ意味のある対処を示すための失敗種別。 */
 export type WhipPublishErrorCode = 'H264_UNAVAILABLE' | 'WHIP_REQUEST_FAILED' | 'WHIP_RESPONSE_INVALID';
@@ -13,9 +17,6 @@ export const SCREEN_SHARE_VIDEO_SETTINGS = {
   degradationPreference: 'maintain-resolution',
   scaleResolutionDownBy: 1,
 } as const;
-
-/** MP3 beta 配信だけで許可するkeyframe要求の固定間隔。 */
-export const MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS = 500;
 
 /** WHIP publish が開始できなかった理由を保持する。 */
 export class WhipPublishError extends Error {
@@ -66,6 +67,7 @@ interface StartWhipPublisherInput {
   streamId: string;
   publishToken: string;
   keyframeRequestIntervalMs?: typeof MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS;
+  rawAudioProfile?: boolean;
   fetchImpl?: typeof fetch;
 }
 
@@ -100,13 +102,19 @@ export async function startWhipPublisher(input: StartWhipPublisherInput): Promis
     transceiver.setCodecPreferences(preferredCodecs);
     await configureVideoSender(transceiver.sender);
     track.contentHint = SCREEN_SHARE_VIDEO_SETTINGS.contentHint;
-    for (const audioTrack of input.stream.getAudioTracks()) peerConnection.addTrack(audioTrack, input.stream);
+    for (const audioTrack of input.stream.getAudioTracks()) {
+      const audioSender = peerConnection.addTrack(audioTrack, input.stream);
+      if (input.rawAudioProfile) await configureRawAudioSender(audioSender);
+    }
 
     await peerConnection.setLocalDescription(await peerConnection.createOffer());
     await waitForIceGathering(peerConnection);
     const response = await publishOffer(peerConnection, input, input.fetchImpl ?? fetch);
     resourceUrl = response.resourceUrl;
-    await peerConnection.setRemoteDescription({ type: 'answer', sdp: response.answerSdp });
+    await peerConnection.setRemoteDescription({
+      type: 'answer',
+      sdp: input.rawAudioProfile ? withRawAudioOpusParameters(response.answerSdp) : response.answerSdp,
+    });
     const keyframeRequester = input.keyframeRequestIntervalMs === MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS
       ? createKeyframeRequester(transceiver.sender)
       : undefined;

--- a/web/tests/ui/audio-profile.test.ts
+++ b/web/tests/ui/audio-profile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
-  configureRawAudioTracks,
+  configureCaptureAudioTracks,
   displayAudioConstraintForRawProfile,
   isRawAudioProfileForSearch,
 } from '../../src/lib/ui/audio-profile';
@@ -41,15 +41,42 @@ describe('raw 音声プロファイル', () => {
     } as unknown as MediaStreamTrack;
     console.info = (...values: unknown[]) => { events.push(values); };
     try {
-      configureRawAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream);
+      configureCaptureAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream, true);
 
       expect(track.contentHint).toBe('music');
-      expect(events).toEqual([['raw_audio_capture_settings', {
-        event: 'raw_audio_capture_settings',
+      expect(events).toEqual([['audio_capture_settings', {
+        event: 'audio_capture_settings',
+        profile: 'raw',
         channelCount: 2,
         echoCancellation: false,
         noiseSuppression: false,
         autoGainControl: false,
+        sampleRate: 48_000,
+      }]]);
+    } finally {
+      console.info = previousInfo;
+    }
+  });
+
+  test('既定経路でも取得設定を記録するが contentHint は変えない', () => {
+    const previousInfo = console.info;
+    const events: unknown[][] = [];
+    const track = {
+      contentHint: '',
+      getSettings: () => ({ channelCount: 1, echoCancellation: true, noiseSuppression: true, autoGainControl: true, sampleRate: 48_000 }),
+    } as unknown as MediaStreamTrack;
+    console.info = (...values: unknown[]) => { events.push(values); };
+    try {
+      configureCaptureAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream, false);
+
+      expect(track.contentHint).toBe('');
+      expect(events).toEqual([['audio_capture_settings', {
+        event: 'audio_capture_settings',
+        profile: 'default',
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
         sampleRate: 48_000,
       }]]);
     } finally {

--- a/web/tests/ui/audio-profile.test.ts
+++ b/web/tests/ui/audio-profile.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  configureRawAudioTracks,
+  displayAudioConstraintForRawProfile,
+  isRawAudioProfileForSearch,
+} from '../../src/lib/ui/audio-profile';
+
+describe('raw 音声プロファイル', () => {
+  test('audio-profile=raw が重複なく1個の時だけ有効にする', () => {
+    expect(isRawAudioProfileForSearch('?audio-profile=raw')).toBe(true);
+    expect(isRawAudioProfileForSearch('')).toBe(false);
+    expect(isRawAudioProfileForSearch('?audio-profile=aac')).toBe(false);
+    expect(isRawAudioProfileForSearch('?audio-profile=raw&audio-profile=raw')).toBe(false);
+    expect(isRawAudioProfileForSearch('?audio-profile=raw&audio-profile=aac')).toBe(false);
+    expect(isRawAudioProfileForSearch('?audio-profile=')).toBe(false);
+    expect(isRawAudioProfileForSearch('?audio-profile=RAW')).toBe(false);
+  });
+
+  test('有効時だけブラウザの音声処理を無効化する制約を返す', () => {
+    expect(displayAudioConstraintForRawProfile(false)).toBe(true);
+    expect(displayAudioConstraintForRawProfile(true)).toEqual({
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+    });
+  });
+
+  test('raw 音声トラックを music として送出し、取得設定を記録する', () => {
+    const previousInfo = console.info;
+    const events: unknown[][] = [];
+    const track = {
+      contentHint: '',
+      getSettings: () => ({
+        channelCount: 2,
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        sampleRate: 48_000,
+      }),
+    } as unknown as MediaStreamTrack;
+    console.info = (...values: unknown[]) => { events.push(values); };
+    try {
+      configureRawAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream);
+
+      expect(track.contentHint).toBe('music');
+      expect(events).toEqual([['raw_audio_capture_settings', {
+        event: 'raw_audio_capture_settings',
+        channelCount: 2,
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        sampleRate: 48_000,
+      }]]);
+    } finally {
+      console.info = previousInfo;
+    }
+  });
+});

--- a/web/tests/ui/screen-share-profile.test.ts
+++ b/web/tests/ui/screen-share-profile.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 
 import { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from '../../src/lib/ui/whip-publisher';
-import { keyframeRequestIntervalForSearch } from '../../src/lib/ui/stream-profile';
+import { hasSingleExactQueryValue, keyframeRequestIntervalForSearch } from '../../src/lib/ui/stream-profile';
 
 describe('MP3 beta stream profile', () => {
+  test('共通のquery判定はキーと値の完全一致を重複なく要求する', () => {
+    expect(hasSingleExactQueryValue('?stream-profile=mp3-beta', 'stream-profile', 'mp3-beta')).toBe(true);
+    expect(hasSingleExactQueryValue('?stream-profile=mp3-beta&stream-profile=mp3-beta', 'stream-profile', 'mp3-beta')).toBe(false);
+  });
+
   test('stream-profile=mp3-betaが1個だけの時に固定intervalを返す', () => {
     expect(keyframeRequestIntervalForSearch('?stream-profile=mp3-beta')).toBe(
       MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS

--- a/web/tests/ui/screen-share.test.ts
+++ b/web/tests/ui/screen-share.test.ts
@@ -76,7 +76,7 @@ describe('画面共有 controller', () => {
       addEventListener: () => undefined,
       stop: () => { stopped += 1; },
     };
-    const audioTrack = { stop: () => { stopped += 1; } };
+    const audioTrack = { stop: () => { stopped += 1; }, getSettings: () => ({ channelCount: 2 }) };
     const media = {
       getTracks: () => [videoTrack, audioTrack],
       getVideoTracks: () => [videoTrack],

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { STREAM_WHIP_BASE_URL } from '../../src/lib/contracts/streams';
+import { withRawAudioOpusParameters } from '../../src/lib/ui/audio-profile';
 import {
   SCREEN_SHARE_VIDEO_SETTINGS,
   buildWhipUrl,
@@ -49,6 +50,51 @@ describe('WHIP publisher', () => {
     expect(resolveWhipResourceUrl('/live/other/whip/resource', 'Ab12Cd34Ef56')).toBeNull();
   });
 
+  test('raw 音声用に既存の Opus fmtp へ不足パラメータだけを補完する', () => {
+    const answer = [
+      'v=0',
+      'a=rtpmap:111 opus/48000/2',
+      'a=fmtp:111 minptime=10;useinbandfec=1;stereo=1;sprop-stereo=1',
+    ].join('\r\n');
+
+    expect(withRawAudioOpusParameters(answer)).toBe([
+      'v=0',
+      'a=rtpmap:111 opus/48000/2',
+      'a=fmtp:111 minptime=10;useinbandfec=1;stereo=1;sprop-stereo=1;maxaveragebitrate=128000',
+    ].join('\r\n'));
+  });
+
+  test('raw 音声用に fmtp がない Opus だけへ fmtp 行を追加する', () => {
+    const answer = [
+      'a=rtpmap:111 opus/48000/2',
+      'a=rtpmap:0 PCMU/8000',
+      'a=fmtp:0 useinbandfec=1',
+    ].join('\n');
+
+    expect(withRawAudioOpusParameters(answer)).toBe([
+      'a=rtpmap:111 opus/48000/2',
+      'a=fmtp:111 stereo=1;sprop-stereo=1;maxaveragebitrate=128000',
+      'a=rtpmap:0 PCMU/8000',
+      'a=fmtp:0 useinbandfec=1',
+    ].join('\n'));
+  });
+
+  test('raw 音声用の Opus fmtp は重複を正規化し、Opus 以外を変更しない', () => {
+    const answer = [
+      'a=rtpmap:111 opus/48000/2',
+      'a=fmtp:111 stereo=0;stereo=1;maxaveragebitrate=64000;useinbandfec=1',
+      'a=rtpmap:96 H264/90000',
+      'a=fmtp:96 profile-level-id=42e01f',
+    ].join('\n');
+
+    expect(withRawAudioOpusParameters(answer)).toBe([
+      'a=rtpmap:111 opus/48000/2',
+      'a=fmtp:111 useinbandfec=1;stereo=1;sprop-stereo=1;maxaveragebitrate=128000',
+      'a=rtpmap:96 H264/90000',
+      'a=fmtp:96 profile-level-id=42e01f',
+    ].join('\n'));
+  });
+
   test('H.264 映像とすべての音声 track を送出し、同じ入力で一度だけ再 publish できる', async () => {
     const previousSender = globalThis.RTCRtpSender;
     const previousConnection = globalThis.RTCPeerConnection;
@@ -57,6 +103,7 @@ describe('WHIP publisher', () => {
     const senderParameters: RTCRtpSendParameters[] = [];
     let keyframeRequests = 0;
     const addedAudioTracks: MediaStreamTrack[] = [];
+    const remoteDescriptions: RTCSessionDescriptionInit[] = [];
     let delayedDelete: ReturnType<typeof deferred<Response>> | null = null;
     let closed = 0;
     class Sender {
@@ -91,7 +138,7 @@ describe('WHIP publisher', () => {
       }
       async createOffer() { return { sdp: 'offer', type: 'offer' } as RTCSessionDescriptionInit; }
       async setLocalDescription() {}
-      async setRemoteDescription() {}
+      async setRemoteDescription(description: RTCSessionDescriptionInit) { remoteDescriptions.push(description); }
       close() { closed += 1; }
       addEventListener() {}
       removeEventListener() {}
@@ -162,6 +209,11 @@ describe('WHIP publisher', () => {
       })));
       expect(videoTrack.contentHint).toBe(SCREEN_SHARE_VIDEO_SETTINGS.contentHint);
       expect(addedAudioTracks).toEqual([...audioTracks, ...audioTracks]);
+      expect(remoteDescriptions).toEqual([
+        { type: 'answer', sdp: 'answer' },
+        { type: 'answer', sdp: 'answer' },
+        { type: 'answer', sdp: 'answer' },
+      ]);
       expect(requests[0]?.headers).toMatchObject({ Authorization: 'Bearer first-token' });
       expect(requests[1]?.headers).toMatchObject({ Authorization: 'Bearer extended-token' });
       expect(requests[2]?.headers).toMatchObject({ Authorization: 'Bearer extended-token' });
@@ -217,6 +269,40 @@ describe('WHIP publisher', () => {
     }
   });
 
+  test('raw 音声プロファイルだけが Opus answer と audio sender の上限を変更する', async () => {
+    const restore = installWebRtcMocks(() => undefined);
+    const audioTrack = { stop() {} } as unknown as MediaStreamTrack;
+    try {
+      const publisher = await startWhipPublisher({
+        ...testPublisherInput(),
+        stream: {
+          getVideoTracks: () => [{ contentHint: '', stop() {} }],
+          getAudioTracks: () => [audioTrack],
+        } as unknown as MediaStream,
+        rawAudioProfile: true,
+        fetchImpl: (async () => new Response([
+          'a=rtpmap:111 opus/48000/2',
+          'a=fmtp:111 minptime=10',
+        ].join('\r\n'), {
+          status: 201,
+          headers: { Location: '/live/Ab12Cd34Ef56/whip/resource' },
+        })) as unknown as typeof fetch,
+      });
+      publisher.close();
+
+      expect(restore.audioParameters).toEqual([128_000]);
+      expect(restore.remoteDescriptions).toEqual([{
+        type: 'answer',
+        sdp: [
+          'a=rtpmap:111 opus/48000/2',
+          'a=fmtp:111 minptime=10;stereo=1;sprop-stereo=1;maxaveragebitrate=128000',
+        ].join('\r\n'),
+      }]);
+    } finally {
+      restore.globals();
+    }
+  });
+
 });
 
 interface WebRtcMockState {
@@ -228,6 +314,8 @@ interface WebRtcMockState {
   getParametersCalls: number;
   postCalls: number;
   closed: number;
+  audioParameters: Array<number | undefined>;
+  remoteDescriptions: RTCSessionDescriptionInit[];
   globals: () => void;
 }
 
@@ -242,6 +330,8 @@ function installWebRtcMocks(
     getParametersCalls: 0,
     postCalls: 0,
     closed: 0,
+    audioParameters: [],
+    remoteDescriptions: [],
     globals: () => {
       Object.defineProperty(globalThis, 'RTCRtpSender', { configurable: true, value: previousSender });
       Object.defineProperty(globalThis, 'RTCPeerConnection', { configurable: true, value: previousConnection });
@@ -272,10 +362,19 @@ function installWebRtcMocks(
         },
       } as unknown as RTCRtpTransceiver;
     }
-    addTrack() { return {} as RTCRtpSender; }
+    addTrack() {
+      return {
+        getParameters: () => ({}),
+        setParameters: async (parameters: RTCRtpSendParameters) => {
+          state.audioParameters.push(parameters.encodings?.[0]?.maxBitrate);
+        },
+      } as unknown as RTCRtpSender;
+    }
     async createOffer() { return { sdp: 'offer', type: 'offer' } as RTCSessionDescriptionInit; }
     async setLocalDescription() {}
-    async setRemoteDescription() {}
+    async setRemoteDescription(description: RTCSessionDescriptionInit) {
+      state.remoteDescriptions.push(description);
+    }
     close() { state.closed += 1; }
     addEventListener() {}
     removeEventListener() {}

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -269,6 +269,31 @@ describe('WHIP publisher', () => {
     }
   });
 
+  test('既定経路では Opus を含む answer を加工せず audio sender の上限も変更しない', async () => {
+    const restore = installWebRtcMocks(() => undefined);
+    const audioTrack = { stop() {} } as unknown as MediaStreamTrack;
+    const answerSdp = ['a=rtpmap:111 opus/48000/2', 'a=fmtp:111 minptime=10;useinbandfec=1'].join('\r\n');
+    try {
+      const publisher = await startWhipPublisher({
+        ...testPublisherInput(),
+        stream: {
+          getVideoTracks: () => [{ contentHint: '', stop() {} }],
+          getAudioTracks: () => [audioTrack],
+        } as unknown as MediaStream,
+        fetchImpl: (async () => new Response(answerSdp, {
+          status: 201,
+          headers: { Location: '/live/Ab12Cd34Ef56/whip/resource' },
+        })) as unknown as typeof fetch,
+      });
+      publisher.close();
+
+      expect(restore.audioParameters).toEqual([]);
+      expect(restore.remoteDescriptions).toEqual([{ type: 'answer', sdp: answerSdp }]);
+    } finally {
+      restore.globals();
+    }
+  });
+
   test('raw 音声プロファイルだけが Opus answer と audio sender の上限を変更する', async () => {
     const restore = installWebRtcMocks(() => undefined);
     const audioTrack = { stop() {} } as unknown as MediaStreamTrack;


### PR DESCRIPTION
## なぜこの変更が必要か

本番配信の音声が「モノラルでこもって聞こえる」と報告があり、出口（RTSPT, AAC 48 kHz stereo）を計測すると L−R 差分が −91 dB（完全モノラル）だった。共有元はステレオ素材で、MediaMTX 側の Opus 受信 SDP は `stereo=1` を宣言済み。ブラウザ側は `getDisplayMedia({ audio: true })` で制約なし・contentHint なし・SDP 加工なし。Chrome のタブ音声処理（EC / NS / AGC）がモノラル化と高域減衰を起こしているという仮説を、本番既定を変えずに A/B で確かめる経路が要る。

## 変更内容

- `audio-profile=raw` クエリが重複なく 1 個ある時だけ有効な raw 音声プロファイルを追加（`stream-profile=mp3-beta` と同じ判定ヘルパー `hasSingleExactQueryValue` に一般化）
- 有効時: 音声制約 `echoCancellation / noiseSuppression / autoGainControl = false`、音声トラック `contentHint = 'music'`、answer SDP の Opus fmtp に `stereo=1;sprop-stereo=1;maxaveragebitrate=128000` を補完、音声 sender に `maxBitrate 128000` をベストエフォート設定、`track.getSettings()` を構造化ログ出力
- 既定経路（クエリなし）の制約と SDP は不変（テストで担保）
- `docs/streaming/stability-audio-verification.md` に候補の説明と L−R 計測手順を追記

## 意思決定

- 原因は仮説として扱い、既定は変えずフラグで A/B する（出口 L−R 計測で効果を確認してから既定化を判断）
- relay 側でのステレオ化は却下（入力がモノなら情報は戻らない）

## テスト

- [x] `bun run typecheck`
- [x] `bun test` 765 pass（新規: audio-profile / whip-publisher の SDP 補完・既定不変）
- [ ] 本番 A/B（出口 L−R 計測 + 実聴）は PR マージ後にハーネスで実施

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt6tb5xRLk8cuoDaboAzEW
