### PR TITLE
feat(streaming): 音声のステレオ化（raw）を既定にする

### DIFF
--- a/docs/streaming/requirements.md
+++ b/docs/streaming/requirements.md
@@ -66,7 +66,7 @@ Issue #93 で `stream.web-screen.net` に凍結後、実装着手前の 2026-09-
 
 MP3 betaだけは、ChromeでURL queryに `stream-profile=mp3-beta` が**ちょうど1個**ある時、ブラウザから500 ms周期で次キーフレームを要求する。通常アクセス、unknown値、重複値では無効で、任意intervalは受け付けない。これは生成完了やreaderのfirst-packet IDRを保証せず、MediaMTXにGOP cacheもない。非対応ブラウザでは第2引数が無視され、要求がno-opになる可能性がある。本番AACの2秒GOP契約は変更しない。
 
-同じ判定意味論で、URL queryに `audio-profile=raw` が**ちょうど1個**ある時だけ、画面取得の音声制約を `echoCancellation / noiseSuppression / autoGainControl = false` にし、音声トラックに `contentHint = 'music'`、answer SDPのOpus fmtpに `stereo=1;maxaveragebitrate=128000` を補い、audio senderの上限を128 kbpsにする。これはモノラル化の仮説を比較するための候補で、既定経路の制約・SDPは変えない（[stability-audio-verification.md](stability-audio-verification.md) の A/B 手順）。
+音声は**既定がraw**で、画面取得の音声制約を `echoCancellation / noiseSuppression / autoGainControl = false` にし、音声トラックに `contentHint = 'music'`、answer SDPのOpus fmtpに `stereo=1;sprop-stereo=1;maxaveragebitrate=128000` を補い、audio senderの上限を128 kbpsにする。2026-09-02の本番A/Bで旧挙動は出口のL−Rが−91 dB（完全モノラル）だったのに対し、rawは−57.6 dBでステレオ成分が残り実聴でもステレオだったため既定にした。同じ判定意味論で、URL queryに `audio-profile=legacy` が**ちょうど1個**ある時だけ旧挙動（`audio: true`・contentHintなし・SDP無加工・sender未設定）へ戻す。unknown値・重複・空値・case違いは既定のrawになる（[stability-audio-verification.md](stability-audio-verification.md) の A/B 手順）。
 
 ### キーフレーム 2 秒固定が連鎖させる制約
 
@@ -88,7 +88,7 @@ MP3 betaだけは、ChromeでURL queryに `stream-profile=mp3-beta` が**ちょ�
 | コンテンツヒント | `track.contentHint = 'detail'` | R10。I18で動画像・文字可読性とも合格 |
 | スケール | `encodings[0].scaleResolutionDownBy = 1` | R10。I18で動画像・文字可読性とも合格 |
 | 解像度 / fps | **入力 1280x720 / 最大 30 fps** | I18で動画像のRTSP出力は1280x720 / 30.00〜30.06 fps。24 fpsの旧代表素材比較は変更しない |
-| 画面取得 | `getDisplayMedia({ video, audio: true })`（`audio-profile=raw` 時だけ音声制約オブジェクト。**既定ピッカー**。画面全体・ウィンドウ・タブから選ばせる） | Chrome のタブ共有で「タブの音声を共有」をオンにした時だけ音声が付く。macOS の画面収録未許可はエラー文言でシステム設定へ案内する |
+| 画面取得 | `getDisplayMedia({ video, audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false } })`（`audio-profile=legacy` 時だけ `audio: true`。**既定ピッカー**。画面全体・ウィンドウ・タブから選ばせる） | Chrome のタブ共有で「タブの音声を共有」をオンにした時だけ音声が付く。macOS の画面収録未許可はエラー文言でシステム設定へ案内する |
 | 開始判定 | ingress / egress bytes を最大 10 秒、1 秒間隔で監視 | 両方が連続観測で増えた時だけ URL を表示する。未到達なら 1 回自動再 publish する |
 
 ### 対応ブラウザ

--- a/docs/streaming/stability-audio-verification.md
+++ b/docs/streaming/stability-audio-verification.md
@@ -18,7 +18,7 @@ Qiita の「配信が不安定な時」の OBS 設定を比較対象にし、Web
 | 劣化方針 | OBS プリセット P7 / 高品質 | **`contentHint = 'detail'` + `maintain-resolution`** | I18 の本番 relay 合成QAで、文字可読性と動画安定性が合格 |
 | スケール | — | **`scaleResolutionDownBy = 1`** | I18 で動画像区間の送出解像度を1280x720に維持 |
 | キーフレーム | 0 秒（自動） | **通常はMediaMTXのPLIにより約2秒** | MP3 betaのChromeだけ500 ms周期で次キーフレームを要求。first-packet IDRは保証しない |
-| 音声 | FFmpeg AAC、音声トラック 1 | **タブ音声 → WebRTC 音声 → AAC-LC 48 kHz / stereo / 128 kbps** | Chrome で「タブの音声を共有」をオンにした時だけ音声を付ける |
+| 音声 | FFmpeg AAC、音声トラック 1 | **タブ音声 → WebRTC 音声 → AAC-LC 48 kHz / stereo / 128 kbps。Chrome の音声処理は切る（EC/NS/AGC=false, contentHint 'music'）** | Chrome で「タブの音声を共有」をオンにした時だけ音声を付ける |
 
 採用実装の正本は `web/src/lib/ui/whip-publisher.ts`。本番 relay の合成 motion/static QA は合格したが、WebScreen UI からの actual YouTube 最終確認は未実施。
 full設定がブラウザに拒否された時はfresh parametersからmaxBitrate-only fallbackを1回だけ試す。これは配信継続の互換策であり、文字品質を保証しない。
@@ -114,7 +114,8 @@ MP3 48 kHz stereo 128 kbpsは30分・非無音・A/V 7〜15 msまで自動確認
 - 選択結果に音声トラックがあれば「音声を含めて配信しています」、なければ「映像のみ」と表示する。
 - relay 出口は現行でH.264 + AAC、MP3 beta候補でH.264 + MP3を `verify-codecs.sh` で検証する。
 - 表示文言は **「検証時に音声が出ることを確認済み」** とし、PoC という表現は使わない。
-- `?audio-profile=raw` は、Chromeの音声処理（EC / NS / AGC）がモノラル化・高域減衰の一因かもしれないという仮説を比較する候補（既定では無効。ブラウザ取得側の設定で、relay の `audio-profile.sh` とは別物）。
-- A/Bでは同じ共有元で既定とrawを各5秒測り、`ffmpeg -rtsp_transport tcp -i rtsp://webscreen.tv/live/{id} -t 5 -vn -af "pan=mono|c0=0.5*c0-0.5*c1,volumedetect" -f null -` を実行する。L−R差分が本体（`volumedetect` 単独）より 40 dB 以上低ければモノラルとみなす（2026-09-02 の実測は本体 −21 dB に対し L−R −91 dB）。
+- Chromeの音声処理（EC / NS / AGC）がモノラル化の原因だったため、**rawが既定**になった（ブラウザ取得側の設定で、relay の `audio-profile.sh` とは別物）。2026-09-02の本番A/Bで、legacy（処理あり）は出口のL−Rが−91 dBの完全モノラルだったのに対し、rawは−57.6 dB（本体 −32.6 dB との差 25 dB）でステレオ成分が残り、実聴でもステレオを確認した。
+- `?audio-profile=legacy` は旧挙動へ戻す退避経路。rawが原因かを切り分ける時と、rawで問題が出た配信環境の一時回避に使う。
+- A/Bでは同じ共有元でrawとlegacyを各5秒測り、`ffmpeg -rtsp_transport tcp -i rtsp://webscreen.tv/live/{id} -t 5 -vn -af "pan=mono|c0=0.5*c0-0.5*c1,volumedetect" -f null -` を実行する。L−R差分が本体（`volumedetect` 単独）より 40 dB 以上低ければモノラルとみなす（2026-09-02 の legacy 実測は本体 −21 dB に対し L−R −91 dB）。
 - 測定境界: 出口は relay が `-ac 2 -b:a 128k` で再エンコードした後なので、判定できるのは**モノラルかどうか**まで。Opus の `maxaveragebitrate` や高域の差は出口に届かないため、高域比較は ingress（`rtsp://127.0.0.1:8554`、サーバー内）で測る。
-- 取得側の `audio_capture_settings` ログ（channelCount / EC / NS / AGC）は既定・rawの両方で出るので、A/Bではこれも並べて比較する。raw で `raw_audio_sender_bitrate_failed` が出た時は 128 kbps 未適用として記録する。
+- 取得側の `audio_capture_settings` ログ（`profile` は `raw` / `legacy`、channelCount / EC / NS / AGC）は両方で出るので、A/Bではこれも並べて比較する。raw で `raw_audio_sender_bitrate_failed` が出た時は 128 kbps 未適用として記録する。

--- a/web/src/lib/ui/audio-profile.ts
+++ b/web/src/lib/ui/audio-profile.ts
@@ -1,5 +1,8 @@
 import { hasSingleExactQueryValue } from './stream-profile';
 
+/** 画面取得〜送出までの音声の扱い。'legacy' は Chrome の音声処理に任せた旧挙動。 */
+export type AudioProfile = 'raw' | 'legacy';
+
 export const RAW_AUDIO_MAX_BITRATE = 128_000;
 
 const RAW_AUDIO_CONSTRAINTS = {
@@ -8,27 +11,32 @@ const RAW_AUDIO_CONSTRAINTS = {
   autoGainControl: false,
 } as const satisfies MediaTrackConstraints;
 
-/** URL query で raw 音声プロファイルが明示的に有効かを判定する。 */
-export function isRawAudioProfileForSearch(search: string): boolean {
-  return hasSingleExactQueryValue(search, 'audio-profile', 'raw');
+/**
+ * URL query から音声プロファイルを決める。既定は raw。
+ * 2026-09-02 の本番 A/B で、旧挙動は出口の L−R が −91 dB（完全モノラル）だったのに対し
+ * raw は −57.6 dB でステレオ成分が残り、実聴でもステレオだったため raw を既定にした。
+ * `audio-profile=legacy` が重複なく1個ある時だけ旧挙動へ戻す（切り分け用の退避経路）。
+ */
+export function resolveAudioProfileForSearch(search: string): AudioProfile {
+  return hasSingleExactQueryValue(search, 'audio-profile', 'legacy') ? 'legacy' : 'raw';
 }
 
-/** raw 音声プロファイルに応じた画面共有の音声制約を返す。 */
-export function displayAudioConstraintForRawProfile(rawAudioProfile: boolean): boolean | MediaTrackConstraints {
-  return rawAudioProfile ? { ...RAW_AUDIO_CONSTRAINTS } : true;
+/** 音声プロファイルに応じた画面共有の音声制約を返す。 */
+export function displayAudioConstraint(profile: AudioProfile): boolean | MediaTrackConstraints {
+  return profile === 'raw' ? { ...RAW_AUDIO_CONSTRAINTS } : true;
 }
 
 /**
- * 取得済み音声トラックの設定を既定・raw の両方でログに残し（A/B で並べて比較するため）、
+ * 取得済み音声トラックの設定を raw・legacy の両方でログに残し（A/B で並べて比較するため）、
  * raw の時だけ contentHint を 'music' にして音声向けの処理を避ける。
  */
-export function configureCaptureAudioTracks(media: MediaStream, rawAudioProfile: boolean): void {
+export function configureCaptureAudioTracks(media: MediaStream, profile: AudioProfile): void {
   for (const track of media.getAudioTracks()) {
-    if (rawAudioProfile) track.contentHint = 'music';
+    if (profile === 'raw') track.contentHint = 'music';
     const settings = track.getSettings();
     console.info('audio_capture_settings', {
       event: 'audio_capture_settings',
-      profile: rawAudioProfile ? 'raw' : 'default',
+      profile,
       channelCount: settings.channelCount,
       echoCancellation: settings.echoCancellation,
       noiseSuppression: settings.noiseSuppression,

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -9,8 +9,9 @@ import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './req
 import { waitForStreamReady } from './stream-health';
 import {
   configureCaptureAudioTracks,
-  displayAudioConstraintForRawProfile,
-  isRawAudioProfileForSearch,
+  displayAudioConstraint,
+  resolveAudioProfileForSearch,
+  type AudioProfile,
 } from './audio-profile';
 import { keyframeRequestIntervalForSearch } from './stream-profile';
 import {
@@ -117,9 +118,9 @@ export class ScreenShareController {
     const retry = this.button('[data-screen-retry]');
     if (retry) retry.disabled = true;
     try {
-      const rawAudioProfile = hasRawAudioProfile();
-      const media = await this.deps.getDisplayMedia(displayMediaConstraints(rawAudioProfile));
-      configureCaptureAudioTracks(media, rawAudioProfile);
+      const profile = currentAudioProfile();
+      const media = await this.deps.getDisplayMedia(displayMediaConstraints(profile));
+      configureCaptureAudioTracks(media, profile);
       if (!this.isActiveStart(generation)) {
         stopMedia(media);
         return;
@@ -141,9 +142,9 @@ export class ScreenShareController {
     const retry = this.button('[data-screen-retry]');
     if (retry) retry.disabled = true;
     try {
-      const rawAudioProfile = hasRawAudioProfile();
-      media = await this.deps.getDisplayMedia(displayMediaConstraints(rawAudioProfile));
-      configureCaptureAudioTracks(media, rawAudioProfile);
+      const profile = currentAudioProfile();
+      media = await this.deps.getDisplayMedia(displayMediaConstraints(profile));
+      configureCaptureAudioTracks(media, profile);
       if (!this.isActiveStart(generation)) {
         stopMedia(media);
         return;
@@ -221,7 +222,7 @@ export class ScreenShareController {
         streamId: created.id,
         publishToken: created.publishToken,
         keyframeRequestIntervalMs: keyframeRequestIntervalForSearch(globalThis.window?.location?.search ?? ''),
-        rawAudioProfile: hasRawAudioProfile(),
+        audioProfile: currentAudioProfile(),
       });
       stream = { ...created, publisher, media };
       if (!this.isActiveStart(generation)) {
@@ -514,7 +515,7 @@ export class ScreenShareController {
   }
 }
 
-function displayMediaConstraints(rawAudioProfile: boolean): MediaStreamConstraints {
+function displayMediaConstraints(profile: AudioProfile): MediaStreamConstraints {
   return {
     // ピッカーは既定のまま（画面全体・ウィンドウ・タブから選ばせる）。検証時の
     // preferCurrentTab は macOS 権限回避用で、自タブ共有は製品では意味がない。
@@ -524,12 +525,12 @@ function displayMediaConstraints(rawAudioProfile: boolean): MediaStreamConstrain
       height: { ideal: SCREEN_SHARE_VIDEO_SETTINGS.height },
       frameRate: { ideal: SCREEN_SHARE_VIDEO_SETTINGS.frameRate, max: SCREEN_SHARE_VIDEO_SETTINGS.frameRate },
     },
-    audio: displayAudioConstraintForRawProfile(rawAudioProfile),
+    audio: displayAudioConstraint(profile),
   };
 }
 
-function hasRawAudioProfile(): boolean {
-  return isRawAudioProfileForSearch(globalThis.window?.location?.search ?? '');
+function currentAudioProfile(): AudioProfile {
+  return resolveAudioProfileForSearch(globalThis.window?.location?.search ?? '');
 }
 
 function asCreateStream(value: unknown): CreateStreamResponse {

--- a/web/src/lib/ui/whip-publisher.ts
+++ b/web/src/lib/ui/whip-publisher.ts
@@ -1,5 +1,5 @@
 import { STREAM_WHIP_BASE_URL } from '../contracts/streams';
-import { configureRawAudioSender, withRawAudioOpusParameters } from './audio-profile';
+import { configureRawAudioSender, withRawAudioOpusParameters, type AudioProfile } from './audio-profile';
 import { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from './stream-profile';
 
 export { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from './stream-profile';
@@ -67,7 +67,8 @@ interface StartWhipPublisherInput {
   streamId: string;
   publishToken: string;
   keyframeRequestIntervalMs?: typeof MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS;
-  rawAudioProfile?: boolean;
+  /** 呼び出し元が URL query から決めた音声プロファイル（既定は raw だが、省略は許さず明示させる）。 */
+  audioProfile: AudioProfile;
   fetchImpl?: typeof fetch;
 }
 
@@ -104,7 +105,7 @@ export async function startWhipPublisher(input: StartWhipPublisherInput): Promis
     track.contentHint = SCREEN_SHARE_VIDEO_SETTINGS.contentHint;
     for (const audioTrack of input.stream.getAudioTracks()) {
       const audioSender = peerConnection.addTrack(audioTrack, input.stream);
-      if (input.rawAudioProfile) await configureRawAudioSender(audioSender);
+      if (input.audioProfile === 'raw') await configureRawAudioSender(audioSender);
     }
 
     await peerConnection.setLocalDescription(await peerConnection.createOffer());
@@ -113,7 +114,7 @@ export async function startWhipPublisher(input: StartWhipPublisherInput): Promis
     resourceUrl = response.resourceUrl;
     await peerConnection.setRemoteDescription({
       type: 'answer',
-      sdp: input.rawAudioProfile ? withRawAudioOpusParameters(response.answerSdp) : response.answerSdp,
+      sdp: input.audioProfile === 'raw' ? withRawAudioOpusParameters(response.answerSdp) : response.answerSdp,
     });
     const keyframeRequester = input.keyframeRequestIntervalMs === MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS
       ? createKeyframeRequester(transceiver.sender)

--- a/web/src/pages/screen-share.astro
+++ b/web/src/pages/screen-share.astro
@@ -7,5 +7,6 @@ import { resolveLocale } from '../i18n';
 export const prerender = false;
 
 const locale = resolveLocale(Astro.request.headers.get('accept-language'));
-return Astro.redirect(`/${locale}/screen-share/`, 302);
+// audio-profile=legacy 等のクエリを言語別 URL へ引き継ぐ（落とすと既定の raw に戻ってしまう）
+return Astro.redirect(`/${locale}/screen-share/${Astro.url.search}`, 302);
 ---

--- a/web/tests/ui/audio-profile.test.ts
+++ b/web/tests/ui/audio-profile.test.ts
@@ -2,28 +2,29 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   configureCaptureAudioTracks,
-  displayAudioConstraintForRawProfile,
-  isRawAudioProfileForSearch,
+  displayAudioConstraint,
+  resolveAudioProfileForSearch,
 } from '../../src/lib/ui/audio-profile';
 
-describe('raw 音声プロファイル', () => {
-  test('audio-profile=raw が重複なく1個の時だけ有効にする', () => {
-    expect(isRawAudioProfileForSearch('?audio-profile=raw')).toBe(true);
-    expect(isRawAudioProfileForSearch('')).toBe(false);
-    expect(isRawAudioProfileForSearch('?audio-profile=aac')).toBe(false);
-    expect(isRawAudioProfileForSearch('?audio-profile=raw&audio-profile=raw')).toBe(false);
-    expect(isRawAudioProfileForSearch('?audio-profile=raw&audio-profile=aac')).toBe(false);
-    expect(isRawAudioProfileForSearch('?audio-profile=')).toBe(false);
-    expect(isRawAudioProfileForSearch('?audio-profile=RAW')).toBe(false);
+describe('音声プロファイル', () => {
+  test('audio-profile=legacy が重複なく1個の時だけ旧挙動へ戻す', () => {
+    expect(resolveAudioProfileForSearch('?audio-profile=legacy')).toBe('legacy');
+    expect(resolveAudioProfileForSearch('')).toBe('raw');
+    expect(resolveAudioProfileForSearch('?audio-profile=raw')).toBe('raw');
+    expect(resolveAudioProfileForSearch('?audio-profile=aac')).toBe('raw');
+    expect(resolveAudioProfileForSearch('?audio-profile=legacy&audio-profile=legacy')).toBe('raw');
+    expect(resolveAudioProfileForSearch('?audio-profile=legacy&audio-profile=raw')).toBe('raw');
+    expect(resolveAudioProfileForSearch('?audio-profile=')).toBe('raw');
+    expect(resolveAudioProfileForSearch('?audio-profile=LEGACY')).toBe('raw');
   });
 
-  test('有効時だけブラウザの音声処理を無効化する制約を返す', () => {
-    expect(displayAudioConstraintForRawProfile(false)).toBe(true);
-    expect(displayAudioConstraintForRawProfile(true)).toEqual({
+  test('raw だけブラウザの音声処理を無効化する制約を返す', () => {
+    expect(displayAudioConstraint('raw')).toEqual({
       echoCancellation: false,
       noiseSuppression: false,
       autoGainControl: false,
     });
+    expect(displayAudioConstraint('legacy')).toBe(true);
   });
 
   test('raw 音声トラックを music として送出し、取得設定を記録する', () => {
@@ -41,7 +42,7 @@ describe('raw 音声プロファイル', () => {
     } as unknown as MediaStreamTrack;
     console.info = (...values: unknown[]) => { events.push(values); };
     try {
-      configureCaptureAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream, true);
+      configureCaptureAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream, 'raw');
 
       expect(track.contentHint).toBe('music');
       expect(events).toEqual([['audio_capture_settings', {
@@ -58,7 +59,7 @@ describe('raw 音声プロファイル', () => {
     }
   });
 
-  test('既定経路でも取得設定を記録するが contentHint は変えない', () => {
+  test('legacy でも取得設定を記録するが contentHint は変えない', () => {
     const previousInfo = console.info;
     const events: unknown[][] = [];
     const track = {
@@ -67,12 +68,12 @@ describe('raw 音声プロファイル', () => {
     } as unknown as MediaStreamTrack;
     console.info = (...values: unknown[]) => { events.push(values); };
     try {
-      configureCaptureAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream, false);
+      configureCaptureAudioTracks({ getAudioTracks: () => [track] } as unknown as MediaStream, 'legacy');
 
       expect(track.contentHint).toBe('');
       expect(events).toEqual([['audio_capture_settings', {
         event: 'audio_capture_settings',
-        profile: 'default',
+        profile: 'legacy',
         channelCount: 1,
         echoCancellation: true,
         noiseSuppression: true,

--- a/web/tests/ui/screen-share.test.ts
+++ b/web/tests/ui/screen-share.test.ts
@@ -64,6 +64,7 @@ describe('画面共有 controller', () => {
     let closed = 0;
     let deleted = 0;
     let requestedConstraints: MediaStreamConstraints | undefined;
+    let publishedInput: Parameters<ScreenShareDependencies['startWhipPublisher']>[0] | undefined;
     const page = fakeScreenSharePage();
     const publisher: WhipPublisher = {
       close: () => { closed += 1; },
@@ -76,7 +77,7 @@ describe('画面共有 controller', () => {
       addEventListener: () => undefined,
       stop: () => { stopped += 1; },
     };
-    const audioTrack = { stop: () => { stopped += 1; }, getSettings: () => ({ channelCount: 2 }) };
+    const audioTrack = { contentHint: '', stop: () => { stopped += 1; }, getSettings: () => ({ channelCount: 2 }) };
     const media = {
       getTracks: () => [videoTrack, audioTrack],
       getVideoTracks: () => [videoTrack],
@@ -97,7 +98,10 @@ describe('画面共有 controller', () => {
         }
         return null;
       }) as unknown as ScreenShareDependencies['requestJson'],
-      startWhipPublisher: async () => publisher,
+      startWhipPublisher: async (input) => {
+        publishedInput = input;
+        return publisher;
+      },
       waitForStreamReady: async () => true,
       getDisplayMedia: async (constraints) => {
         requestedConstraints = constraints;
@@ -114,14 +118,17 @@ describe('画面共有 controller', () => {
     await waitFor(() => !page.step('url').hidden);
     expect(page.url.value).toBe('rtspt://webscreen.tv/live/Ab12Cd34Ef56');
     expect(page.button('[data-screen-audio-status]').textContent).toBe('audio-included');
+    // クエリなし = 既定の raw なので、音声処理を切る制約と raw プロファイルで publish する。
     expect(requestedConstraints).toEqual({
-      audio: true,
+      audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
       video: {
         width: { ideal: 1280 },
         height: { ideal: 720 },
         frameRate: { ideal: 30, max: 30 },
       },
     });
+    expect(publishedInput?.audioProfile).toBe('raw');
+    expect(audioTrack.contentHint).toBe('music');
 
     page.button('[data-screen-show-live]').click();
     expect(page.step('live').hidden).toBe(false);

--- a/web/tests/ui/whip-publisher-keyframe.test.ts
+++ b/web/tests/ui/whip-publisher-keyframe.test.ts
@@ -182,6 +182,7 @@ function publisherInput(
     } as unknown as MediaStream,
     streamId: 'Ab12Cd34Ef56',
     publishToken: 'token',
+    audioProfile: 'raw',
     fetchImpl: (async (_url, options) => {
       if (options?.method === 'POST') {
         return new Response('answer', { status: 201, headers: { Location: '/live/Ab12Cd34Ef56/whip/resource' } });

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -156,6 +156,8 @@ describe('WHIP publisher', () => {
         stream,
         streamId: 'Ab12Cd34Ef56',
         publishToken: 'first-token',
+        // 再 publish と停止だけを見るケースなので、audio sender へ触らない legacy で固定する。
+        audioProfile: 'legacy',
         fetchImpl: (async (_url, options) => {
           requests.push(options ?? {});
           if (options?.method === 'POST') {
@@ -187,6 +189,7 @@ describe('WHIP publisher', () => {
         } as unknown as MediaStream,
         streamId: 'Ab12Cd34Ef56',
         publishToken: 'video-only-token',
+        audioProfile: 'raw',
         fetchImpl: (async () => new Response('answer', {
           status: 201,
           headers: { Location: '/live/Ab12Cd34Ef56/whip/video-only' },
@@ -269,7 +272,7 @@ describe('WHIP publisher', () => {
     }
   });
 
-  test('既定経路では Opus を含む answer を加工せず audio sender の上限も変更しない', async () => {
+  test('legacy では Opus を含む answer を加工せず audio sender の上限も変更しない', async () => {
     const restore = installWebRtcMocks(() => undefined);
     const audioTrack = { stop() {} } as unknown as MediaStreamTrack;
     const answerSdp = ['a=rtpmap:111 opus/48000/2', 'a=fmtp:111 minptime=10;useinbandfec=1'].join('\r\n');
@@ -280,6 +283,7 @@ describe('WHIP publisher', () => {
           getVideoTracks: () => [{ contentHint: '', stop() {} }],
           getAudioTracks: () => [audioTrack],
         } as unknown as MediaStream,
+        audioProfile: 'legacy',
         fetchImpl: (async () => new Response(answerSdp, {
           status: 201,
           headers: { Location: '/live/Ab12Cd34Ef56/whip/resource' },
@@ -294,7 +298,7 @@ describe('WHIP publisher', () => {
     }
   });
 
-  test('raw 音声プロファイルだけが Opus answer と audio sender の上限を変更する', async () => {
+  test('既定の raw は Opus answer と audio sender の上限を変更する', async () => {
     const restore = installWebRtcMocks(() => undefined);
     const audioTrack = { stop() {} } as unknown as MediaStreamTrack;
     try {
@@ -304,7 +308,7 @@ describe('WHIP publisher', () => {
           getVideoTracks: () => [{ contentHint: '', stop() {} }],
           getAudioTracks: () => [audioTrack],
         } as unknown as MediaStream,
-        rawAudioProfile: true,
+        audioProfile: 'raw',
         fetchImpl: (async () => new Response([
           'a=rtpmap:111 opus/48000/2',
           'a=fmtp:111 minptime=10',
@@ -417,6 +421,7 @@ function testPublisherInput(onPost: () => void = () => {}): Parameters<typeof st
     } as unknown as MediaStream,
     streamId: 'Ab12Cd34Ef56',
     publishToken: 'token',
+    audioProfile: 'raw',
     fetchImpl: (async (_url, options) => {
       if (options?.method === 'POST') {
         onPost();


### PR DESCRIPTION
## なぜこの変更が必要か

PR #174 で追加した `?audio-profile=raw`（Chrome の音声処理を切ってステレオ Opus を送る経路）を本番 A/B で検証したところ、既定は出口 L−R 差分 −91 dB（完全モノラル）、raw は L−R −57.6 dB（本体 −32.6 dB との差 25 dB）でステレオ成分が戻り、ユーザー実聴でもステレオ・こもり解消を確認した（2026-09-02）。効果が確認できたので raw を既定にする。

## 変更内容

- 音声プロファイルの既定を raw にする。判定を `resolveAudioProfileForSearch(search): 'raw' | 'legacy'` に集約し、`audio-profile=legacy` が重複なくちょうど 1 個ある時だけ旧挙動（`audio: true`・contentHint なし・SDP 無加工・sender 未設定）に戻す。unknown / 重複 / 空値 / 大文字小文字違い・クエリなしは既定（raw）
- boolean フラグを `AudioProfile` union に置換し、`whip-publisher` の入力を必須にして配線漏れを型で落とす。`audio_capture_settings` ログの `profile` は `'raw' | 'legacy'`
- `docs/streaming/requirements.md` / `stability-audio-verification.md` を「既定が raw、legacy で旧挙動」に更新し、A/B 結果を記録

## 意思決定

- 既定を変える理由（A/B の実測差）はコードコメントと docs に残す
- 不具合が出た環境は `?audio-profile=legacy` で即回避でき、巻き戻しは `wrangler rollback`（Worker のみ）で足りる

## テスト

- [x] `bun run typecheck` / `bun test` 775 pass
- [x] 既定（クエリなし）で raw の制約・SDP 加工・sender 128k、`legacy` で無加工をテストで担保
- [x] 本番 A/B（出口 L−R −91 → −57.6 dB）＋ユーザー実聴

## 本番影響

以後すべての配信が EC/NS/AGC=false + contentHint 'music' + Opus stereo/128k で取得・送出される。D1 / R2 変更なし。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt6tb5xRLk8cuoDaboAzEW
