### PR TITLE
fix: 画面共有開始中の資源所有とキャンセルを一意化

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -32,7 +32,8 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `PATCH /api/movies/{shortId}/` | ファイル名の変更 | 本人（所有者） | `RenameMovieRequest` / `RenameMovieResponse` |
 | `DELETE /api/movies/{shortId}/` | `ready` 動画の削除（R2 の実体 → D1 の行の順） | 本人（所有者） | `pending` / `failed` は 409 `INVALID_REQUEST`。`pending` の破棄は abandon を使う |
 | `POST /api/client-error/` | クライアント側の失敗報告（識別子だけを受けて `client_error` として構造化ログに残す。応答は 204） | 任意（Cookie があれば `userId` を添える） | `ClientErrorReport` |
-| `POST /api/streams/` | 新しい 12 文字 path ID と publish JWT を発行 | 本人 | `CreateStreamResponse`。本人の同時配信は 409 `STREAM_ALREADY_LIVE`、全体 20 本到達は 429 `STREAM_CAPACITY_REACHED`、作成間隔内は 429 `STREAM_CREATE_RATE_LIMITED` |
+| `POST /api/streams/` | 新しい 12 文字 path ID と publish JWT を発行 | 本人 | `CreateStreamResponse`。任意の `X-WebScreen-Start-Token` は UUIDv4。欠落は旧クライアント互換。本人の同時配信は 409 `STREAM_ALREADY_LIVE`、取り消し済み token は 409 `STREAM_START_CANCELLED`、全体 20 本到達は 429 `STREAM_CAPACITY_REACHED`、作成間隔内は 429 `STREAM_CREATE_RATE_LIMITED` |
+| `POST /api/streams/cancel-start/` | 配信開始操作を取り消す | 本人 | `application/json` の `{ "startToken": UUIDv4 }` だけを許可（余分なフィールド不可、本文 1024 byte 上限）。対象が未作成・作成済み・取り消し済みのいずれでも冪等 204 |
 | `POST /api/streams/stop-live/` | 本人の live 配信をすべて `user_stop` で終了し、cron の kick 対象にする | 本人 | `StopLiveStreamsResponse`（`stopped` と `retryAfterSeconds`）。冪等 200 |
 | `POST /api/streams/{id}/extend/` | 延長期限を更新し、同じ期限の新 publish JWT を発行 | 本人（所有者） | `ExtendStreamResponse`。終了済みは 409 `STREAM_ENDED` |
 | `POST /api/streams/{id}/heartbeat/` | 配信ブラウザの生存時刻を更新 | 本人（所有者） | 成功は 204。終了済みは 409 `STREAM_ENDED` |
@@ -42,6 +43,17 @@ URL は `trailingSlash: 'always'`（末尾スラッシュ必須）。スラッ�
 | `GET /api/streams/jwks/` | MediaMTX が publish JWT を検証する公開 JWKS | 不要 | RS256 公開鍵のみ。秘密要素は返さない。`Cache-Control: no-store` |
 
 エラーは全経路で `ErrorResponse`（`errorCode` + `message`）を返す。
+
+### 配信開始 operation token
+
+同一ユーザーの create と cancel は、UUIDv4 の開始 token 単位で次を保証する。
+
+- cancel が先なら tombstone を作り、同じ token の create は 409 `STREAM_START_CANCELLED` で live を作らない
+- create が先なら cancel が同じ token の live を `user_stop` で終了する。並行実行でも両方の完了後に live は残らない
+- tombstone はユーザーごとに最新 32 件まで保持し、24 時間を超えたものを毎分の cron で削除する
+
+この契約を追加する migration は既存列を壊さない加算変更であり、デプロイは **D1 migration → 本体 Worker → cron Worker** の順に行う。
+旧 Worker は追加列・追加テーブルを参照しないため、Worker コードだけを旧版へロールバックしても動作できる。ただし D1 migration 自体は戻さない。
 
 ### 配信JWTとMediaMTXの運用ゲート
 

--- a/web/migrations/0004_stream_start_cancellations.sql
+++ b/web/migrations/0004_stream_start_cancellations.sql
@@ -1,0 +1,15 @@
+-- pagehide と配信作成の順序競合を operation token で解消する。
+ALTER TABLE stream_sessions ADD COLUMN start_token TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stream_sessions_user_start_token
+  ON stream_sessions(user_id, start_token);
+
+CREATE TABLE IF NOT EXISTS stream_start_cancellations (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  start_token TEXT NOT NULL,
+  cancelled_at TEXT NOT NULL,
+  PRIMARY KEY (user_id, start_token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_start_cancellations_cancelled_at
+  ON stream_start_cancellations(cancelled_at);

--- a/web/src/lib/contracts/api.ts
+++ b/web/src/lib/contracts/api.ts
@@ -20,7 +20,6 @@ export type {
 } from './streams';
 /** 1 ファイルあたりのアップロード上限（50 MiB）。R2 の単発 PUT で扱える範囲に収める。 */
 export const MAX_UPLOAD_BYTES = 52_428_800;
-
 /** abandon の JSON 本文上限。shortId 1 件に対し十分な余裕を持たせる。 */
 export const MAX_ABANDON_UPLOAD_BODY_BYTES = 4 * 1024;
 
@@ -75,6 +74,7 @@ export const ERROR_CODES = {
   streamAlreadyLive: 'STREAM_ALREADY_LIVE',
   streamCapacityReached: 'STREAM_CAPACITY_REACHED',
   streamCreateRateLimited: 'STREAM_CREATE_RATE_LIMITED',
+  streamStartCancelled: 'STREAM_START_CANCELLED',
   streamEnded: 'STREAM_ENDED',
   captureFailed: 'CAPTURE_FAILED',
   pageTooLong: 'PAGE_TOO_LONG',

--- a/web/src/lib/contracts/streams.ts
+++ b/web/src/lib/contracts/streams.ts
@@ -5,6 +5,20 @@ export type StreamSessionStatus = (typeof STREAM_SESSION_STATUSES)[number];
 /** WHIP publisher が接続する、allowlist 固定済みの配信オリジン。 */
 export const STREAM_WHIP_BASE_URL = 'https://webscreen.tv/live';
 
+/** 配信開始操作を pagehide 後も同定する任意ヘッダー。 */
+export const STREAM_START_TOKEN_HEADER = 'X-WebScreen-Start-Token';
+
+/** 配信開始キャンセル本文の上限。UUID 1 件だけを受け取る。 */
+export const MAX_CANCEL_STREAM_START_BODY_BYTES = 1024;
+
+/** crypto.randomUUID() が返す RFC 4122 UUID v4 だけを受理する。 */
+export function isStreamStartToken(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+
 /** 配信が終了した理由。D1 の CHECK 制約と一致させる。 */
 export const STREAM_END_REASONS = [
   'extend_timeout',
@@ -45,6 +59,19 @@ export interface ExtendStreamResponse {
 export interface StopLiveStreamsResponse {
   stopped: number;
   retryAfterSeconds: number;
+}
+
+/** `POST /api/streams/cancel-start/` の本文。 */
+export interface CancelStreamStartRequest {
+  startToken: string;
+}
+
+/** 余分なフィールドを許可せず、配信開始キャンセル本文を検証する。 */
+export function parseCancelStreamStartRequest(input: unknown): CancelStreamStartRequest | null {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return null;
+  const body = input as Record<string, unknown>;
+  if (Object.keys(body).length !== 1 || !isStreamStartToken(body.startToken)) return null;
+  return { startToken: body.startToken };
 }
 
 /** `GET /api/streams/{id}/health/` の relay 到達状態。 */

--- a/web/src/lib/services/stream-lifecycle.ts
+++ b/web/src/lib/services/stream-lifecycle.ts
@@ -16,6 +16,7 @@ export interface StreamLifecycleSettings {
 }
 
 export interface StreamLifecycleSummary {
+  deletedStartCancellations: number;
   endedByExtendTimeout: number;
   endedByHeartbeatLost: number;
   endedByNoViewers: number;
@@ -44,6 +45,10 @@ export async function runStreamLifecycle(input: {
   now: Date;
 }): Promise<StreamLifecycleSummary> {
   const summary = emptySummary();
+  summary.deletedStartCancellations = await deleteExpiredStartCancellations(
+    input.database,
+    input.now
+  );
   const newlyEnded = new Set<string>();
   const initialRows = await listRelevant(input.database);
   if (initialRows.length === 0) return summary;
@@ -225,6 +230,7 @@ async function listRelevant(database: StreamLifecycleDatabase): Promise<Lifecycl
 
 function emptySummary(): StreamLifecycleSummary {
   return {
+    deletedStartCancellations: 0,
     endedByExtendTimeout: 0,
     endedByHeartbeatLost: 0,
     endedByNoViewers: 0,
@@ -232,6 +238,18 @@ function emptySummary(): StreamLifecycleSummary {
     publishersKicked: 0,
     kickPendingCleared: 0,
   };
+}
+
+async function deleteExpiredStartCancellations(
+  database: StreamLifecycleDatabase,
+  now: Date
+): Promise<number> {
+  const cutoff = subtractSeconds(now, 24 * 60 * 60).toISOString();
+  const result = await database
+    .prepare('DELETE FROM stream_start_cancellations WHERE cancelled_at < ?')
+    .bind(cutoff)
+    .run();
+  return result.meta.changes;
 }
 
 function subtractSeconds(date: Date, seconds: number): Date {

--- a/web/src/lib/services/stream-start.ts
+++ b/web/src/lib/services/stream-start.ts
@@ -1,0 +1,60 @@
+import type { StreamDatabase } from './streams';
+
+/** 各利用者について保持する開始キャンセルtombstoneの上限。 */
+export const MAX_STREAM_START_CANCELLATIONS_PER_USER = 32;
+const OTHER_START_CANCELLATIONS_TO_KEEP = MAX_STREAM_START_CANCELLATIONS_PER_USER - 1;
+
+/** 開始 token をtombstone化し、履歴制限とmatching live停止を1 batchで適用する。 */
+export async function cancelStreamStart(input: {
+  database: StreamDatabase;
+  userId: number;
+  startToken: string;
+  now?: Date;
+}): Promise<void> {
+  const cancelledAt = (input.now ?? new Date()).toISOString();
+  const tombstone = input.database
+    .prepare(
+      `INSERT INTO stream_start_cancellations (user_id, start_token, cancelled_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(user_id, start_token) DO NOTHING`
+    )
+    .bind(input.userId, input.startToken, cancelledAt);
+  const prune = input.database
+    .prepare(
+      `DELETE FROM stream_start_cancellations
+       WHERE user_id = ? AND start_token <> ? AND start_token NOT IN (
+         SELECT start_token FROM stream_start_cancellations
+         WHERE user_id = ? AND start_token <> ?
+         ORDER BY cancelled_at DESC, start_token DESC
+         LIMIT ?
+       )`
+    )
+    .bind(
+      input.userId,
+      input.startToken,
+      input.userId,
+      input.startToken,
+      OTHER_START_CANCELLATIONS_TO_KEEP
+    );
+  const stopMatching = input.database
+    .prepare(
+      `UPDATE stream_sessions
+       SET status = 'ended', ended_at = ?, end_reason = 'user_stop', kick_pending = 1
+       WHERE user_id = ? AND start_token = ? AND status = 'live'`
+    )
+    .bind(cancelledAt, input.userId, input.startToken);
+  await input.database.batch([tombstone, prune, stopMatching]);
+}
+
+/** 同じ利用者・開始tokenですでに確定したsessionの状態を返す。 */
+export async function existingStreamStartStatus(
+  database: StreamDatabase,
+  userId: number,
+  startToken: string
+): Promise<'live' | 'ended' | null> {
+  const existing = await database
+    .prepare('SELECT status FROM stream_sessions WHERE user_id = ? AND start_token = ?')
+    .bind(userId, startToken)
+    .first<{ status: 'live' | 'ended' }>();
+  return existing?.status ?? null;
+}

--- a/web/src/lib/services/streams.ts
+++ b/web/src/lib/services/streams.ts
@@ -8,16 +8,17 @@ import {
   type StreamStatusResponse,
 } from '../contracts/api';
 import { generateShortId } from '../contracts/r2key';
+import { existingStreamStartStatus } from './stream-start';
 // 配信ホスト名は allowlist に焼き込まれるため凍結（2026-09-01 webscreen.tv に確定。docs/streaming/requirements.md）
 const STREAM_BASE_URL = 'rtspt://webscreen.tv/live';
 const DEFAULT_CREATE_RETRIES = 4;
 export interface StreamDatabase {
-  prepare(query: string): {
-    bind(...values: unknown[]): {
-      first<T>(): Promise<T | null>;
-      run(): Promise<{ meta: { changes: number } }>;
-    };
-  };
+  prepare(query: string): { bind(...values: unknown[]): StreamDatabaseStatement };
+  batch(statements: StreamDatabaseStatement[]): Promise<Array<{ meta: { changes: number } }>>;
+}
+export interface StreamDatabaseStatement {
+  first<T>(): Promise<T | null>;
+  run(): Promise<{ meta: { changes: number } }>;
 }
 export interface StreamSettings {
   extensionCycleSeconds: number;
@@ -57,6 +58,7 @@ export interface StreamServiceInput {
   signPublishToken: StreamJwtSigner;
   now?: Date;
   generateId?: () => string;
+  startToken?: string | null;
 }
 /** 新しい path ID を予約し、延長期限と同じ exp の publish JWT を返す。 */
 export async function createStream(input: StreamServiceInput): Promise<CreateStreamResponse> {
@@ -76,9 +78,18 @@ export async function createStream(input: StreamServiceInput): Promise<CreateStr
       if (inserted) return createResponse(id, now, expiresAt, publishToken);
     } catch (error) {
       if (await streamIdExists(input.database, id)) continue;
+      if (input.startToken) {
+        await throwIfExistingStartToken(input.database, input.userId, input.startToken);
+      }
       throw error;
     }
-    await throwCreateRejection(input.database, input.userId, rateThreshold, input.settings);
+    await throwCreateRejection(
+      input.database,
+      input.userId,
+      rateThreshold,
+      input.settings,
+      input.startToken
+    );
   }
   throw new Error('Unable to allocate a unique stream path ID');
 }
@@ -204,14 +215,18 @@ async function insertStream(
     .prepare(
       `INSERT INTO stream_sessions (
          id, user_id, status, started_at, extend_expires_at,
-         last_heartbeat_at, last_viewer_at, kick_pending
+         last_heartbeat_at, last_viewer_at, kick_pending, start_token
        )
-       SELECT ?, ?, 'live', ?, ?, ?, ?, 0
+       SELECT ?, ?, 'live', ?, ?, ?, ?, 0, ?
        WHERE (SELECT COUNT(*) FROM stream_sessions WHERE status = 'live') < ?
        AND (SELECT COUNT(*) FROM stream_sessions WHERE user_id = ? AND status = 'live') < ?
        AND NOT EXISTS (
          SELECT 1 FROM stream_sessions WHERE user_id = ? AND started_at > ?
-       )`
+       )
+       AND (? IS NULL OR NOT EXISTS (
+         SELECT 1 FROM stream_start_cancellations
+         WHERE user_id = ? AND start_token = ?
+       ))`
     )
     .bind(
       id,
@@ -220,11 +235,15 @@ async function insertStream(
       expiresAt.toISOString(),
       iso,
       iso,
+      input.startToken ?? null,
       input.settings.maxLiveStreams,
       input.userId,
       input.settings.maxLiveStreamsPerUser,
       input.userId,
-      rateThreshold
+      rateThreshold,
+      input.startToken ?? null,
+      input.userId,
+      input.startToken ?? null
     )
     .run();
   return result.meta.changes > 0;
@@ -234,8 +253,21 @@ async function throwCreateRejection(
   database: StreamDatabase,
   userId: number,
   rateThreshold: string,
-  settings: StreamSettings
+  settings: StreamSettings,
+  startToken?: string | null
 ): Promise<never> {
+  if (startToken) {
+    const cancellation = await database
+      .prepare(
+        'SELECT start_token FROM stream_start_cancellations WHERE user_id = ? AND start_token = ?'
+      )
+      .bind(userId, startToken)
+      .first<{ start_token: string }>();
+    if (cancellation) {
+      throw new StreamError(409, ERROR_CODES.streamStartCancelled, '取り消された配信開始操作です');
+    }
+    await throwIfExistingStartToken(database, userId, startToken);
+  }
   const active = await database
     .prepare("SELECT COUNT(*) AS count FROM stream_sessions WHERE user_id = ? AND status = 'live'")
     .bind(userId)
@@ -258,6 +290,18 @@ async function throwCreateRejection(
     throw new StreamError(429, ERROR_CODES.streamCreateRateLimited, '配信の再作成が速すぎます');
   }
   throw new Error('Stream reservation was rejected unexpectedly');
+}
+
+async function throwIfExistingStartToken(
+  database: StreamDatabase,
+  userId: number,
+  startToken: string
+): Promise<void> {
+  const status = await existingStreamStartStatus(database, userId, startToken);
+  if (status === 'live') {
+    throw new StreamError(409, ERROR_CODES.streamAlreadyLive, '既に配信中です');
+  }
+  if (status === 'ended') throw endedError();
 }
 
 async function streamIdExists(database: StreamDatabase, id: string): Promise<boolean> {

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -221,9 +221,9 @@ export class ScreenShareController {
   private async createAndPublish(run: StartRun): Promise<StartedStream | null> {
     let created: CreateStreamResponse;
     try {
+      // 応答前に離脱しても作成済みIDを回収し、直後にserver stopできるようPOST自体はabortしない。
       created = asCreateStream(await this.deps.requestJson('/api/streams/', {
         method: 'POST',
-        signal: run.abortController.signal,
       }));
     } catch (error) {
       this.cancelStart(run);

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -25,7 +25,27 @@ export const HEARTBEAT_INTERVAL_MS = 25_000;
 export const EXPIRY_WARNING_SECONDS = 5 * 60;
 
 type ScreenSharePhase = 'idle' | 'login' | 'url' | 'live' | 'error';
-type LiveStream = CreateStreamResponse & { publisher: WhipPublisher; media: MediaStream };
+type CaptureHandle = {
+  readonly media: MediaStream;
+  dispose: () => void;
+};
+type StartRun = {
+  readonly generation: number;
+  readonly capture: CaptureHandle;
+  readonly abortController: AbortController;
+};
+type LiveStreamLifecycle = {
+  localReleased: boolean;
+  serverStopRequested: boolean;
+  whipDeleteRequested: boolean;
+};
+type LiveStream = CreateStreamResponse & {
+  publisher: WhipPublisher;
+  media: MediaStream;
+  capture: CaptureHandle;
+  abortController: AbortController;
+  lifecycle: LiveStreamLifecycle;
+};
 type StartedStream = { live: LiveStream; ready: boolean };
 
 class StreamHealthError extends Error {}
@@ -34,7 +54,7 @@ class StreamHealthError extends Error {}
 export interface ScreenShareDependencies {
   requestJson: typeof requestJson;
   startWhipPublisher: typeof startWhipPublisher;
-  waitForStreamReady: (streamId: string) => Promise<boolean>;
+  waitForStreamReady: (streamId: string, signal?: AbortSignal) => Promise<boolean>;
   getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
   delay?: (ms: number) => Promise<void>;
   now: () => number;
@@ -45,7 +65,7 @@ export interface ScreenShareDependencies {
 const DEFAULT_DEPENDENCIES: ScreenShareDependencies = {
   requestJson,
   startWhipPublisher,
-  waitForStreamReady: (streamId) => waitForStreamReady(streamId, requestJson),
+  waitForStreamReady: (streamId, signal) => waitForStreamReady(streamId, requestJson, undefined, signal),
   getDisplayMedia: (constraints) => navigator.mediaDevices.getDisplayMedia(constraints),
   delay: (ms) => new Promise((resolve) => window.setTimeout(resolve, ms)),
   now: () => Date.now(),
@@ -59,7 +79,7 @@ export function releaseScreenShare(
   clearTimers: () => void
 ): void {
   clearTimers();
-  stopMedia(live.media);
+  createCaptureHandle(live.media).dispose();
   live.publisher.close();
 }
 
@@ -90,6 +110,8 @@ export class ScreenShareController {
   private phase: ScreenSharePhase = 'idle';
   private stopping = false;
   private startGeneration = 0;
+  private startReservation: number | null = null;
+  private activeStart: StartRun | null = null;
 
   constructor(
     private readonly root: HTMLElement,
@@ -110,8 +132,9 @@ export class ScreenShareController {
   }
 
   private async selectScreen(): Promise<void> {
-    const generation = ++this.startGeneration;
-    this.stopping = false;
+    const generation = this.reserveStart();
+    if (generation === null) return;
+    let run: StartRun | null = null;
     this.setBusy('[data-screen-start]', true, 'labelSelecting');
     // 再試行ボタンからも入るため連打でピッカーが競合しないよう無効化する
     // （span なし構造なのでラベルは触らずアイコンを保つ）
@@ -120,146 +143,164 @@ export class ScreenShareController {
     try {
       const profile = currentAudioProfile();
       const media = await this.deps.getDisplayMedia(displayMediaConstraints(profile));
+      run = this.registerStart(media, generation);
+      if (!run) return;
       configureCaptureAudioTracks(media, profile);
-      if (!this.isActiveStart(generation)) {
-        stopMedia(media);
-        return;
-      }
-      await this.continueStart(media, generation);
+      await this.continueStart(run);
     } catch (error) {
+      if (run) this.cancelStart(run);
       if (this.isActiveStart(generation)) this.handleStartError(error);
     } finally {
+      if (run && this.activeStart === run) this.activeStart = null;
+      this.releaseStartReservation(generation);
       this.setBusy('[data-screen-start]', false, 'labelStart');
       if (retry) retry.disabled = false;
     }
   }
 
   private async stopOthersAndStart(): Promise<void> {
-    const generation = ++this.startGeneration;
-    let media: MediaStream | null = null;
-    this.stopping = false;
+    const generation = this.reserveStart();
+    if (generation === null) return;
+    let run: StartRun | null = null;
     this.setBusy('[data-screen-stop-others]', true, 'labelStopOthers');
     const retry = this.button('[data-screen-retry]');
     if (retry) retry.disabled = true;
     try {
       const profile = currentAudioProfile();
-      media = await this.deps.getDisplayMedia(displayMediaConstraints(profile));
-      configureCaptureAudioTracks(media, profile);
-      if (!this.isActiveStart(generation)) {
-        stopMedia(media);
-        return;
-      }
+      const media = await this.deps.getDisplayMedia(displayMediaConstraints(profile));
+      run = this.registerStart(media, generation);
+      if (!run) return;
+      configureCaptureAudioTracks(run.capture.media, profile);
       const stopped = asStopLiveStreams(
-        await this.deps.requestJson('/api/streams/stop-live/', { method: 'POST' })
+        await this.deps.requestJson('/api/streams/stop-live/', {
+          method: 'POST',
+          signal: run.abortController.signal,
+        })
       );
-      if (!this.isActiveStart(generation)) {
-        stopMedia(media);
+      if (!this.isActiveRun(run)) {
+        this.cancelStart(run);
         return;
       }
       this.text('[data-screen-error-message]', this.message('labelStoppingOthers'));
       this.setButtonLabel('[data-screen-stop-others]', 'labelStoppingOthers');
       await (this.deps.delay ?? delay)(Math.max(stopped.retryAfterSeconds, 3) * 1000);
-      if (!this.isActiveStart(generation)) {
-        stopMedia(media);
+      if (!this.isActiveRun(run)) {
+        this.cancelStart(run);
         return;
       }
-      await this.continueStart(media, generation);
-      media = null;
+      await this.continueStart(run);
     } catch (error) {
-      if (media) stopMedia(media);
+      if (run) this.cancelStart(run);
       if (this.isActiveStart(generation)) this.handleStartError(error);
     } finally {
+      if (run && this.activeStart === run) this.activeStart = null;
+      this.releaseStartReservation(generation);
       this.setBusy('[data-screen-stop-others]', false, 'labelStopOthers');
       if (retry) retry.disabled = false;
     }
   }
 
-  private async continueStart(media: MediaStream, generation: number): Promise<void> {
-    const started = await this.createAndPublish(media, generation);
+  private async continueStart(run: StartRun): Promise<void> {
+    const started = await this.createAndPublish(run);
     if (!started) return;
     const stream = started.live;
-    if (!this.isActiveStart(generation)) {
-      releaseScreenShare(stream, () => this.clearTimers());
-      void this.notifyRemoteStop(stream);
+    if (!this.isActiveRun(run)) {
+      this.discardInactiveRun(stream, run);
       return;
     }
     this.live = stream;
     this.setUrl(stream.streamUrl);
-    this.setAudioStatus(stream.media);
-    this.preview(stream.media);
+    this.setAudioStatus(stream.capture.media);
+    this.preview(stream.capture.media);
     this.startTimers();
-    stream.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
+    stream.capture.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
     if (started.ready) this.show('url');
     else this.showError(new StreamHealthError());
   }
 
-  private async createAndPublish(media: MediaStream, generation: number): Promise<StartedStream | null> {
+  private async createAndPublish(run: StartRun): Promise<StartedStream | null> {
     let created: CreateStreamResponse;
     try {
-      created = asCreateStream(await this.deps.requestJson('/api/streams/', { method: 'POST' }));
+      created = asCreateStream(await this.deps.requestJson('/api/streams/', {
+        method: 'POST',
+        signal: run.abortController.signal,
+      }));
     } catch (error) {
-      stopMedia(media);
+      this.cancelStart(run);
       throw error;
     }
-    if (!this.isActiveStart(generation)) {
-      stopMedia(media);
+    if (!this.isActiveRun(run)) {
+      this.cancelStart(run);
       void this.notifyServerStop(created.id);
       return null;
     }
-    return this.publishAndVerify(media, created, generation);
+    return this.publishAndVerify(run, created);
   }
 
   private async publishAndVerify(
-    media: MediaStream,
-    created: CreateStreamResponse,
-    generation: number
+    run: StartRun,
+    created: CreateStreamResponse
   ): Promise<StartedStream | null> {
     let publisher: WhipPublisher | null = null;
     let stream: LiveStream | null = null;
     try {
       publisher = await this.deps.startWhipPublisher({
-        stream: media,
+        stream: run.capture.media,
         streamId: created.id,
         publishToken: created.publishToken,
         keyframeRequestIntervalMs: keyframeRequestIntervalForSearch(globalThis.window?.location?.search ?? ''),
         audioProfile: currentAudioProfile(),
       });
-      stream = { ...created, publisher, media };
-      if (!this.isActiveStart(generation)) {
-        releaseScreenShare(stream, () => this.clearTimers());
-        void this.notifyRemoteStop(stream);
+      stream = {
+        ...created,
+        publisher,
+        media: run.capture.media,
+        capture: run.capture,
+        abortController: run.abortController,
+        lifecycle: {
+          localReleased: false,
+          serverStopRequested: false,
+          whipDeleteRequested: false,
+        },
+      };
+      if (!this.isActiveRun(run)) {
+        this.discardInactiveRun(stream, run);
         return null;
       }
       this.live = stream;
-      return await this.verifyInitialStream(stream, generation);
+      return await this.verifyInitialStream(stream, run);
     } catch (error) {
-      if (stream && !this.isActiveLive(stream)) return null;
-      if (stream) this.live = null;
-      const failedPublisher = stream?.publisher ?? publisher;
-      if (failedPublisher) {
-        failedPublisher.close();
-        void failedPublisher.deleteResource().catch((deleteError) => {
-          console.warn('Failed to delete WHIP resource after start failure', deleteError);
-        });
+      if (stream) {
+        const stale = !this.isActiveRun(run) || !this.isActiveLive(stream);
+        this.discardInactiveRun(stream, run);
+        if (stale) return null;
+        throw error;
       }
-      stopMedia(media);
+      this.cancelStart(run);
       void this.notifyServerStop(created.id);
       throw error;
     }
   }
 
-  private async verifyInitialStream(stream: LiveStream, generation: number): Promise<StartedStream | null> {
-    const ready = await this.deps.waitForStreamReady(stream.id);
-    if (!this.isActiveStart(generation) || !this.isActiveLive(stream)) return null;
+  private async verifyInitialStream(stream: LiveStream, run: StartRun): Promise<StartedStream | null> {
+    const ready = await this.deps.waitForStreamReady(stream.id, run.abortController.signal);
+    if (!this.isActiveRun(run) || !this.isActiveLive(stream)) {
+      this.discardInactiveRun(stream, run);
+      return null;
+    }
     if (ready) return { live: stream, ready: true };
     const replacement = await stream.publisher.republish();
-    if (!this.isActiveStart(generation) || !this.isActiveLive(stream)) {
+    if (!this.isActiveRun(run) || !this.isActiveLive(stream)) {
       await this.releasePublisher(replacement);
+      this.discardInactiveRun(stream, run);
       return null;
     }
     stream.publisher = replacement;
-    const retryReady = await this.deps.waitForStreamReady(stream.id);
-    if (!this.isActiveStart(generation) || !this.isActiveLive(stream)) return null;
+    const retryReady = await this.deps.waitForStreamReady(stream.id, run.abortController.signal);
+    if (!this.isActiveRun(run) || !this.isActiveLive(stream)) {
+      this.discardInactiveRun(stream, run);
+      return null;
+    }
     return { live: stream, ready: retryReady };
   }
 
@@ -284,7 +325,7 @@ export class ScreenShareController {
         return;
       }
       live.publisher = publisher;
-      const ready = await this.deps.waitForStreamReady(live.id);
+      const ready = await this.deps.waitForStreamReady(live.id, live.abortController.signal);
       if (!this.isActiveLive(live)) return;
       if (ready) {
         this.setUrl(live.streamUrl);
@@ -307,7 +348,10 @@ export class ScreenShareController {
     this.setBusy('[data-screen-extend]', true, 'labelExtending');
     try {
       const response = asExtendStream(
-        await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/extend/`, { method: 'POST' })
+        await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/extend/`, {
+          method: 'POST',
+          signal: live.abortController.signal,
+        })
       );
       if (this.stopping || this.live !== live) return;
       live.extendExpiresAt = response.extendExpiresAt;
@@ -337,7 +381,10 @@ export class ScreenShareController {
     const live = this.live;
     if (!live || this.stopping) return;
     try {
-      await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/heartbeat/`, { method: 'POST' });
+      await this.deps.requestJson(`/api/streams/${encodeURIComponent(live.id)}/heartbeat/`, {
+        method: 'POST',
+        signal: live.abortController.signal,
+      });
     } catch (error) {
       if (!this.stopping && this.live === live) this.handleRuntimeError(error);
     }
@@ -364,12 +411,17 @@ export class ScreenShareController {
   }
 
   private finishLocally(phase: 'idle' | 'error', error?: unknown): LiveStream | null {
-    if (this.stopping || !this.live) return null;
+    if (this.stopping) return null;
     this.stopping = true;
     this.startGeneration += 1;
+    const run = this.activeStart;
+    this.activeStart = null;
+    run?.abortController.abort();
     const live = this.live;
+    live?.abortController.abort();
+    if (live) this.releaseLiveLocally(live, true);
+    else run?.capture.dispose();
     this.live = null;
-    releaseScreenShare(live, () => this.clearTimers());
     if (phase === 'error') this.showError(error);
     else this.show('idle');
     return live;
@@ -377,21 +429,26 @@ export class ScreenShareController {
 
   private stopForPageHide(): void {
     const live = this.finishLocally('idle');
-    this.startGeneration += 1;
-    this.stopping = true;
     if (!live) return;
-    const stopUrl = streamStopUrl(live.id);
-    try {
-      if (!this.deps.sendBeacon(stopUrl)) void this.notifyServerStop(live.id);
-    } catch (error) {
-      console.warn('Failed to queue stream stop beacon', error);
-      void this.notifyServerStop(live.id);
-    }
+    void this.notifyLiveServerStop(live, true);
     void this.notifyWhipDeletion(live);
   }
 
   private async notifyRemoteStop(live: LiveStream): Promise<void> {
-    await Promise.all([this.notifyServerStop(live.id), this.notifyWhipDeletion(live)]);
+    await Promise.all([this.notifyLiveServerStop(live), this.notifyWhipDeletion(live)]);
+  }
+
+  private async notifyLiveServerStop(live: LiveStream, preferBeacon = false): Promise<void> {
+    if (live.lifecycle.serverStopRequested) return;
+    live.lifecycle.serverStopRequested = true;
+    if (preferBeacon) {
+      try {
+        if (this.deps.sendBeacon(streamStopUrl(live.id))) return;
+      } catch (error) {
+        console.warn('Failed to queue stream stop beacon', error);
+      }
+    }
+    await this.notifyServerStop(live.id);
   }
 
   private async notifyServerStop(id: string): Promise<void> {
@@ -403,6 +460,8 @@ export class ScreenShareController {
   }
 
   private async notifyWhipDeletion(live: LiveStream): Promise<void> {
+    if (live.lifecycle.whipDeleteRequested) return;
+    live.lifecycle.whipDeleteRequested = true;
     await live.publisher.deleteResource().catch((error) => {
       console.warn('Failed to delete WHIP resource', error);
     });
@@ -417,6 +476,64 @@ export class ScreenShareController {
 
   private isActiveStart(generation: number): boolean {
     return !this.stopping && this.startGeneration === generation;
+  }
+
+  private isActiveRun(run: StartRun): boolean {
+    return (
+      this.activeStart === run &&
+      this.isActiveStart(run.generation) &&
+      !run.abortController.signal.aborted
+    );
+  }
+
+  private reserveStart(): number | null {
+    if (this.startReservation !== null || this.activeStart || this.live) return null;
+    this.stopping = false;
+    const generation = ++this.startGeneration;
+    this.startReservation = generation;
+    return generation;
+  }
+
+  private releaseStartReservation(generation: number): void {
+    if (this.startReservation === generation) this.startReservation = null;
+  }
+
+  private registerStart(media: MediaStream, generation: number): StartRun | null {
+    const run: StartRun = {
+      generation,
+      capture: createCaptureHandle(media),
+      abortController: new AbortController(),
+    };
+    if (this.startReservation !== generation || !this.isActiveStart(generation)) {
+      this.cancelStart(run);
+      return null;
+    }
+    if (this.activeStart || this.live) {
+      this.cancelStart(run);
+      return null;
+    }
+    this.activeStart = run;
+    return run;
+  }
+
+  private cancelStart(run: StartRun): void {
+    run.abortController.abort();
+    run.capture.dispose();
+    if (this.activeStart === run) this.activeStart = null;
+  }
+
+  private discardInactiveRun(stream: LiveStream, run: StartRun): void {
+    this.cancelStart(run);
+    const wasCurrent = this.live === stream;
+    if (wasCurrent) this.live = null;
+    this.releaseLiveLocally(stream, wasCurrent);
+    void this.notifyRemoteStop(stream);
+  }
+
+  private releaseLiveLocally(stream: LiveStream, clearCurrentTimers: boolean): void {
+    if (stream.lifecycle.localReleased) return;
+    stream.lifecycle.localReleased = true;
+    releaseScreenShare(stream, clearCurrentTimers ? () => this.clearTimers() : () => undefined);
   }
 
   private isActiveLive(live: LiveStream): boolean {
@@ -574,8 +691,22 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
-function stopMedia(media: MediaStream): void {
-  for (const track of media.getTracks()) track.stop();
+const CAPTURE_HANDLES = new WeakMap<MediaStream, CaptureHandle>();
+
+function createCaptureHandle(media: MediaStream): CaptureHandle {
+  const existing = CAPTURE_HANDLES.get(media);
+  if (existing) return existing;
+  let disposed = false;
+  const capture = {
+    media,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      for (const track of media.getTracks()) track.stop();
+    },
+  };
+  CAPTURE_HANDLES.set(media, capture);
+  return capture;
 }
 
 function streamStopUrl(id: string): string {

--- a/web/src/lib/ui/screen-share.ts
+++ b/web/src/lib/ui/screen-share.ts
@@ -4,6 +4,7 @@ import {
   type ExtendStreamResponse,
   type StopLiveStreamsResponse,
 } from '../contracts/api';
+import { STREAM_START_TOKEN_HEADER } from '../contracts/streams';
 import { copyToClipboard } from './clipboard';
 import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
 import { waitForStreamReady } from './stream-health';
@@ -31,8 +32,10 @@ type CaptureHandle = {
 };
 type StartRun = {
   readonly generation: number;
+  readonly startToken: string;
   readonly capture: CaptureHandle;
   readonly abortController: AbortController;
+  cancellationRequested: boolean;
 };
 type LiveStreamLifecycle = {
   localReleased: boolean;
@@ -58,7 +61,8 @@ export interface ScreenShareDependencies {
   getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
   delay?: (ms: number) => Promise<void>;
   now: () => number;
-  sendBeacon: (url: string) => boolean;
+  createStartToken?: () => string;
+  sendBeacon: (url: string, data?: BodyInit | null) => boolean;
   onPageHide: (handler: () => void) => void;
 }
 
@@ -69,7 +73,8 @@ const DEFAULT_DEPENDENCIES: ScreenShareDependencies = {
   getDisplayMedia: (constraints) => navigator.mediaDevices.getDisplayMedia(constraints),
   delay: (ms) => new Promise((resolve) => window.setTimeout(resolve, ms)),
   now: () => Date.now(),
-  sendBeacon: (url) => navigator.sendBeacon(url),
+  createStartToken: () => globalThis.crypto.randomUUID(),
+  sendBeacon: (url, data) => navigator.sendBeacon(url, data),
   onPageHide: (handler) => window.addEventListener('pagehide', handler),
 };
 
@@ -224,6 +229,7 @@ export class ScreenShareController {
       // 応答前に離脱しても作成済みIDを回収し、直後にserver stopできるようPOST自体はabortしない。
       created = asCreateStream(await this.deps.requestJson('/api/streams/', {
         method: 'POST',
+        headers: { [STREAM_START_TOKEN_HEADER]: run.startToken },
       }));
     } catch (error) {
       this.cancelStart(run);
@@ -428,10 +434,14 @@ export class ScreenShareController {
   }
 
   private stopForPageHide(): void {
+    const run = this.activeStart;
     const live = this.finishLocally('idle');
-    if (!live) return;
-    void this.notifyLiveServerStop(live, true);
-    void this.notifyWhipDeletion(live);
+    if (live) {
+      void this.notifyLiveServerStop(live, true);
+      void this.notifyWhipDeletion(live);
+      return;
+    }
+    if (run) void this.notifyStartCancellation(run, true);
   }
 
   private async notifyRemoteStop(live: LiveStream): Promise<void> {
@@ -456,6 +466,30 @@ export class ScreenShareController {
       await this.deps.requestJson(streamStopUrl(id), { method: 'POST' });
     } catch (error) {
       console.warn('Failed to stop stream session remotely', error);
+    }
+  }
+
+  private async notifyStartCancellation(run: StartRun, preferBeacon = false): Promise<void> {
+    if (run.cancellationRequested) return;
+    run.cancellationRequested = true;
+    const body = JSON.stringify({ startToken: run.startToken });
+    if (preferBeacon) {
+      try {
+        const payload = new Blob([body], { type: 'application/json' });
+        if (this.deps.sendBeacon('/api/streams/cancel-start/', payload)) return;
+      } catch (error) {
+        console.warn('Failed to queue stream start cancellation beacon', error);
+      }
+    }
+    try {
+      await this.deps.requestJson('/api/streams/cancel-start/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        keepalive: true,
+      });
+    } catch (error) {
+      console.warn('Failed to cancel stream start remotely', error);
     }
   }
 
@@ -501,8 +535,10 @@ export class ScreenShareController {
   private registerStart(media: MediaStream, generation: number): StartRun | null {
     const run: StartRun = {
       generation,
+      startToken: this.deps.createStartToken?.() ?? globalThis.crypto.randomUUID(),
       capture: createCaptureHandle(media),
       abortController: new AbortController(),
+      cancellationRequested: false,
     };
     if (this.startReservation !== generation || !this.isActiveStart(generation)) {
       this.cancelStart(run);

--- a/web/src/lib/ui/stream-health.ts
+++ b/web/src/lib/ui/stream-health.ts
@@ -8,13 +8,16 @@ export const STREAM_HEALTH_MAX_ATTEMPTS = 10;
 export async function waitForStreamReady(
   streamId: string,
   request: typeof requestJson,
-  wait: (milliseconds: number) => Promise<void> = delay
+  wait: (milliseconds: number) => Promise<void> = delay,
+  signal?: AbortSignal
 ): Promise<boolean> {
   let previous: StreamHealthResponse | null = null;
   for (let attempt = 0; attempt < STREAM_HEALTH_MAX_ATTEMPTS; attempt += 1) {
+    if (signal?.aborted) return false;
     const current = asStreamHealth(
-      await request(`/api/streams/${encodeURIComponent(streamId)}/health/`, {})
+      await request(`/api/streams/${encodeURIComponent(streamId)}/health/`, { signal })
     );
+    if (signal?.aborted) return false;
     if (
       previous &&
       current.state === 'ready' &&
@@ -26,6 +29,7 @@ export async function waitForStreamReady(
     previous = current;
     if (attempt + 1 < STREAM_HEALTH_MAX_ATTEMPTS) {
       await wait(STREAM_HEALTH_POLL_INTERVAL_MS);
+      if (signal?.aborted) return false;
     }
   }
   return false;

--- a/web/src/pages/api/streams/cancel-start.ts
+++ b/web/src/pages/api/streams/cancel-start.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+
+import { ERROR_CODES } from '../../../lib/contracts/api';
+import {
+  MAX_CANCEL_STREAM_START_BODY_BYTES,
+  parseCancelStreamStartRequest,
+} from '../../../lib/contracts/streams';
+import { readLimitedJsonBody } from '../../../lib/services/upload-request';
+import { cancelStreamStart } from '../../../lib/services/stream-start';
+import {
+  json,
+  noContent,
+  runStreamApi,
+  type StreamApiBindings,
+} from '../../../lib/services/stream-api';
+
+export const prerender = false;
+
+/** 離脱済みの配信開始 token を記録し、同 token の live があれば終了する。 */
+export const POST: APIRoute = ({ request }) =>
+  runStreamApi(request, env as unknown as StreamApiBindings, async (context) => {
+    if (!isJsonContentType(request.headers.get('content-type'))) {
+      return json(
+        { errorCode: ERROR_CODES.invalidRequest, message: 'Content-Type は application/json である必要があります' },
+        400
+      );
+    }
+    const body = await readLimitedJsonBody(request, MAX_CANCEL_STREAM_START_BODY_BYTES);
+    if (!body.ok) return json(body.error, body.status);
+    const validated = parseCancelStreamStartRequest(body.value);
+    if (!validated) {
+      return json({ errorCode: ERROR_CODES.invalidRequest, message: 'startToken が不正です' }, 400);
+    }
+    await cancelStreamStart({
+      database: context.database,
+      userId: context.userId,
+      startToken: validated.startToken,
+    });
+    return noContent();
+  });
+
+function isJsonContentType(value: string | null): boolean {
+  return value?.split(';', 1)[0]?.trim().toLowerCase() === 'application/json';
+}

--- a/web/src/pages/api/streams/index.ts
+++ b/web/src/pages/api/streams/index.ts
@@ -3,6 +3,11 @@ import { env } from 'cloudflare:workers';
 
 import { createStream } from '../../../lib/services/streams';
 import {
+  isStreamStartToken,
+  STREAM_START_TOKEN_HEADER,
+} from '../../../lib/contracts/streams';
+import { ERROR_CODES } from '../../../lib/contracts/api';
+import {
   json,
   runStreamApi,
   type StreamApiBindings,
@@ -12,6 +17,13 @@ export const prerender = false;
 
 /** 新しい配信セッションと publish JWT を発行する。 */
 export const POST: APIRoute = ({ request }) =>
-  runStreamApi(request, env as unknown as StreamApiBindings, async (context) =>
-    json(await createStream(context), 201)
-  );
+  runStreamApi(request, env as unknown as StreamApiBindings, async (context) => {
+    const startToken = request.headers.get(STREAM_START_TOKEN_HEADER);
+    if (startToken !== null && !isStreamStartToken(startToken)) {
+      return json(
+        { errorCode: ERROR_CODES.invalidRequest, message: '配信開始 token が不正です' },
+        400
+      );
+    }
+    return json(await createStream({ ...context, startToken }), 201);
+  });

--- a/web/tests/api/streams-start-cancel.test.ts
+++ b/web/tests/api/streams-start-cancel.test.ts
@@ -1,0 +1,188 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+
+import {
+  createSessionPayload,
+  importSigningKey,
+  signSession,
+} from '../../src/lib/contracts/session';
+import { STREAM_START_TOKEN_HEADER } from '../../src/lib/contracts/streams';
+import { createStreamDatabase, type StreamSqliteAdapter } from '../services/helpers/stream-db';
+import { generateTestPrivateKeyBase64 } from '../services/helpers/stream-keys';
+
+const runtimeEnv: Record<string, unknown> = {};
+mock.module('cloudflare:workers', () => ({ env: runtimeEnv }));
+const { POST: createPost } = await import('../../src/pages/api/streams/index');
+const { POST: cancelPost } = await import('../../src/pages/api/streams/cancel-start');
+
+const SESSION_SECRET = 'stream-start-cancel-session-key';
+const START_TOKEN = '11111111-1111-4111-8111-111111111111';
+let sessionCookie: string;
+let privateKey: string;
+
+beforeAll(async () => {
+  const signingKey = await importSigningKey(SESSION_SECRET);
+  sessionCookie = await signSession(createSessionPayload(10), signingKey);
+  privateKey = await generateTestPrivateKeyBase64();
+});
+
+function setBindings(database: StreamSqliteAdapter): void {
+  Object.assign(runtimeEnv, {
+    DB: database,
+    SESSION_SIGNING_KEY: SESSION_SECRET,
+    STREAM_JWT_PRIVATE_KEY: privateKey,
+    STREAM_EXTENSION_SECONDS: '7200',
+    STREAM_MAX_LIVE_PER_USER: '1',
+    STREAM_MAX_LIVE: '20',
+    STREAM_CREATE_INTERVAL_SECONDS: '10',
+  });
+}
+
+function authHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return { cookie: `ws_session=${sessionCookie}`, ...extra };
+}
+
+function callCreate(request: Request): Promise<Response> | Response {
+  return createPost({ request } as Parameters<typeof createPost>[0]);
+}
+
+function callCancel(request: Request): Promise<Response> | Response {
+  return cancelPost({ request } as Parameters<typeof cancelPost>[0]);
+}
+
+describe('配信開始token API境界', () => {
+  test('createの不正なtoken headerを400で拒否する', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders({ [STREAM_START_TOKEN_HEADER]: 'not-a-uuid' }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ errorCode: 'INVALID_REQUEST' });
+    expect(database.sqlite.query('SELECT COUNT(*) AS count FROM stream_sessions').get()).toEqual({
+      count: 0,
+    });
+  });
+
+  test('token headerを送らない旧クライアントも201で作成できる', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders(),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(database.sqlite.query('SELECT start_token FROM stream_sessions').get()).toEqual({
+      start_token: null,
+    });
+  });
+
+  test('有効なheader tokenをcreate行へ保存する', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders({ [STREAM_START_TOKEN_HEADER]: START_TOKEN }),
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(database.sqlite.query('SELECT start_token FROM stream_sessions').get()).toEqual({
+      start_token: START_TOKEN,
+    });
+  });
+
+  test('cancel-startはContent-Typeと厳格なUUID本文を検証する', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const missingContentType = await callCancel(
+      new Request('https://web-screen.net/api/streams/cancel-start/', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ startToken: START_TOKEN }),
+      })
+    );
+    const invalidBody = await callCancel(
+      new Request('https://web-screen.net/api/streams/cancel-start/', {
+        method: 'POST',
+        headers: authHeaders({ 'content-type': 'application/json' }),
+        body: JSON.stringify({ startToken: 'not-a-uuid', extra: true }),
+      })
+    );
+
+    expect(missingContentType.status).toBe(400);
+    expect(invalidBody.status).toBe(400);
+    expect(await invalidBody.json()).toMatchObject({ errorCode: 'INVALID_REQUEST' });
+  });
+
+  test('cancel-startの本文が上限を超えたら413にする', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCancel(
+      new Request('https://web-screen.net/api/streams/cancel-start/', {
+        method: 'POST',
+        headers: authHeaders({ 'content-type': 'application/json' }),
+        body: JSON.stringify({ startToken: START_TOKEN, padding: 'x'.repeat(1_024) }),
+      })
+    );
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toMatchObject({ errorCode: 'PAYLOAD_TOO_LARGE' });
+  });
+
+  test('cancel-startは有効な本文を204で冪等に受理しmatching liveを終了する', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders({ [STREAM_START_TOKEN_HEADER]: START_TOKEN }),
+      })
+    );
+    const request = () =>
+      new Request('https://web-screen.net/api/streams/cancel-start/', {
+        method: 'POST',
+        headers: authHeaders({ 'content-type': 'application/json; charset=utf-8' }),
+        body: JSON.stringify({ startToken: START_TOKEN }),
+      });
+
+    expect((await callCancel(request())).status).toBe(204);
+    expect((await callCancel(request())).status).toBe(204);
+    expect(database.sqlite.query('SELECT status, end_reason FROM stream_sessions').get()).toEqual({
+      status: 'ended',
+      end_reason: 'user_stop',
+    });
+  });
+
+  test('cancel-start 204後の同token createを409にしてliveを作らない', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const cancelled = await callCancel(
+      new Request('https://web-screen.net/api/streams/cancel-start/', {
+        method: 'POST',
+        headers: authHeaders({ 'content-type': 'application/json' }),
+        body: JSON.stringify({ startToken: START_TOKEN }),
+      })
+    );
+    const created = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders({ [STREAM_START_TOKEN_HEADER]: START_TOKEN }),
+      })
+    );
+
+    expect(cancelled.status).toBe(204);
+    expect(created.status).toBe(409);
+    expect(await created.json()).toMatchObject({ errorCode: 'STREAM_START_CANCELLED' });
+    expect(
+      database.sqlite.query("SELECT COUNT(*) AS count FROM stream_sessions WHERE status = 'live'").get()
+    ).toEqual({ count: 0 });
+  });
+});

--- a/web/tests/cron/stream-worker.test.ts
+++ b/web/tests/cron/stream-worker.test.ts
@@ -26,5 +26,6 @@ describe('配信 lifecycle cron の振り分け', () => {
 
     expect(logs).toHaveLength(1);
     expect(logs[0]).toMatchObject({ event: 'stream_lifecycle_completed', severity: 'info' });
+    expect(logs[0]?.['summary']).toMatchObject({ deletedStartCancellations: 0 });
   });
 });

--- a/web/tests/services/helpers/stream-db.ts
+++ b/web/tests/services/helpers/stream-db.ts
@@ -3,33 +3,63 @@ import { Database, type SQLQueryBindings } from 'bun:sqlite';
 import type { StreamLifecycleDatabase } from '../../../src/lib/services/stream-lifecycle';
 import type { StreamDatabase } from '../../../src/lib/services/streams';
 
+interface SqliteStatementDetails {
+  query: string;
+  values: unknown[];
+}
+
 /** bun:sqlite を stream service / lifecycle の D1 境界へ合わせる。 */
 export class StreamSqliteAdapter implements StreamDatabase, StreamLifecycleDatabase {
+  private readonly statementDetails = new WeakMap<object, SqliteStatementDetails>();
+
   constructor(readonly sqlite: Database) {}
 
   prepare(query: string) {
     return {
-      bind: (...values: unknown[]) => ({
-        first: async <T>(): Promise<T | null> =>
-          (this.sqlite.query(query).get(...(values as SQLQueryBindings[])) as T | null) ?? null,
-        all: async <T>(): Promise<{ results: T[] }> => ({
-          results: this.sqlite.query(query).all(...(values as SQLQueryBindings[])) as T[],
-        }),
-        run: async (): Promise<{ meta: { changes: number } }> => {
-          const result = this.sqlite.query(query).run(...(values as SQLQueryBindings[]));
-          return { meta: { changes: result.changes } };
-        },
-      }),
+      bind: (...values: unknown[]) => {
+        const statement = {
+          first: async <T>(): Promise<T | null> =>
+            (this.sqlite.query(query).get(...(values as SQLQueryBindings[])) as T | null) ?? null,
+          all: async <T>(): Promise<{ results: T[] }> => ({
+            results: this.sqlite.query(query).all(...(values as SQLQueryBindings[])) as T[],
+          }),
+          run: async (): Promise<{ meta: { changes: number } }> =>
+            this.runStatement(query, values),
+        };
+        this.statementDetails.set(statement, { query, values });
+        return statement;
+      },
     };
+  }
+
+  async batch(
+    statements: Parameters<StreamDatabase['batch']>[0]
+  ): Promise<Array<{ meta: { changes: number } }>> {
+    const execute = this.sqlite.transaction(() =>
+      statements.map((statement) => {
+        const details = this.statementDetails.get(statement);
+        if (!details) throw new Error('Unknown test database statement');
+        return this.runStatement(details.query, details.values);
+      })
+    );
+    return execute();
+  }
+
+  private runStatement(query: string, values: unknown[]): { meta: { changes: number } } {
+    const result = this.sqlite.query(query).run(...(values as SQLQueryBindings[]));
+    return { meta: { changes: result.changes } };
   }
 }
 
-/** 実 migration 0001 + 0003 を適用したテスト用 DB を作る。 */
+/** 実 migration 0001 + 0003 + 0004 を適用したテスト用 DB を作る。 */
 export async function createStreamDatabase(): Promise<StreamSqliteAdapter> {
   const sqlite = new Database(':memory:');
   sqlite.exec(await Bun.file(new URL('../../../migrations/0001_init.sql', import.meta.url)).text());
   sqlite.exec(
     await Bun.file(new URL('../../../migrations/0003_stream_sessions.sql', import.meta.url)).text()
+  );
+  sqlite.exec(
+    await Bun.file(new URL('../../../migrations/0004_stream_start_cancellations.sql', import.meta.url)).text()
   );
   sqlite
     .query('INSERT INTO users (id, discord_id, name) VALUES (?, ?, ?), (?, ?, ?)')

--- a/web/tests/services/stream-lifecycle.test.ts
+++ b/web/tests/services/stream-lifecycle.test.ts
@@ -57,6 +57,28 @@ function row(database: StreamSqliteAdapter) {
 }
 
 describe('配信セッション lifecycle', () => {
+  it('streamが0件でも24時間を超えた開始tombstoneだけを削除する', async () => {
+    const database = await createStreamDatabase();
+    database.sqlite
+      .query(
+        `INSERT INTO stream_start_cancellations (user_id, start_token, cancelled_at)
+         VALUES (10, ?, ?), (10, ?, ?)`
+      )
+      .run(
+        '11111111-1111-4111-8111-111111111111',
+        '2026-08-31T01:59:59.999Z',
+        '22222222-2222-4222-9222-222222222222',
+        '2026-08-31T02:00:00.000Z'
+      );
+
+    const summary = await runStreamLifecycle({ database, settings: SETTINGS, now: NOW });
+
+    expect(summary.deletedStartCancellations).toBe(1);
+    expect(
+      database.sqlite.query('SELECT start_token FROM stream_start_cancellations').all()
+    ).toEqual([{ start_token: '22222222-2222-4222-9222-222222222222' }]);
+  });
+
   it('延長期限に達したliveをextend_timeoutで終了しpublisherをkickする', async () => {
     const database = await createStreamDatabase();
     await insertLive(database, { extendAt: NOW.toISOString() });

--- a/web/tests/services/streams.test.ts
+++ b/web/tests/services/streams.test.ts
@@ -10,6 +10,10 @@ import {
   stopStream,
   type StreamSettings,
 } from '../../src/lib/services/streams';
+import {
+  cancelStreamStart,
+  MAX_STREAM_START_CANCELLATIONS_PER_USER,
+} from '../../src/lib/services/stream-start';
 import { createStreamDatabase } from './helpers/stream-db';
 
 const NOW = new Date('2026-09-01T00:00:00.000Z');
@@ -21,6 +25,8 @@ const SETTINGS: StreamSettings = {
 };
 const signer = async ({ expiresAtSeconds }: { expiresAtSeconds: number }) =>
   `token-exp-${expiresAtSeconds}`;
+const START_TOKEN_A = '11111111-1111-4111-8111-111111111111';
+const START_TOKEN_B = '22222222-2222-4222-9222-222222222222';
 
 function input(database: Awaited<ReturnType<typeof createStreamDatabase>>, id: string, now = NOW) {
   return {
@@ -34,6 +40,180 @@ function input(database: Awaited<ReturnType<typeof createStreamDatabase>>, id: s
 }
 
 describe('配信セッション service', () => {
+  it('cancel先行ならcreateを409で拒否しliveも作らない', async () => {
+    const database = await createStreamDatabase();
+    await cancelStreamStart({ database, userId: 10, startToken: START_TOKEN_A, now: NOW });
+
+    await expect(
+      createStream({ ...input(database, 'AbCdEf123456'), startToken: START_TOKEN_A })
+    ).rejects.toMatchObject({
+      status: 409,
+      errorCode: ERROR_CODES.streamStartCancelled,
+    });
+    expect(
+      database.sqlite.query("SELECT COUNT(*) AS count FROM stream_sessions WHERE status = 'live'").get()
+    ).toEqual({ count: 0 });
+  });
+
+  it('create先行なら同じtokenのliveだけをuser_stopで終了する', async () => {
+    const database = await createStreamDatabase();
+    await createStream({ ...input(database, 'AbCdEf123456'), startToken: START_TOKEN_A });
+
+    await cancelStreamStart({ database, userId: 10, startToken: START_TOKEN_A, now: NOW });
+
+    expect(
+      database.sqlite
+        .query('SELECT status, end_reason, kick_pending, start_token FROM stream_sessions')
+        .get()
+    ).toEqual({
+      status: 'ended',
+      end_reason: 'user_stop',
+      kick_pending: 1,
+      start_token: START_TOKEN_A,
+    });
+  });
+
+  it('createとcancelが並行しても完了後のliveは0本になる', async () => {
+    const database = await createStreamDatabase();
+    await Promise.allSettled([
+      createStream({ ...input(database, 'AbCdEf123456'), startToken: START_TOKEN_A }),
+      cancelStreamStart({ database, userId: 10, startToken: START_TOKEN_A, now: NOW }),
+    ]);
+
+    expect(
+      database.sqlite.query("SELECT COUNT(*) AS count FROM stream_sessions WHERE status = 'live'").get()
+    ).toEqual({ count: 0 });
+  });
+
+  it('別tokenと別userのliveへキャンセルを波及させない', async () => {
+    const database = await createStreamDatabase();
+    await createStream({ ...input(database, 'AbCdEf123456'), startToken: START_TOKEN_A });
+    await createStream({
+      ...input(database, 'ZyXwVu987654'),
+      userId: 20,
+      startToken: START_TOKEN_A,
+    });
+
+    await cancelStreamStart({ database, userId: 10, startToken: START_TOKEN_B, now: NOW });
+    await cancelStreamStart({ database, userId: 20, startToken: START_TOKEN_B, now: NOW });
+
+    expect(
+      database.sqlite
+        .query("SELECT user_id, status FROM stream_sessions WHERE status = 'live' ORDER BY user_id")
+        .all()
+    ).toEqual([
+      { user_id: 10, status: 'live' },
+      { user_id: 20, status: 'live' },
+    ]);
+  });
+
+  it('同じキャンセルを再送してもtombstoneは1件で対象は終了済みのまま', async () => {
+    const database = await createStreamDatabase();
+    await createStream({ ...input(database, 'AbCdEf123456'), startToken: START_TOKEN_A });
+
+    await cancelStreamStart({ database, userId: 10, startToken: START_TOKEN_A, now: NOW });
+    await cancelStreamStart({
+      database,
+      userId: 10,
+      startToken: START_TOKEN_A,
+      now: new Date(NOW.getTime() + 1_000),
+    });
+
+    expect(
+      database.sqlite.query('SELECT COUNT(*) AS count FROM stream_start_cancellations').get()
+    ).toEqual({ count: 1 });
+    expect(
+      database.sqlite.query('SELECT cancelled_at FROM stream_start_cancellations').get()
+    ).toEqual({ cancelled_at: NOW.toISOString() });
+    expect(database.sqlite.query('SELECT status FROM stream_sessions').get()).toEqual({
+      status: 'ended',
+    });
+  });
+
+  it('40 token burst後も利用者ごとに最新32件だけを保持する', async () => {
+    const database = await createStreamDatabase();
+    for (const userId of [10, 20]) {
+      for (let index = 0; index < 40; index += 1) {
+        await cancelStreamStart({
+          database,
+          userId,
+          startToken: numberedStartToken(index),
+          now: new Date(NOW.getTime() + index * 1_000),
+        });
+      }
+    }
+    const oldCurrentToken = numberedStartToken(99);
+    const oldCancelledAt = new Date(NOW.getTime() - 1_000).toISOString();
+    database.sqlite
+      .query(
+        `INSERT INTO stream_start_cancellations (user_id, start_token, cancelled_at)
+         VALUES (10, ?, ?)`
+      )
+      .run(oldCurrentToken, oldCancelledAt);
+    await cancelStreamStart({
+      database,
+      userId: 10,
+      startToken: oldCurrentToken,
+      now: new Date(NOW.getTime() + 100_000),
+    });
+
+    for (const userId of [10, 20]) {
+      expect(
+        database.sqlite
+          .query('SELECT COUNT(*) AS count FROM stream_start_cancellations WHERE user_id = ?')
+          .get(userId)
+      ).toEqual({ count: MAX_STREAM_START_CANCELLATIONS_PER_USER });
+      expect(
+        database.sqlite
+          .query(
+            'SELECT start_token FROM stream_start_cancellations WHERE user_id = ? AND start_token = ?'
+          )
+          .get(userId, numberedStartToken(39))
+      ).toEqual({ start_token: numberedStartToken(39) });
+    }
+    expect(
+      database.sqlite
+        .query('SELECT cancelled_at FROM stream_start_cancellations WHERE start_token = ?')
+        .get(oldCurrentToken)
+    ).toEqual({ cancelled_at: oldCancelledAt });
+  });
+
+  it('cancel先行は作成間隔を消費せず別tokenを直後に作成できる', async () => {
+    const database = await createStreamDatabase();
+    await cancelStreamStart({ database, userId: 10, startToken: START_TOKEN_A, now: NOW });
+
+    await expect(
+      createStream({ ...input(database, 'AbCdEf123456'), startToken: START_TOKEN_B })
+    ).resolves.toMatchObject({ id: 'AbCdEf123456' });
+  });
+
+  it('start tokenのない旧クライアントは従来通り作成しNULLを保存する', async () => {
+    const database = await createStreamDatabase();
+    await createStream(input(database, 'AbCdEf123456'));
+
+    expect(database.sqlite.query('SELECT start_token FROM stream_sessions').get()).toEqual({
+      start_token: null,
+    });
+  });
+
+  it('同じstart tokenのcreate再送を既存session状態に応じた409へ変換する', async () => {
+    const liveDatabase = await createStreamDatabase();
+    await createStream({ ...input(liveDatabase, 'AbCdEf123456'), startToken: START_TOKEN_A });
+    await expect(
+      createStream({ ...input(liveDatabase, 'ZyXwVu987654'), startToken: START_TOKEN_A })
+    ).rejects.toMatchObject({ status: 409, errorCode: ERROR_CODES.streamAlreadyLive });
+
+    const endedDatabase = await createStreamDatabase();
+    await createStream({ ...input(endedDatabase, 'AbCdEf123456'), startToken: START_TOKEN_A });
+    await stopStream({ database: endedDatabase, userId: 10, id: 'AbCdEf123456', now: NOW });
+    await expect(
+      createStream({
+        ...input(endedDatabase, 'ZyXwVu987654', new Date(NOW.getTime() + 11_000)),
+        startToken: START_TOKEN_A,
+      })
+    ).rejects.toMatchObject({ status: 409, errorCode: ERROR_CODES.streamEnded });
+  });
+
   it('作成時刻を秒精度へ揃えD1・response・JWT NumericDateを一致させる', async () => {
     const database = await createStreamDatabase();
     let signedIssued = 0;
@@ -299,3 +479,7 @@ describe('配信セッション service', () => {
     ).toEqual({ status: 'live' });
   });
 });
+
+function numberedStartToken(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+}

--- a/web/tests/ui/screen-share-race.test.ts
+++ b/web/tests/ui/screen-share-race.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ScreenShareController, type ScreenShareDependencies } from '../../src/lib/ui/screen-share';
+import type { WhipPublisher } from '../../src/lib/ui/whip-publisher';
+
+describe('画面共有runの競合拒否', () => {
+  test('picker未解決中はstartとstop-othersの重複入口を拒否する', async () => {
+    const page = fakePage();
+    const pendingMedia = deferred<MediaStream>();
+    const calls = { mediaSelections: 0, creates: 0, publisherStarts: 0 };
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path === '/api/streams/') {
+          calls.creates += 1;
+          return createResponse();
+        }
+        return null;
+      },
+      getDisplayMedia: () => {
+        calls.mediaSelections += 1;
+        return pendingMedia.promise;
+      },
+      startWhipPublisher: async () => {
+        calls.publisherStarts += 1;
+        return publisher(() => undefined, () => undefined);
+      },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    page.button('[data-screen-start]').click();
+    page.button('[data-screen-stop-others]').click();
+    await flushMicrotasks();
+
+    expect(calls).toEqual({ mediaSelections: 1, creates: 0, publisherStarts: 0 });
+    pendingMedia.resolve(media(() => undefined));
+    await waitFor(() => !page.step('url').hidden);
+    expect(calls).toEqual({ mediaSelections: 1, creates: 1, publisherStarts: 1 });
+  });
+
+  test('picker cancel後は予約を解除して再開始できる', async () => {
+    const page = fakePage();
+    let selections = 0;
+    let creates = 0;
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path === '/api/streams/') creates += 1;
+        return createResponse();
+      },
+      getDisplayMedia: async () => {
+        selections += 1;
+        if (selections === 1) throw new DOMException('denied', 'NotAllowedError');
+        return media(() => undefined);
+      },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('url').hidden);
+
+    expect(selections).toBe(2);
+    expect(creates).toBe(1);
+  });
+
+  test.each(['resolve', 'reject'] as const)(
+    'health待機中の2回目startを拒否し、pagehide後の%sでも二重解放しない',
+    async (settlement) => {
+      const page = fakePage();
+      const oldHealth = deferred<boolean>();
+      let pageHide: (() => void) | undefined;
+      const calls = {
+        mediaSelections: 0,
+        creates: 0,
+        publisherStarts: 0,
+        healthChecks: 0,
+        trackStops: 0,
+        closes: 0,
+        deletes: 0,
+        serverStops: 0,
+      };
+      const activePublisher = publisher(
+        () => { calls.closes += 1; },
+        () => { calls.deletes += 1; }
+      );
+      new ScreenShareController(page.root, dependencies({
+        requestJson: async (path) => {
+          if (path === '/api/streams/') {
+            calls.creates += 1;
+            return createResponse();
+          }
+          return null;
+        },
+        getDisplayMedia: async () => {
+          calls.mediaSelections += 1;
+          return media(() => { calls.trackStops += 1; });
+        },
+        startWhipPublisher: async () => {
+          calls.publisherStarts += 1;
+          return activePublisher;
+        },
+        waitForStreamReady: async () => {
+          calls.healthChecks += 1;
+          return oldHealth.promise;
+        },
+        sendBeacon: () => {
+          calls.serverStops += 1;
+          return true;
+        },
+        onPageHide: (handler) => { pageHide = handler; },
+      })).mount();
+
+      page.button('[data-screen-start]').click();
+      await waitFor(() => calls.healthChecks === 1);
+      page.button('[data-screen-start]').click();
+      await flushMicrotasks();
+
+      expect(calls).toEqual({
+        mediaSelections: 1,
+        creates: 1,
+        publisherStarts: 1,
+        healthChecks: 1,
+        trackStops: 0,
+        closes: 0,
+        deletes: 0,
+        serverStops: 0,
+      });
+      pageHide?.();
+      const released = {
+        mediaSelections: 1,
+        creates: 1,
+        publisherStarts: 1,
+        healthChecks: 1,
+        trackStops: 1,
+        closes: 1,
+        deletes: 1,
+        serverStops: 1,
+      };
+      expect(calls).toEqual(released);
+
+      if (settlement === 'resolve') oldHealth.resolve(true);
+      else oldHealth.reject(new Error('late health failure'));
+      await flushMicrotasks();
+
+      expect(calls).toEqual(released);
+      expect(page.step('idle').hidden).toBe(false);
+      expect(page.step('url').hidden).toBe(true);
+      expect(page.step('error').hidden).toBe(true);
+    }
+  );
+});
+
+function dependencies(overrides: Partial<ScreenShareDependencies>): ScreenShareDependencies {
+  return {
+    requestJson: async () => null,
+    startWhipPublisher: async () => publisher(() => undefined, () => undefined),
+    waitForStreamReady: async () => true,
+    getDisplayMedia: async () => media(() => undefined),
+    delay: async () => undefined,
+    now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+    sendBeacon: () => true,
+    onPageHide: () => undefined,
+    ...overrides,
+  };
+}
+
+function createResponse(): Record<string, unknown> {
+  return {
+    id: 'OldStream123',
+    streamUrl: 'rtspt://webscreen.tv/live/OldStream123',
+    status: 'live',
+    publishToken: 'token',
+    publishTokenExpiresAt: '2026-09-01T01:00:00.000Z',
+    extendExpiresAt: '2026-09-01T01:00:00.000Z',
+    startedAt: '2026-09-01T00:00:00.000Z',
+    lastHeartbeatAt: '2026-09-01T00:00:00.000Z',
+    endedAt: null,
+    endReason: null,
+  };
+}
+
+function media(onStop: () => void): MediaStream {
+  const track = { addEventListener: () => undefined, stop: onStop };
+  return {
+    getTracks: () => [track],
+    getVideoTracks: () => [track],
+    getAudioTracks: () => [],
+  } as unknown as MediaStream;
+}
+
+function publisher(onClose: () => void, onDelete: () => void): WhipPublisher {
+  const value: WhipPublisher = {
+    close: onClose,
+    deleteResource: async () => { onDelete(); },
+    stop: async () => undefined,
+    republish: async () => value,
+    setPublishToken: () => undefined,
+  };
+  return value;
+}
+
+function fakePage(): {
+  root: HTMLElement;
+  button: (selector: string) => FakeElement;
+  step: (phase: string) => FakeElement;
+} {
+  const elements = new Map<string, FakeElement>();
+  for (const selector of [
+    '[data-screen-start]', '[data-screen-stop-others]', '[data-screen-retry]', '[data-screen-url]',
+    '[data-screen-preview]', '[data-screen-audio-status]', '[data-screen-expiry-warning]',
+    '[data-screen-indicators]', '[data-screen-error-message]',
+  ]) elements.set(selector, new FakeElement());
+  const steps = ['idle', 'login', 'url', 'live', 'error'].map((phase) => {
+    const step = new FakeElement();
+    step.dataset.screenStep = phase;
+    return step;
+  });
+  const root = {
+    dataset: {
+      labelStart: 'start',
+      labelSelecting: 'selecting',
+      labelStopOthers: 'stop-others',
+      msgVideoOnly: 'video',
+      msgDisplayDenied: 'denied',
+      msgGeneric: 'error',
+    },
+    querySelector: (selector: string) => elements.get(selector) ?? null,
+    querySelectorAll: (selector: string) => selector === '[data-screen-step]' ? steps : [],
+  } as unknown as HTMLElement;
+  return {
+    root,
+    button: (selector) => elements.get(selector)!,
+    step: (phase) => steps.find((step) => step.dataset.screenStep === phase)!,
+  };
+}
+
+class FakeElement {
+  dataset: Record<string, string> = {};
+  disabled = false;
+  hidden = false;
+  textContent = '';
+  value = '';
+  srcObject: MediaStream | null = null;
+  private readonly listeners: Array<() => void> = [];
+
+  querySelector(): null { return null; }
+  addEventListener(event: string, listener: () => void): void {
+    if (event === 'click') this.listeners.push(listener);
+  }
+  click(): void { for (const listener of this.listeners) listener(); }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (condition()) return;
+    await Promise.resolve();
+  }
+  throw new Error('Expected asynchronous UI update');
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/web/tests/ui/screen-share-race.test.ts
+++ b/web/tests/ui/screen-share-race.test.ts
@@ -4,6 +4,49 @@ import { ScreenShareController, type ScreenShareDependencies } from '../../src/l
 import type { WhipPublisher } from '../../src/lib/ui/whip-publisher';
 
 describe('画面共有runの競合拒否', () => {
+  test('create待機中のpagehideでPOSTをabortせず、回収したIDを即stopする', async () => {
+    const page = fakePage();
+    const pendingCreate = deferred<Record<string, unknown>>();
+    let pageHide: (() => void) | undefined;
+    let createRequested = false;
+    let createSignal: AbortSignal | undefined;
+    const calls = { trackStops: 0, publisherStarts: 0, serverStops: 0 };
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path, init) => {
+        if (path === '/api/streams/') {
+          createRequested = true;
+          createSignal = init.signal as AbortSignal | undefined;
+          createSignal?.addEventListener(
+            'abort',
+            () => pendingCreate.reject(new DOMException('aborted', 'AbortError')),
+            { once: true }
+          );
+          return pendingCreate.promise;
+        }
+        if (path.endsWith('/stop/')) calls.serverStops += 1;
+        return null;
+      },
+      startWhipPublisher: async () => {
+        calls.publisherStarts += 1;
+        return publisher(() => undefined, () => undefined);
+      },
+      getDisplayMedia: async () => media(() => { calls.trackStops += 1; }),
+      onPageHide: (handler) => { pageHide = handler; },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => createRequested);
+    pageHide?.();
+    pendingCreate.resolve(createResponse());
+    await waitFor(() => calls.serverStops === 1);
+
+    expect(createSignal).toBeUndefined();
+    expect(calls).toEqual({ trackStops: 1, publisherStarts: 0, serverStops: 1 });
+    expect(page.step('idle').hidden).toBe(false);
+    expect(page.step('url').hidden).toBe(true);
+    expect(page.step('error').hidden).toBe(true);
+  });
+
   test('picker未解決中はstartとstop-othersの重複入口を拒否する', async () => {
     const page = fakePage();
     const pendingMedia = deferred<MediaStream>();

--- a/web/tests/ui/screen-share-race.test.ts
+++ b/web/tests/ui/screen-share-race.test.ts
@@ -3,7 +3,113 @@ import { describe, expect, test } from 'bun:test';
 import { ScreenShareController, type ScreenShareDependencies } from '../../src/lib/ui/screen-share';
 import type { WhipPublisher } from '../../src/lib/ui/whip-publisher';
 
+const START_TOKEN = '11111111-1111-4111-8111-111111111111';
+
 describe('画面共有runの競合拒否', () => {
+  test('pagehideはcreate headerと同じtokenをcancel-start beaconへ送る', async () => {
+    const page = fakePage();
+    const pendingCreate = deferred<Record<string, unknown>>();
+    let pageHide: (() => void) | undefined;
+    let createToken: string | undefined;
+    let beaconUrl: string | undefined;
+    let beaconData: BodyInit | null | undefined;
+    new ScreenShareController(page.root, dependencies({
+      createStartToken: () => START_TOKEN,
+      requestJson: async (path, init) => {
+        if (path === '/api/streams/') {
+          createToken = new Headers(init.headers).get('X-WebScreen-Start-Token') ?? undefined;
+          return pendingCreate.promise;
+        }
+        return null;
+      },
+      sendBeacon: (url, data) => {
+        beaconUrl = url;
+        beaconData = data;
+        return true;
+      },
+      onPageHide: (handler) => { pageHide = handler; },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => createToken !== undefined);
+    pageHide?.();
+
+    expect(createToken).toBe(START_TOKEN);
+    expect(beaconUrl).toBe('/api/streams/cancel-start/');
+    expect(beaconData).toBeInstanceOf(Blob);
+    expect(JSON.parse(await (beaconData as Blob).text())).toEqual({ startToken: START_TOKEN });
+    expect((beaconData as Blob).type).toContain('application/json');
+    pendingCreate.resolve(createResponse());
+    await flushMicrotasks();
+  });
+
+  test.each(['false', 'throw'] as const)(
+    'cancel-start beaconが%sならkeepalive fetchへfallbackする',
+    async (failure) => {
+      const page = fakePage();
+      const pendingCreate = deferred<Record<string, unknown>>();
+      let pageHide: (() => void) | undefined;
+      let fallback: RequestInit | undefined;
+      const originalWarn = console.warn;
+      console.warn = () => undefined;
+      try {
+        new ScreenShareController(page.root, dependencies({
+          createStartToken: () => START_TOKEN,
+          requestJson: async (path, init) => {
+            if (path === '/api/streams/') return pendingCreate.promise;
+            if (path === '/api/streams/cancel-start/') fallback = init;
+            return null;
+          },
+          sendBeacon: () => {
+            if (failure === 'throw') throw new Error('beacon unavailable');
+            return false;
+          },
+          onPageHide: (handler) => { pageHide = handler; },
+        })).mount();
+
+        page.button('[data-screen-start]').click();
+        await flushMicrotasks();
+        pageHide?.();
+        await waitFor(() => fallback !== undefined);
+
+        expect(fallback).toMatchObject({ method: 'POST', keepalive: true });
+        expect(new Headers(fallback?.headers).get('Content-Type')).toBe('application/json');
+        expect(JSON.parse(String(fallback?.body))).toEqual({ startToken: START_TOKEN });
+        pendingCreate.resolve(createResponse());
+        await flushMicrotasks();
+      } finally {
+        console.warn = originalWarn;
+      }
+    }
+  );
+
+  test('live IDが既知ならpagehideは既存stopだけをbeaconしcancel-startを送らない', async () => {
+    const page = fakePage();
+    let pageHide: (() => void) | undefined;
+    const beaconUrls: string[] = [];
+    const requestUrls: string[] = [];
+    new ScreenShareController(page.root, dependencies({
+      createStartToken: () => START_TOKEN,
+      requestJson: async (path) => {
+        requestUrls.push(path);
+        return path === '/api/streams/' ? createResponse() : null;
+      },
+      sendBeacon: (url) => {
+        beaconUrls.push(url);
+        return true;
+      },
+      onPageHide: (handler) => { pageHide = handler; },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('url').hidden);
+    pageHide?.();
+    await flushMicrotasks();
+
+    expect(beaconUrls).toEqual(['/api/streams/OldStream123/stop/']);
+    expect(requestUrls).not.toContain('/api/streams/cancel-start/');
+  });
+
   test('create待機中のpagehideでPOSTをabortせず、回収したIDを即stopする', async () => {
     const page = fakePage();
     const pendingCreate = deferred<Record<string, unknown>>();

--- a/web/tests/ui/screen-share-stop-live.test.ts
+++ b/web/tests/ui/screen-share-stop-live.test.ts
@@ -52,7 +52,8 @@ describe('他の配信を終了して開始', () => {
     const page = fakePage();
     let creates = 0;
     let pageHide: (() => void) | undefined;
-    let stopped = 0;
+    const stopCounts = [0, 0];
+    let selections = 0;
     let resolveDelay: (() => void) | undefined;
     const controller = new ScreenShareController(page.root, dependencies({
       requestJson: async (path) => {
@@ -63,7 +64,11 @@ describe('他の配信を終了して開始', () => {
         }
         return { stopped: 1, retryAfterSeconds: 0 };
       },
-      getDisplayMedia: async () => media(() => { stopped += 1; }),
+      getDisplayMedia: async () => {
+        const selection = selections;
+        selections += 1;
+        return media(() => { stopCounts[selection] = (stopCounts[selection] ?? 0) + 1; });
+      },
       delay: () => new Promise<void>((resolve) => { resolveDelay = resolve; }),
       onPageHide: (handler) => { pageHide = handler; },
     }));
@@ -79,8 +84,219 @@ describe('他の配信を終了して開始', () => {
     await flushMicrotasks();
 
     expect(creates).toBe(1);
-    expect(stopped).toBeGreaterThanOrEqual(2);
+    expect(stopCounts).toEqual([1, 1]);
     expect(page.button('[data-screen-retry]').disabled).toBe(false);
+  });
+
+  test('stop-live待機中の2回目startを拒否して既存runを維持する', async () => {
+    const page = fakePage();
+    const pendingStopLive = deferred<Record<string, unknown>>();
+    const stopCounts = [0, 0];
+    let selections = 0;
+    let creates = 0;
+    let oldSignal: AbortSignal | undefined;
+    let pageHide: (() => void) | undefined;
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path, init) => {
+        if (path === '/api/streams/stop-live/') {
+          oldSignal = init.signal as AbortSignal | undefined;
+          return pendingStopLive.promise;
+        }
+        if (path === '/api/streams/') {
+          creates += 1;
+          if (creates === 1) throw new JsonRequestError(409, ERROR_CODES.streamAlreadyLive);
+          return createResponse();
+        }
+        return null;
+      },
+      getDisplayMedia: async () => {
+        const selection = selections;
+        selections += 1;
+        return media(() => { stopCounts[selection] = (stopCounts[selection] ?? 0) + 1; });
+      },
+      onPageHide: (handler) => { pageHide = handler; },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-stop-others]').click();
+    await waitFor(() => oldSignal !== undefined);
+    page.button('[data-screen-start]').click();
+    await flushMicrotasks();
+
+    expect(oldSignal?.aborted).toBe(false);
+    expect(selections).toBe(2);
+    expect(creates).toBe(1);
+    expect(stopCounts).toEqual([1, 0]);
+    pageHide?.();
+    expect(oldSignal?.aborted).toBe(true);
+    expect(stopCounts).toEqual([1, 1]);
+    pendingStopLive.resolve({ stopped: 1, retryAfterSeconds: 0 });
+    await flushMicrotasks();
+
+    expect(creates).toBe(1);
+    expect(stopCounts).toEqual([1, 1]);
+    expect(page.step('idle').hidden).toBe(false);
+    expect(page.step('error').hidden).toBe(true);
+  });
+
+  test('stop-live後のcreate失敗でも再取得したtrackを一度だけ停止する', async () => {
+    const page = fakePage();
+    const stopCounts = [0, 0];
+    let creates = 0;
+    let selections = 0;
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path !== '/api/streams/') return { stopped: 1, retryAfterSeconds: 0 };
+        creates += 1;
+        if (creates === 1) throw new JsonRequestError(409, ERROR_CODES.streamAlreadyLive);
+        throw new Error('create failed');
+      },
+      getDisplayMedia: async () => {
+        const selection = selections;
+        selections += 1;
+        return media(() => { stopCounts[selection] = (stopCounts[selection] ?? 0) + 1; });
+      },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-stop-others]').click();
+    await waitFor(() => stopCounts[1] === 1);
+
+    expect(stopCounts).toEqual([1, 1]);
+  });
+
+  test('stop-live後のpublisher失敗でも再取得したtrackを一度だけ停止する', async () => {
+    const page = fakePage();
+    const stopCounts = [0, 0];
+    let creates = 0;
+    let selections = 0;
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path !== '/api/streams/') return { stopped: 1, retryAfterSeconds: 0 };
+        creates += 1;
+        if (creates === 1) throw new JsonRequestError(409, ERROR_CODES.streamAlreadyLive);
+        return createResponse();
+      },
+      startWhipPublisher: async () => { throw new Error('publish failed'); },
+      getDisplayMedia: async () => {
+        const selection = selections;
+        selections += 1;
+        return media(() => { stopCounts[selection] = (stopCounts[selection] ?? 0) + 1; });
+      },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-stop-others]').click();
+    await waitFor(() => stopCounts[1] === 1);
+
+    expect(stopCounts).toEqual([1, 1]);
+  });
+
+  test('create待機中のpagehide後に応答してもURLやerrorを表示しない', async () => {
+    const page = fakePage();
+    const pendingCreate = deferred<Record<string, unknown>>();
+    let pageHide: (() => void) | undefined;
+    let stopCount = 0;
+    let publisherStarts = 0;
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => path === '/api/streams/' ? pendingCreate.promise : null,
+      startWhipPublisher: async () => {
+        publisherStarts += 1;
+        return publisher();
+      },
+      getDisplayMedia: async () => media(() => { stopCount += 1; }),
+      onPageHide: (handler) => { pageHide = handler; },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await flushMicrotasks();
+    pageHide?.();
+    pendingCreate.resolve(createResponse());
+    await flushMicrotasks();
+
+    expect(stopCount).toBe(1);
+    expect(publisherStarts).toBe(0);
+    expect(page.step('idle').hidden).toBe(false);
+    expect(page.step('url').hidden).toBe(true);
+    expect(page.step('error').hidden).toBe(true);
+  });
+
+  test('publisher待機中のpagehide後に解決しても全資源を一度だけ解放する', async () => {
+    const page = fakePage();
+    const pendingPublisher = deferred<WhipPublisher>();
+    let pageHide: (() => void) | undefined;
+    let publisherStarted = false;
+    const calls = { stopped: 0, closed: 0, deleted: 0, serverStops: 0, healthChecks: 0 };
+    const delayedPublisher: WhipPublisher = {
+      close: () => { calls.closed += 1; },
+      deleteResource: async () => { calls.deleted += 1; },
+      stop: async () => undefined,
+      republish: async () => delayedPublisher,
+      setPublishToken: () => undefined,
+    };
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path) => {
+        if (path === '/api/streams/') return createResponse();
+        if (path.endsWith('/stop/')) calls.serverStops += 1;
+        return null;
+      },
+      startWhipPublisher: () => {
+        publisherStarted = true;
+        return pendingPublisher.promise;
+      },
+      waitForStreamReady: async () => {
+        calls.healthChecks += 1;
+        return true;
+      },
+      getDisplayMedia: async () => media(() => { calls.stopped += 1; }),
+      onPageHide: (handler) => { pageHide = handler; },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => publisherStarted);
+    pageHide?.();
+    expect(calls.stopped).toBe(1);
+    pendingPublisher.resolve(delayedPublisher);
+    await waitFor(() => calls.deleted === 1 && calls.serverStops === 1);
+
+    expect(calls).toEqual({ stopped: 1, closed: 1, deleted: 1, serverStops: 1, healthChecks: 0 });
+    expect(page.step('idle').hidden).toBe(false);
+    expect(page.step('url').hidden).toBe(true);
+    expect(page.step('error').hidden).toBe(true);
+  });
+
+  test('extend待機中の停止はsession signalをabortして遅延UIを復活させない', async () => {
+    const page = fakePage();
+    const pendingExtend = deferred<Record<string, unknown>>();
+    let extendSignal: AbortSignal | undefined;
+    new ScreenShareController(page.root, dependencies({
+      requestJson: async (path, init) => {
+        if (path === '/api/streams/') return createResponse();
+        if (path.endsWith('/extend/')) {
+          extendSignal = init.signal as AbortSignal | undefined;
+          return pendingExtend.promise;
+        }
+        return null;
+      },
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('url').hidden);
+    page.button('[data-screen-extend]').click();
+    await waitFor(() => extendSignal !== undefined);
+    page.button('[data-screen-stop]').click();
+
+    expect(extendSignal?.aborted).toBe(true);
+    pendingExtend.resolve({
+      extendExpiresAt: '2026-09-01T02:00:00.000Z',
+      publishToken: 'late-token',
+    });
+    await flushMicrotasks();
+    expect(page.step('idle').hidden).toBe(false);
+    expect(page.step('error').hidden).toBe(true);
   });
 
   test('stop-live API の失敗時は取得済み画面を停止してエラー表示へ戻る', async () => {
@@ -169,6 +385,7 @@ function fakePage(): {
   const elements = new Map<string, FakeElement>();
   for (const selector of [
     '[data-screen-start]', '[data-screen-stop-others]', '[data-screen-retry]',
+    '[data-screen-extend]', '[data-screen-stop]',
     '[data-screen-error-message]', '[data-screen-url]', '[data-screen-audio-status]',
     '[data-screen-preview]', '[data-screen-expiry-warning]', '[data-screen-indicators]',
   ]) elements.set(selector, new FakeElement());
@@ -217,4 +434,10 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
 }

--- a/web/tests/ui/stream-health.test.ts
+++ b/web/tests/ui/stream-health.test.ts
@@ -37,4 +37,54 @@ describe('配信開始のhealth判定', () => {
     expect(requests).toBe(STREAM_HEALTH_MAX_ATTEMPTS);
     expect(waits).toBe(STREAM_HEALTH_MAX_ATTEMPTS - 1);
   });
+
+  test('health request待機中のabort後は次のrequestを送らない', async () => {
+    const pendingRequest = deferred<Record<string, unknown>>();
+    const abortController = new AbortController();
+    let requests = 0;
+    let receivedSignal: AbortSignal | undefined;
+    const request = (async (_path: string, init: RequestInit) => {
+      requests += 1;
+      receivedSignal = init.signal as AbortSignal | undefined;
+      return pendingRequest.promise;
+    }) as unknown as ScreenShareDependencies['requestJson'];
+
+    const result = waitForStreamReady('Ab12Cd34Ef56', request, async () => undefined, abortController.signal);
+    await Promise.resolve();
+    abortController.abort();
+    pendingRequest.resolve({ state: 'starting', ingressBytes: 0, egressBytes: 0, audioDetected: null });
+
+    await expect(result).resolves.toBe(false);
+    expect(receivedSignal).toBe(abortController.signal);
+    expect(requests).toBe(1);
+  });
+
+  test('poll delay待機中のabort後は次のrequestを送らない', async () => {
+    const pendingDelay = deferred<void>();
+    const abortController = new AbortController();
+    let requests = 0;
+    const request = (async () => {
+      requests += 1;
+      return { state: 'starting', ingressBytes: 0, egressBytes: 0, audioDetected: null };
+    }) as unknown as ScreenShareDependencies['requestJson'];
+
+    const result = waitForStreamReady(
+      'Ab12Cd34Ef56',
+      request,
+      () => pendingDelay.promise,
+      abortController.signal
+    );
+    await Promise.resolve();
+    abortController.abort();
+    pendingDelay.resolve();
+
+    await expect(result).resolves.toBe(false);
+    expect(requests).toBe(1);
+  });
 });
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}


### PR DESCRIPTION
## 背景

画面共有の開始処理中にページ離脱や重複操作が起きると、取得済みの MediaStream、WHIP publisher、サーバー側配信の所有者が曖昧になり、停止漏れや二重停止が起き得ました。#165 の責務分割前に、現行動作を安全なライフサイクルへ固定します。

## 変更内容

- 画面選択中から開始予約を一意にし、並行する開始操作を拒否
- Capture / StartRun / LiveStream の解放を冪等化
- stop-live・health・extend・heartbeat に AbortSignal を伝播
- pagehide 時にローカル資源を同期解放し、サーバー停止と WHIP 削除を高々1回に制限
- 開始ごとの UUIDv4 operation token と D1 tombstone を導入し、cancel先行／create先行の両順序で孤児liveを防止
- `POST /api/streams/cancel-start/` を追加し、Beacon失敗時はkeepalive fetchへフォールバック
- tombstoneを利用者ごと最大32件に制限し、24時間超を毎分cronで削除
- pickerキャンセル、遅延resolve/reject、再接続、stop-others の競合テストを追加

既存の画面・文言・配信設定は変更していません。開始token headerは任意で、旧クライアントのtokenなし作成も維持します。migrationはnullable列と新規表だけの加算変更で、旧Workerへのコードロールバックと互換です。

## 検証

- 対象テスト: 100 passed / 0 failed
- TypeScript: `tsc --noEmit` 成功
- Astro production build: 成功
- architecture changed-only: 違反なし
- コード、セキュリティ、影響範囲、UIの4レビュー: blocking指摘なし

GitHubレビューで指摘された「create POSTを応答前にabortすると作成済みIDを回収できない」「ページ破棄後のPromise継続だけでは停止を保証できない」経路は、createを非abort化したうえでoperation tokenをDBで順序保証し、回帰テスト付きで修正しました。

`screen-share.ts` の責務分割はこのバグ修正へ混ぜず、続く #165 で実施します。

ローカルの全体テストは Bun 1.3.1 に `jest.advanceTimersByTime` がない既存テスト1件のみ失敗します。変更対象外であり、CIはリポジトリ指定の Bun 1.3.6 で実行します。

Closes #180
