### PR TITLE
feat(screen-share): 検証用リアルタイム優先プロファイルを URL query で選べるようにする

### DIFF
--- a/web/src/lib/ui/screen-share/controller.ts
+++ b/web/src/lib/ui/screen-share/controller.ts
@@ -6,7 +6,7 @@ import type { startWhipPublisher, WhipPublisher } from '../whip-publisher';
 import { currentAudioProfile, displayMediaConstraints } from './capture';
 import { isExpiryWarning, LiveStreamSession, releasePublisher, secondsUntil, StartRun } from './session';
 import { createStreamApi, type StreamApi } from './stream-api';
-import { SCREEN_SHARE_VIDEO_SETTINGS } from './video-profile';
+import { resolveScreenShareVideoSettingsForSearch } from './video-profile';
 import {
   isStreamAlreadyLiveError,
   messageKeyForError,
@@ -147,7 +147,7 @@ export class ScreenShareControllerImpl {
         publishToken: created.publishToken,
         keyframeRequestIntervalMs: keyframeRequestIntervalForSearch(currentSearch()),
         audioProfile: currentAudioProfile(),
-        videoSettings: SCREEN_SHARE_VIDEO_SETTINGS,
+        videoSettings: resolveScreenShareVideoSettingsForSearch(currentSearch()),
       });
       stream = new LiveStreamSession(created, publisher, run);
       if (!this.isActiveRun(run)) return this.discardInactiveRun(stream, run);

--- a/web/src/lib/ui/screen-share/index.ts
+++ b/web/src/lib/ui/screen-share/index.ts
@@ -12,7 +12,11 @@ export {
   releaseScreenShare,
   secondsUntil,
 } from './session';
-export { SCREEN_SHARE_VIDEO_SETTINGS } from './video-profile';
+export {
+  REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+  resolveScreenShareVideoSettingsForSearch,
+  SCREEN_SHARE_VIDEO_SETTINGS,
+} from './video-profile';
 
 const BROWSER_DEPENDENCIES: ScreenShareDependencies = {
   requestJson,

--- a/web/src/lib/ui/screen-share/video-profile.ts
+++ b/web/src/lib/ui/screen-share/video-profile.ts
@@ -1,3 +1,6 @@
+import { realtimeVideoMaxBitrateForSearch } from '../stream-profile';
+import type { WhipVideoSettings } from '../whip-publisher';
+
 /** Capture・track・sender に同じ値を渡す固定映像プロファイル。 */
 export const SCREEN_SHARE_VIDEO_SETTINGS = {
   width: 1280,
@@ -8,6 +11,24 @@ export const SCREEN_SHARE_VIDEO_SETTINGS = {
   degradationPreference: 'maintain-resolution',
   scaleResolutionDownBy: 1,
 } as const;
+
+/** Issue #177 の検証時だけ query で選べるリアルタイム優先の映像プロファイル。 */
+export const REALTIME_SCREEN_SHARE_VIDEO_SETTINGS = {
+  width: 1280,
+  height: 720,
+  frameRate: 30,
+  maxBitrate: 1_500_000,
+  contentHint: 'motion',
+  degradationPreference: 'maintain-framerate',
+} as const;
+
+/** URL query から画面共有の送出設定を解決する。 */
+export function resolveScreenShareVideoSettingsForSearch(search: string): WhipVideoSettings {
+  const maxBitrate = realtimeVideoMaxBitrateForSearch(search);
+  if (maxBitrate === undefined) return SCREEN_SHARE_VIDEO_SETTINGS;
+
+  return { ...REALTIME_SCREEN_SHARE_VIDEO_SETTINGS, maxBitrate };
+}
 
 /** 画面取得に渡す固定制約を返す。 */
 export function captureVideoConstraints(): MediaTrackConstraints {

--- a/web/src/lib/ui/stream-profile.ts
+++ b/web/src/lib/ui/stream-profile.ts
@@ -1,6 +1,15 @@
 /** MP3 beta 配信だけで許可するkeyframe要求の固定間隔。 */
 export const MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS = 500;
 
+/** 検証用リアルタイム映像プロファイルで許可する sender bitrate。 */
+export const REALTIME_VIDEO_MAX_BITRATES = [1_200_000, 1_500_000, 2_000_000] as const;
+
+/** 検証用リアルタイム映像プロファイルで bitrate 指定がない時の暫定値。 */
+export const DEFAULT_REALTIME_VIDEO_MAX_BITRATE = 1_500_000;
+
+/** 検証用リアルタイム映像プロファイルで許可する sender bitrate の型。 */
+export type RealtimeVideoMaxBitrate = (typeof REALTIME_VIDEO_MAX_BITRATES)[number];
+
 /** URL query に指定された値が重複なく完全一致するかを判定する。 */
 export function hasSingleExactQueryValue(search: string, name: string, expectedValue: string): boolean {
   const values = new URLSearchParams(search).getAll(name);
@@ -14,4 +23,21 @@ export function keyframeRequestIntervalForSearch(
   return hasSingleExactQueryValue(search, 'stream-profile', 'mp3-beta')
     ? MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS
     : undefined;
+}
+
+/** URL query が検証用リアルタイム映像プロファイルを完全一致で要求した時だけ bitrate を返す。 */
+export function realtimeVideoMaxBitrateForSearch(search: string): RealtimeVideoMaxBitrate | undefined {
+  if (!hasSingleExactQueryValue(search, 'video-profile', 'realtime')) return undefined;
+
+  const values = new URLSearchParams(search).getAll('video-max-bitrate');
+  if (values.length === 0) return DEFAULT_REALTIME_VIDEO_MAX_BITRATE;
+  if (values.length !== 1) return undefined;
+
+  // bitrate query が不正なら realtime 候補自体を無効化し、既定プロファイルへ fail-closed する。
+  switch (values[0]) {
+    case '1200000': return 1_200_000;
+    case '1500000': return 1_500_000;
+    case '2000000': return 2_000_000;
+    default: return undefined;
+  }
 }

--- a/web/src/lib/ui/stream-profile.ts
+++ b/web/src/lib/ui/stream-profile.ts
@@ -25,6 +25,8 @@ export function keyframeRequestIntervalForSearch(
 /** URL query が検証用リアルタイム映像プロファイルを完全一致で要求した時だけ bitrate を返す。 */
 export function realtimeVideoMaxBitrateForSearch(search: string): RealtimeVideoMaxBitrate | undefined {
   if (!hasSingleExactQueryValue(search, 'video-profile', 'realtime')) return undefined;
+  // mp3-beta の 500 ms キーフレーム要求との併用は未検証の最大負荷条件になるため、組み合わせごと拒否する。
+  if (new URLSearchParams(search).has('stream-profile')) return undefined;
 
   // bitrate は暗黙の既定を持たせず明示必須にする（未指定・不正・重複はいずれも候補ごと無効化して
   // 既定プロファイルへ fail-closed する）。検証結果の解釈で「どの上限で測ったか」を曖昧にしないため。

--- a/web/src/lib/ui/stream-profile.ts
+++ b/web/src/lib/ui/stream-profile.ts
@@ -4,9 +4,6 @@ export const MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS = 500;
 /** 検証用リアルタイム映像プロファイルで許可する sender bitrate。 */
 export const REALTIME_VIDEO_MAX_BITRATES = [1_200_000, 1_500_000, 2_000_000] as const;
 
-/** 検証用リアルタイム映像プロファイルで bitrate 指定がない時の暫定値。 */
-export const DEFAULT_REALTIME_VIDEO_MAX_BITRATE = 1_500_000;
-
 /** 検証用リアルタイム映像プロファイルで許可する sender bitrate の型。 */
 export type RealtimeVideoMaxBitrate = (typeof REALTIME_VIDEO_MAX_BITRATES)[number];
 
@@ -29,11 +26,11 @@ export function keyframeRequestIntervalForSearch(
 export function realtimeVideoMaxBitrateForSearch(search: string): RealtimeVideoMaxBitrate | undefined {
   if (!hasSingleExactQueryValue(search, 'video-profile', 'realtime')) return undefined;
 
+  // bitrate は暗黙の既定を持たせず明示必須にする（未指定・不正・重複はいずれも候補ごと無効化して
+  // 既定プロファイルへ fail-closed する）。検証結果の解釈で「どの上限で測ったか」を曖昧にしないため。
   const values = new URLSearchParams(search).getAll('video-max-bitrate');
-  if (values.length === 0) return DEFAULT_REALTIME_VIDEO_MAX_BITRATE;
   if (values.length !== 1) return undefined;
 
-  // bitrate query が不正なら realtime 候補自体を無効化し、既定プロファイルへ fail-closed する。
   switch (values[0]) {
     case '1200000': return 1_200_000;
     case '1500000': return 1_500_000;

--- a/web/src/lib/ui/whip-publisher.ts
+++ b/web/src/lib/ui/whip-publisher.ts
@@ -56,7 +56,7 @@ export interface WhipVideoSettings {
   maxBitrate: number;
   contentHint: string;
   degradationPreference: RTCDegradationPreference;
-  scaleResolutionDownBy: number;
+  scaleResolutionDownBy?: number;
 }
 
 interface StartWhipPublisherInput {
@@ -143,7 +143,9 @@ async function configureVideoSender(sender: RTCRtpSender, settings: WhipVideoSet
   const parameters = sender.getParameters();
   parameters.encodings = parameters.encodings?.length ? parameters.encodings : [{}];
   parameters.encodings[0]!.maxBitrate = settings.maxBitrate;
-  parameters.encodings[0]!.scaleResolutionDownBy = settings.scaleResolutionDownBy;
+  if (settings.scaleResolutionDownBy !== undefined) {
+    parameters.encodings[0]!.scaleResolutionDownBy = settings.scaleResolutionDownBy;
+  }
   parameters.degradationPreference = settings.degradationPreference;
   try {
     await sender.setParameters(parameters);

--- a/web/tests/ui/screen-share-profile.test.ts
+++ b/web/tests/ui/screen-share-profile.test.ts
@@ -71,6 +71,7 @@ describe('検証用リアルタイム映像プロファイル', () => {
       '?video-profile=realtime&video-max-bitrate=1200000&video-max-bitrate=2000000',
       '?video-profile=REALTIME',
       '?video-profile=realtime&video-profile=realtime',
+      '?video-profile=realtime&video-max-bitrate=2000000&stream-profile=mp3-beta',
     ]) {
       expect(resolveScreenShareVideoSettingsForSearch(search)).toEqual(SCREEN_SHARE_VIDEO_SETTINGS);
     }

--- a/web/tests/ui/screen-share-profile.test.ts
+++ b/web/tests/ui/screen-share-profile.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from 'bun:test';
 
 import { MP3_BETA_KEYFRAME_REQUEST_INTERVAL_MS } from '../../src/lib/ui/whip-publisher';
 import { hasSingleExactQueryValue, keyframeRequestIntervalForSearch } from '../../src/lib/ui/stream-profile';
+import {
+  REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+  resolveScreenShareVideoSettingsForSearch,
+  SCREEN_SHARE_VIDEO_SETTINGS,
+} from '../../src/lib/ui/screen-share/video-profile';
 
 describe('MP3 beta stream profile', () => {
   test('共通のquery判定はキーと値の完全一致を重複なく要求する', () => {
@@ -29,5 +34,40 @@ describe('MP3 beta stream profile', () => {
     ).toBeUndefined();
     expect(keyframeRequestIntervalForSearch('?stream-profile=')).toBeUndefined();
     expect(keyframeRequestIntervalForSearch('?stream-profile=MP3-BETA')).toBeUndefined();
+  });
+});
+
+describe('検証用リアルタイム映像プロファイル', () => {
+  test('queryなしでは既定の画質優先設定をそのまま返す', () => {
+    expect(resolveScreenShareVideoSettingsForSearch('')).toEqual(SCREEN_SHARE_VIDEO_SETTINGS);
+  });
+
+  test('video-profile=realtimeでは未指定bitrateを暫定値にして解像度固定を外す', () => {
+    expect(resolveScreenShareVideoSettingsForSearch('?video-profile=realtime')).toEqual(
+      REALTIME_SCREEN_SHARE_VIDEO_SETTINGS
+    );
+  });
+
+  test('許可された realtime bitrate だけを送出設定へ反映する', () => {
+    expect(resolveScreenShareVideoSettingsForSearch('?video-profile=realtime&video-max-bitrate=1200000')).toMatchObject({
+      ...REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+      maxBitrate: 1_200_000,
+    });
+    expect(resolveScreenShareVideoSettingsForSearch('?video-profile=realtime&video-max-bitrate=2000000')).toMatchObject({
+      ...REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+      maxBitrate: 2_000_000,
+    });
+  });
+
+  test('不正な realtime query は候補全体を既定設定へ戻す', () => {
+    for (const search of [
+      '?video-profile=realtime&video-max-bitrate=3000000',
+      '?video-profile=realtime&video-max-bitrate=',
+      '?video-profile=realtime&video-max-bitrate=1200000&video-max-bitrate=2000000',
+      '?video-profile=REALTIME',
+      '?video-profile=realtime&video-profile=realtime',
+    ]) {
+      expect(resolveScreenShareVideoSettingsForSearch(search)).toEqual(SCREEN_SHARE_VIDEO_SETTINGS);
+    }
   });
 });

--- a/web/tests/ui/screen-share-profile.test.ts
+++ b/web/tests/ui/screen-share-profile.test.ts
@@ -42,10 +42,15 @@ describe('検証用リアルタイム映像プロファイル', () => {
     expect(resolveScreenShareVideoSettingsForSearch('')).toEqual(SCREEN_SHARE_VIDEO_SETTINGS);
   });
 
-  test('video-profile=realtimeでは未指定bitrateを暫定値にして解像度固定を外す', () => {
-    expect(resolveScreenShareVideoSettingsForSearch('?video-profile=realtime')).toEqual(
+  test('video-profile=realtime と明示 bitrate の組で解像度固定を外した候補を返す', () => {
+    expect(resolveScreenShareVideoSettingsForSearch('?video-profile=realtime&video-max-bitrate=1500000')).toEqual(
       REALTIME_SCREEN_SHARE_VIDEO_SETTINGS
     );
+    expect(REALTIME_SCREEN_SHARE_VIDEO_SETTINGS).not.toHaveProperty('scaleResolutionDownBy');
+  });
+
+  test('bitrate 未指定の realtime は既定設定へ戻す', () => {
+    expect(resolveScreenShareVideoSettingsForSearch('?video-profile=realtime')).toEqual(SCREEN_SHARE_VIDEO_SETTINGS);
   });
 
   test('許可された realtime bitrate だけを送出設定へ反映する', () => {

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -8,7 +8,10 @@ import {
   resolveWhipResourceUrl,
   startWhipPublisher,
 } from '../../src/lib/ui/whip-publisher';
-import { SCREEN_SHARE_VIDEO_SETTINGS } from '../../src/lib/ui/screen-share/video-profile';
+import {
+  REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+  SCREEN_SHARE_VIDEO_SETTINGS,
+} from '../../src/lib/ui/screen-share/video-profile';
 
 describe('WHIP publisher', () => {
   test('固定済みの配信オリジンから stream ID ごとの WHIP URL を作る', () => {
@@ -255,6 +258,28 @@ describe('WHIP publisher', () => {
     }
   });
 
+  test('解像度倍率が未指定の映像設定では sender encoding に代入しない', async () => {
+    const restore = installWebRtcMocks(() => undefined);
+    try {
+      const publisher = await startWhipPublisher({
+        ...testPublisherInput(),
+        videoSettings: REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+      });
+      publisher.close();
+
+      expect(restore.parameters).toEqual([
+        {
+          maxBitrate: 1_500_000,
+          scaleResolutionDownBy: undefined,
+          degradationPreference: 'maintain-framerate',
+        },
+      ]);
+      expect(restore.encodingKeys).toEqual([['maxBitrate']]);
+    } finally {
+      restore.globals();
+    }
+  });
+
   test('full設定とfallbackがともに拒否されたらPOSTせず接続を閉じてfallback例外を返す', async () => {
     const fallbackError = new Error('fallback rejected');
     const restore = installWebRtcMocks((_parameters, attempt) => {
@@ -342,6 +367,7 @@ interface WebRtcMockState {
     scaleResolutionDownBy: number | undefined;
     degradationPreference: RTCDegradationPreference | undefined;
   }>;
+  encodingKeys: string[][];
   getParametersCalls: number;
   postCalls: number;
   closed: number;
@@ -358,6 +384,7 @@ function installWebRtcMocks(
   const previousConnection = globalThis.RTCPeerConnection;
   const state: WebRtcMockState = {
     parameters: [],
+    encodingKeys: [],
     getParametersCalls: 0,
     postCalls: 0,
     closed: 0,
@@ -388,6 +415,7 @@ function installWebRtcMocks(
               scaleResolutionDownBy: parameters.encodings?.[0]?.scaleResolutionDownBy,
               degradationPreference: parameters.degradationPreference,
             });
+            state.encodingKeys.push(Object.keys(parameters.encodings?.[0] ?? {}));
             setParameters(parameters, state.parameters.length);
           },
         },

--- a/web/tests/ui/whip-publisher.test.ts
+++ b/web/tests/ui/whip-publisher.test.ts
@@ -280,6 +280,32 @@ describe('WHIP publisher', () => {
     }
   });
 
+  test('realtime 候補の full設定が拒否されたら maxBitrate-only fallback で倍率も劣化方針も残さない', async () => {
+    const restore = installWebRtcMocks((parameters, attempt) => {
+      if (attempt === 1) throw new Error('full settings rejected');
+      return parameters;
+    }, [
+      { encodings: [{}] },
+      { encodings: [{ scaleResolutionDownBy: 2 }], degradationPreference: 'maintain-resolution' },
+    ]);
+    try {
+      const publisher = await startWhipPublisher({
+        ...testPublisherInput(() => { restore.postCalls += 1; }),
+        videoSettings: REALTIME_SCREEN_SHARE_VIDEO_SETTINGS,
+      });
+      publisher.close();
+
+      expect(restore.parameters).toEqual([
+        { maxBitrate: 1_500_000, scaleResolutionDownBy: undefined, degradationPreference: 'maintain-framerate' },
+        { maxBitrate: 1_500_000, scaleResolutionDownBy: undefined, degradationPreference: undefined },
+      ]);
+      expect(restore.getParametersCalls).toBe(2);
+      expect(restore.postCalls).toBe(1);
+    } finally {
+      restore.globals();
+    }
+  });
+
   test('full設定とfallbackがともに拒否されたらPOSTせず接続を閉じてfallback例外を返す', async () => {
     const fallbackError = new Error('fallback rejected');
     const restore = installWebRtcMocks((_parameters, attempt) => {


### PR DESCRIPTION
## なぜこの変更が必要か

Issue noricha-vr/WebScreen#177 は「リアルタイム優先モード（`motion` + `maintain-framerate`）」を現行の画質優先設定と同一素材・同一経路で比較する検証を求めている。遅延ハーネスは本番の画面共有ページを実 Chrome で操作して配信を開始するため、候補設定が本番バンドルに存在しないと A/B 実測ができない。UI は変えず、URL query でだけ候補を選べる gate を先に入れる（`stream-profile=mp3-beta` と同じ進め方）。

## 変更内容

- `?video-profile=realtime` がちょうど1個ある時だけ `contentHint: 'motion'` / `degradationPreference: 'maintain-framerate'` / `scaleResolutionDownBy` 未指定の候補を sender に渡す
- `?video-max-bitrate=1200000|1500000|2000000` の3値のみ許可（明示必須）。未指定・不正値・重複・case 違い・`stream-profile` との併用はいずれも候補ごと無効化して既定へ fail-closed
- `WhipVideoSettings.scaleResolutionDownBy` を optional にし、未指定なら encodings に代入しない（既定プロファイルは従来どおり 1）
- query 判定と sender 適用のユニットテストを追加

## 意思決定

### 採用アプローチ
- 既存の `hasSingleExactQueryValue` による fail-closed gate を踏襲。理由: 検証用の隠し経路を既定挙動から完全に分離でき、無効化も query を消すだけで済む

### 却下した代替案
- ハーネス側で `setParameters` をラップして注入 → 却下: 本番と同じコード経路で測れず、採用時に配線をやり直す二度手間になる
- `selectMode` UI への直結 → 却下: Issue の非要件（本番 UI 実装は検証結果が出てから）

### トレードオフ
- 検証中は query を知っていれば誰でも 2 Mbps 上限を選べる > 実装の単純さ: バックエンド側の上限強制は Issue noricha-vr/WebScreen#177 の非要件として別 Issue で扱う

## テスト

- [x] `bun run typecheck`
- [x] `bun run test` 846 pass（query 判定・fallback・scaleResolutionDownBy 未代入・mp3-beta 併用拒否のテストを追加）
- [x] codex レビューゲート（sol high 2 レーン）: P1 1 件・P2 3 件を反映または noricha-vr/choicast#23 へ defer（対応表は PR コメント）
- [ ] 本番デプロイ後、ハーネスの `sender-config.json` で候補設定が sender に届いていることを確認（Issue noricha-vr/WebScreen#177 の実測で実施）

関連: noricha-vr/WebScreen#177（検証 Issue。本 PR では close しない）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpHtFTntuVu261NJL46H29
