### PR TITLE
feat(streaming): 遅延ハーネスに 1 配信内で quality/realtime を自動切替する --ab-cycle を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ main への push で GitHub Actions が本番へ反映する（`.github/workflow
 | ローカル開発・E2E（ポート分離・サンドボックス） | [docs/local-dev.md](docs/local-dev.md) |
 | ライブ配信の設計・検証 | [docs/streaming/](docs/streaming/) |
 | 配信サーバーの本番構成・運用（サーバー実体・secrets・移設・cron 検証） | [docs/streaming/operations.md](docs/streaming/operations.md) |
+| VRChat 実機で配信設定を A/B するときの手順・固定値（配信元 URL・通知先・コマンド） | [docs/streaming/vrchat-ab-runbook.md](docs/streaming/vrchat-ab-runbook.md) |
 
 ## 気をつけること
 

--- a/docs/streaming/README.md
+++ b/docs/streaming/README.md
@@ -5,6 +5,7 @@ Web ページを**リアルタイムに** VRChat のビデオプレイヤーへ�
 本番の実構成は [operations.md](operations.md) が正本。
 
 [配信遅延ハーネス](latency-harness.md) — 実Macの画面共有からRTSPT出口を時系列計測するCLI。
+[VRChat 実機 A/B の手順](vrchat-ab-runbook.md) — URL を 1 回貼るだけで設定候補を往復比較するコピペ用手順。
 
 現行の変換（アップロード → MP4 → R2 配信）とは別系統の機能で、既存の動作には影響しない。
 

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -1,5 +1,7 @@
 # 配信遅延ハーネス
 
+VRChat 実機での A/B（人の手順と固定コマンド）は [vrchat-ab-runbook.md](vrchat-ab-runbook.md) を先に見る。
+
 `web/scripts/latency-probe.ts` は、実Mac Chromeの画面共有を自動開始し、配信元→RTSPT出口を時系列で記録する。計測方法の背景と低遅延入力設定は [I19](verification.md#i19-約3秒に見えた-rtspt-遅延を配信経路と受信側に分離2026-09-01) を参照。
 
 ```bash

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -20,7 +20,9 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 - `--source` の `127.0.0.1:0` は起動時の空きポートへ置換される。`?tones=1` はステレオ定常トーンも加える。
 - 結果は `outlet.csv` と `summary.md`。送出側の生counterは `sender.csv`、共有ページで実際に使われたsender/track設定は `sender-config.json` に保存する。設定取得に失敗してもJSONに理由を残す。
 - 出口画質は遅延用の単発取得と別の連続ffmpegで測り、`outlet-quality.csv`（fps・解像度・freeze・実効ビットレートの窓別値）と `outlet-quality.md`（窓数・freeze・解像度変化の要約）を出す。既定の窓は20秒で、`--outlet-quality-seconds 5..120`で変えられる。失敗時は `outlet-quality.log` に理由を残しrunを失敗にする。
-- `--video-profile quality`（既定）は通常の共有ページを開く。`--video-profile realtime --max-bitrate 1200000|1500000|2000000` はproduction共有ページへ設定queryを渡す（省略時は1500000）。`--max-bitrate`をqualityと併用したり許可外の値を指定すると開始前に失敗する。
+- `--video-profile quality`（既定）は通常の共有ページを開く。`--video-profile realtime --max-bitrate 1200000|1500000|2000000` はproduction共有ページへ設定queryを渡す（省略時は1500000）。`--ab-cycle`なしで`--max-bitrate`をqualityと併用したり許可外の値を指定すると開始前に失敗する。
+- `--ab-cycle 60..600 --max-bitrate 1200000|1500000|2000000` は、開始プロファイルからquality/realtimeを自動往復する。VRChatでは配信URLを1回貼るだけでABAB比較できる。
+- 切替履歴は `profile-switches.csv`（UTC時刻・経過秒・プロファイル・ビットレート）に保存され、`summary.md` の「プロファイル区間別」は切替後15秒を除外して区間別とquality/realtimeプールを集計する。
 - `--scroll 0..2000` は `run` と `source` で使える。外部ページだけを指定速度（px/秒）で末尾で反転する往復スクロールにし、計測ページには適用しない。I9との比較は `--scroll 240` を使う。
 - `latency-source.html?load=heavy` は外部取得なしの写真調グラデーション・広い変化領域・連続移動カーソルを描く高負荷素材。ブロックコードは独立した高コントラスト領域に置くため、縮小しても遅延復号を維持する。
 - `--player win2022` 指定時はWindows録画を回収・復号して `player.csv` を作る。失敗・未復号は `player-error.md` に明記する。

--- a/docs/streaming/vrchat-ab-runbook.md
+++ b/docs/streaming/vrchat-ab-runbook.md
@@ -1,0 +1,49 @@
+# VRChat 実機 A/B 検証の手順（コピペ用）
+
+画面共有の設定候補を VRChat 実機で比べる時の固定手順。計測装置の詳細は [latency-harness.md](latency-harness.md)、結果の記録先は [verification.md](verification.md)。
+
+## 固定値
+
+| 項目 | 値 |
+|---|---|
+| 配信元（計測ページ） | `http://127.0.0.1:0/latency-source.html?tones=1`（ms 時刻のブロックコード + 毎秒ビープ。`?load=heavy` は帯域飢餓の最悪素材） |
+| 配信 URL の通知先 | Discord「通知」チャンネル `1380914078100488334`（skill `discord-mention` の既定） |
+| VRChat 側 | Windows `win2022`（SSH で gdigrab 録画）。プレイヤーのあるワールド（YamaStream）でプレイヤーを正面に映す |
+| 配信サーバー | `webscreen-indigo-poc`（`--server-snap` で ingress / egress を撮る） |
+| 出力 | `docs/tmp/latency/<UTC>/`（git 管理外）。`summary.md` の「VRChat プレイヤー」節と「プロファイル区間別」節を見る |
+
+## 人がやること（毎回同じ）
+
+1. Windows で VRChat を起動し、プレイヤーのあるワールドに入る（前の配信が終わって Player Error が出ていたら、ワールドに入り直す）
+2. Discord「通知」に届いた `rtspt://webscreen.tv/live/…` を **1 回だけ**貼る
+3. run が終わるまで（`--minutes` 分）プレイヤーを正面に近い視点で映し続ける。斜めになると復号できない
+
+## コマンド
+
+事前確認（初回・環境が変わった時）:
+
+```bash
+cd web
+bun scripts/latency-probe.ts login              # 初回のみ。開いた Chrome でログイン
+bun scripts/latency-probe.ts player-check --seconds 8   # Windows 録画の疎通。録画長が 8 秒なら OK
+```
+
+A/B を 1 本の配信で往復（推奨。URL は 1 回貼るだけ）:
+
+```bash
+cd web
+bun scripts/latency-probe.ts run --minutes 12 --ab-cycle 120 \
+  --source 'http://127.0.0.1:0/latency-source.html?tones=1' \
+  --video-profile quality --max-bitrate 1500000 \
+  --player win2022 --notify-discord 1380914078100488334 --server-snap webscreen-indigo-poc
+```
+
+- `--ab-cycle 120` で quality → realtime → … を 2 分ごとに切り替える（6 区間）。`--max-bitrate` は realtime 区間の上限
+- 単一プロファイルで測る時は `--ab-cycle` を外し、`--video-profile quality` または `--video-profile realtime --max-bitrate 1500000`
+
+## 落とし穴
+
+- run ごとに配信 URL は変わる。古い URL は再生できない
+- 前の配信が終わった直後に新しい URL を貼ると Player Error になることがある。ワールドに入り直してから貼る
+- Windows 側の遅延の絶対値は録画時間基準に約 1 秒のオフセットがあり得る（frame 番号 / 30 fps で復元しているため）。同じ run 内の A と B の相対比較に使う
+- 連続 run の間は 20 秒以上空ける。残留 Chrome は `pgrep -f webscreen-harness/chrome-profile` で確認する

--- a/web/scripts/latency-probe-analysis.ts
+++ b/web/scripts/latency-probe-analysis.ts
@@ -80,7 +80,8 @@ export function latencyFromSecondBoundary(observedAtMs: number): number {
 
 /** 最初の30秒と1分単位の集計をMarkdown表へ整形する。 */
 export function formatSummary(
-  outlet: readonly LatencySample[], player: readonly LatencySample[] | null, startedAtMs: number, sender: readonly SenderSample[] | null = null
+  outlet: readonly LatencySample[], player: readonly LatencySample[] | null, startedAtMs: number, sender: readonly SenderSample[] | null = null,
+  profileSwitches: readonly ProfileSwitch[] | null = null,
 ): string {
   const sections = [formatSeries('RTSPT 出口', outlet, startedAtMs)];
   if (player) sections.push(formatSeries('VRChat プレイヤー', player, startedAtMs));
@@ -88,7 +89,115 @@ export function formatSummary(
     // sender.csvはrun中の生counterを保存し、summaryは再集計可能な差分値だけを追加する。
     sections.push(formatSenderSummary(sender));
   }
+  if (profileSwitches) sections.push(formatProfileIntervals(outlet, player, sender, profileSwitches));
   return ['# 遅延計測サマリー', '', ...sections].join('\n');
+}
+
+function formatProfileIntervals(
+  outlet: readonly LatencySample[], player: readonly LatencySample[] | null, sender: readonly SenderSample[] | null,
+  switches: readonly ProfileSwitch[]
+): string {
+  const outletSegments = splitByProfile(outlet, switches, 15);
+  const playerSegments = player ? splitByProfile(player, switches, 15) : null;
+  const senderSegments = sender ? splitByProfile(sender, switches, 15) : null;
+  const rows = outletSegments.map((segment, index) => formatProfileRow(
+    profileIntervalLabel(segment, index), segment.samples, playerSegments?.[index]?.samples ?? null, senderSegments?.[index]?.samples ?? null,
+  ));
+  for (const profile of ['quality', 'realtime'] as const) {
+    const pooledSenderSegments = senderSegments?.filter((segment) => segment.profile === profile) ?? null;
+    rows.push(formatProfileRow(
+      `${profile}（プール）`, poolProfileSegments(outletSegments, profile), playerSegments ? poolProfileSegments(playerSegments, profile) : null,
+      pooledSenderSegments ? poolProfileSegments(pooledSenderSegments, profile) : null,
+      pooledSenderSegments ? summarizeSenderSegments(pooledSenderSegments) : null,
+    ));
+  }
+  return [
+    '## プロファイル区間別', '', '- 各切替直後の15秒はWebRTC送出設定の過渡として除外しています。',
+    '| 区間 | RTSPT median / p95 / n | VRChat median / p95 / n | 送出 fps | 平均ビットレート bps | 平均 QP | 最頻解像度 |',
+    '|---|---|---|---:|---:|---:|---|', ...rows, '',
+  ].join('\n');
+}
+
+function profileIntervalLabel(segment: ProfileSegment<LatencySample>, index: number): string {
+  const start = segment.startedAtMs === null ? '-' : new Date(segment.startedAtMs).toISOString();
+  const end = segment.endedAtMs === null ? '終了' : new Date(segment.endedAtMs).toISOString();
+  return `${index + 1}. ${segment.profile} (${start} 〜 ${end})`;
+}
+
+function formatProfileRow(
+  label: string, outlet: readonly LatencySample[], player: readonly LatencySample[] | null, sender: readonly SenderSample[] | null,
+  senderStatsOverride: SenderIntervalStats | null = null,
+): string {
+  const outletStats = summarizeLatency(outlet);
+  const playerStats = player ? summarizeLatency(player) : null;
+  const senderStats = senderStatsOverride ?? (sender ? summarizeSenderInterval(sender) : null);
+  return `| ${label} | ${formatLatencyStats(outletStats)} | ${playerStats ? formatLatencyStats(playerStats) : 'なし'} | ${formatDecimal(senderStats?.framesPerSecond, 2)} | ${formatDecimal(senderStats?.bitrateBps, 0)} | ${formatDecimal(senderStats?.averageQp, 2)} | ${senderStats?.resolution ?? 'n/a'} |`;
+}
+
+function formatLatencyStats(stats: LatencyStats): string {
+  return `${formatValue(stats.medianMs)} / ${formatValue(stats.p95Ms)} / ${stats.count}`;
+}
+
+interface SenderIntervalStats { framesPerSecond: number | null; bitrateBps: number | null; averageQp: number | null; resolution: string | null }
+
+function summarizeSenderInterval(samples: readonly SenderSample[]): SenderIntervalStats {
+  if (samples.length < 2) return { framesPerSecond: null, bitrateBps: null, averageQp: null, resolution: modeResolution(samples) };
+  const ordered = [...samples].sort((left, right) => left.observedAtMs - right.observedAtMs);
+  const first = ordered[0]!;
+  const last = ordered.at(-1)!;
+  const elapsedSeconds = (last.observedAtMs - first.observedAtMs) / 1_000;
+  const frames = last.framesEncoded - first.framesEncoded;
+  if (elapsedSeconds <= 0 || frames < 0 || last.bytesSent < first.bytesSent || last.qpSum < first.qpSum) {
+    return { framesPerSecond: null, bitrateBps: null, averageQp: null, resolution: modeResolution(samples) };
+  }
+  return {
+    framesPerSecond: frames / elapsedSeconds,
+    bitrateBps: (last.bytesSent - first.bytesSent) * 8 / elapsedSeconds,
+    averageQp: frames > 0 ? (last.qpSum - first.qpSum) / frames : null,
+    resolution: modeResolution(samples),
+  };
+}
+
+function summarizeSenderSegments(segments: readonly ProfileSegment<SenderSample>[]): SenderIntervalStats {
+  const summaries = segments.map((segment) => ({ samples: segment.samples, stats: summarizeSenderInterval(segment.samples) }));
+  const valid = summaries.filter(({ stats }) => stats.framesPerSecond !== null && stats.bitrateBps !== null);
+  const elapsedSeconds = valid.reduce((total, { samples }) => total + senderElapsedSeconds(samples), 0);
+  const frames = valid.reduce((total, { samples }) => total + senderFrames(samples), 0);
+  const bytes = valid.reduce((total, { samples }) => total + senderBytes(samples), 0);
+  const qp = valid.reduce((total, { samples }) => total + senderQp(samples), 0);
+  return {
+    framesPerSecond: elapsedSeconds > 0 ? frames / elapsedSeconds : null,
+    bitrateBps: elapsedSeconds > 0 ? bytes * 8 / elapsedSeconds : null,
+    averageQp: frames > 0 ? qp / frames : null,
+    resolution: modeResolution(summaries.flatMap(({ samples }) => samples)),
+  };
+}
+
+function senderElapsedSeconds(samples: readonly SenderSample[]): number {
+  if (samples.length < 2) return 0;
+  const ordered = [...samples].sort((left, right) => left.observedAtMs - right.observedAtMs);
+  return Math.max(0, (ordered.at(-1)!.observedAtMs - ordered[0]!.observedAtMs) / 1_000);
+}
+
+function senderFrames(samples: readonly SenderSample[]): number { return senderCounterDelta(samples, 'framesEncoded'); }
+function senderBytes(samples: readonly SenderSample[]): number { return senderCounterDelta(samples, 'bytesSent'); }
+function senderQp(samples: readonly SenderSample[]): number { return senderCounterDelta(samples, 'qpSum'); }
+function senderCounterDelta(samples: readonly SenderSample[], field: 'framesEncoded' | 'bytesSent' | 'qpSum'): number {
+  const ordered = [...samples].sort((left, right) => left.observedAtMs - right.observedAtMs);
+  return samples.length < 2 ? 0 : ordered.at(-1)![field] - ordered[0]![field];
+}
+
+function modeResolution(samples: readonly SenderSample[]): string | null {
+  const counts = new Map<string, number>();
+  for (const sample of samples) if (sample.frameWidth !== null && sample.frameHeight !== null) {
+    const resolution = `${sample.frameWidth}x${sample.frameHeight}`;
+    counts.set(resolution, (counts.get(resolution) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))[0]?.[0] ?? null;
+}
+
+function formatDecimal(value: number | null | undefined, digits: number): string {
+  return value === null || value === undefined || !Number.isFinite(value) ? 'n/a' : value.toFixed(digits);
 }
 
 function formatSeries(name: string, samples: readonly LatencySample[], startedAtMs: number): string {
@@ -140,3 +249,4 @@ function formatValue(value: number | null): string {
   return value === null ? '' : value.toFixed(3);
 }
 import { formatSenderSummary, type SenderSample } from './latency-probe-quality';
+import { poolProfileSegments, splitByProfile, type ProfileSegment, type ProfileSwitch } from './latency-probe-profile-analysis';

--- a/web/scripts/latency-probe-profile-analysis.ts
+++ b/web/scripts/latency-probe-profile-analysis.ts
@@ -4,6 +4,10 @@ export interface ProfileSwitch {
   elapsedSeconds: number;
   profile: 'quality' | 'realtime';
   maxBitrate: number;
+  /** 切替か、sender の差し替え後に同じ設定を再適用したか。 */
+  action?: 'applied' | 'reapplied';
+  /** 実行中だけsenderの差し替えを検出するための識別子。CSVには保存しない。 */
+  senderIdentity?: string;
 }
 
 /** プロファイル区間へ分けた時系列標本。 */
@@ -17,25 +21,28 @@ export interface ProfileSegment<T extends { observedAtMs: number }> {
 /** profile-switches.csvを読み、壊れた切替履歴を明示的に拒否する。 */
 export function parseProfileSwitchesCsv(csv: string): ProfileSwitch[] {
   const rows = csv.trim().split(/\r?\n/);
-  if (!rows.length || rows[0] !== 'timestamp_utc,elapsed_s,profile,max_bitrate') throw new Error('unexpected profile switches CSV header');
+  const legacyHeader = 'timestamp_utc,elapsed_s,profile,max_bitrate';
+  const currentHeader = `${legacyHeader},action`;
+  if (!rows.length || (rows[0] !== legacyHeader && rows[0] !== currentHeader)) throw new Error('unexpected profile switches CSV header');
   if (rows.length < 2 || !rows[1]) throw new Error('profile switches CSV must include an initial profile');
   let previousAtMs = Number.NEGATIVE_INFINITY;
   return rows.slice(1).filter(Boolean).map((row, index) => {
-    const [timestamp, elapsed, profile, maxBitrate] = row.split(',');
+    const [timestamp, elapsed, profile, maxBitrate, action = 'applied'] = row.split(',');
     const observedAtMs = Date.parse(timestamp ?? '');
     const elapsedSeconds = Number(elapsed);
     const parsedMaxBitrate = Number(maxBitrate);
     if (!Number.isFinite(observedAtMs) || !Number.isFinite(elapsedSeconds) || !Number.isInteger(parsedMaxBitrate) || parsedMaxBitrate <= 0) throw new Error(`invalid profile switch at row ${index + 2}`);
     if (profile !== 'quality' && profile !== 'realtime') throw new Error(`invalid profile at row ${index + 2}`);
+    if (action !== 'applied' && action !== 'reapplied') throw new Error(`invalid profile action at row ${index + 2}`);
     if (observedAtMs <= previousAtMs) throw new Error(`profile switches must be strictly chronological at row ${index + 2}`);
     previousAtMs = observedAtMs;
-    return { observedAtMs, elapsedSeconds, profile, maxBitrate: parsedMaxBitrate };
+    return { observedAtMs, elapsedSeconds, profile, maxBitrate: parsedMaxBitrate, action };
   });
 }
 
 /** profile-switches.csv本文を作る。 */
 export function formatProfileSwitchesCsv(switches: readonly ProfileSwitch[]): string {
-  return ['timestamp_utc,elapsed_s,profile,max_bitrate', ...switches.map((item) => [new Date(item.observedAtMs).toISOString(), item.elapsedSeconds.toFixed(3), item.profile, item.maxBitrate].join(','))].join('\n') + '\n';
+  return ['timestamp_utc,elapsed_s,profile,max_bitrate,action', ...switches.map((item) => [new Date(item.observedAtMs).toISOString(), item.elapsedSeconds.toFixed(3), item.profile, item.maxBitrate, item.action ?? 'applied'].join(','))].join('\n') + '\n';
 }
 
 /** 切替履歴で標本を区間化し、実際の切替後だけ過渡標本を除外する。 */

--- a/web/scripts/latency-probe-profile-analysis.ts
+++ b/web/scripts/latency-probe-profile-analysis.ts
@@ -1,0 +1,56 @@
+/** quality/realtime を切り替えた時刻と設定値。 */
+export interface ProfileSwitch {
+  observedAtMs: number;
+  elapsedSeconds: number;
+  profile: 'quality' | 'realtime';
+  maxBitrate: number;
+}
+
+/** プロファイル区間へ分けた時系列標本。 */
+export interface ProfileSegment<T extends { observedAtMs: number }> {
+  profile: ProfileSwitch['profile'] | 'unknown';
+  startedAtMs: number | null;
+  endedAtMs: number | null;
+  samples: T[];
+}
+
+/** profile-switches.csvを読み、壊れた切替履歴を明示的に拒否する。 */
+export function parseProfileSwitchesCsv(csv: string): ProfileSwitch[] {
+  const rows = csv.trim().split(/\r?\n/);
+  if (!rows.length || rows[0] !== 'timestamp_utc,elapsed_s,profile,max_bitrate') throw new Error('unexpected profile switches CSV header');
+  if (rows.length < 2 || !rows[1]) throw new Error('profile switches CSV must include an initial profile');
+  let previousAtMs = Number.NEGATIVE_INFINITY;
+  return rows.slice(1).filter(Boolean).map((row, index) => {
+    const [timestamp, elapsed, profile, maxBitrate] = row.split(',');
+    const observedAtMs = Date.parse(timestamp ?? '');
+    const elapsedSeconds = Number(elapsed);
+    const parsedMaxBitrate = Number(maxBitrate);
+    if (!Number.isFinite(observedAtMs) || !Number.isFinite(elapsedSeconds) || !Number.isInteger(parsedMaxBitrate) || parsedMaxBitrate <= 0) throw new Error(`invalid profile switch at row ${index + 2}`);
+    if (profile !== 'quality' && profile !== 'realtime') throw new Error(`invalid profile at row ${index + 2}`);
+    if (observedAtMs <= previousAtMs) throw new Error(`profile switches must be strictly chronological at row ${index + 2}`);
+    previousAtMs = observedAtMs;
+    return { observedAtMs, elapsedSeconds, profile, maxBitrate: parsedMaxBitrate };
+  });
+}
+
+/** profile-switches.csv本文を作る。 */
+export function formatProfileSwitchesCsv(switches: readonly ProfileSwitch[]): string {
+  return ['timestamp_utc,elapsed_s,profile,max_bitrate', ...switches.map((item) => [new Date(item.observedAtMs).toISOString(), item.elapsedSeconds.toFixed(3), item.profile, item.maxBitrate].join(','))].join('\n') + '\n';
+}
+
+/** 切替履歴で標本を区間化し、実際の切替後だけ過渡標本を除外する。 */
+export function splitByProfile<T extends { observedAtMs: number }>(samples: readonly T[], switches: readonly ProfileSwitch[], transientSeconds: number): ProfileSegment<T>[] {
+  if (!Number.isFinite(transientSeconds) || transientSeconds < 0) throw new Error('transientSeconds must be non-negative');
+  if (!switches.length) return [{ profile: 'unknown', startedAtMs: null, endedAtMs: null, samples: [...samples] }];
+  return switches.map((profileSwitch, index) => {
+    const endsAtMs = switches[index + 1]?.observedAtMs ?? null;
+    // 初期行は切替ではない。画面共有開始時の標本を過渡扱いにすると最初の区間を不必要に捨てる。
+    const usableFromMs = profileSwitch.observedAtMs + (index === 0 ? 0 : transientSeconds * 1_000);
+    return { profile: profileSwitch.profile, startedAtMs: profileSwitch.observedAtMs, endedAtMs: endsAtMs, samples: samples.filter((sample) => sample.observedAtMs >= usableFromMs && (endsAtMs === null || sample.observedAtMs < endsAtMs)) };
+  });
+}
+
+/** 同じプロファイルの区間標本をプールし、全区間の集計へ渡す。 */
+export function poolProfileSegments<T extends { observedAtMs: number }>(segments: readonly ProfileSegment<T>[], profile: ProfileSwitch['profile']): T[] {
+  return segments.filter((segment) => segment.profile === profile).flatMap((segment) => segment.samples);
+}

--- a/web/scripts/latency-probe-profile.ts
+++ b/web/scripts/latency-probe-profile.ts
@@ -7,15 +7,60 @@ interface PagePeerConnectionWindow extends Window {
   __webscreenHarnessPeerConnections?: RTCPeerConnection[];
 }
 
+interface ProfileEvaluationArguments {
+  selectedProfile: ProfileSwitch['profile'];
+  selectedMaxBitrate: number;
+}
+
+interface ProfileEvaluationResult { appliedAtMs: number; senderIdentity: string }
+
+/** Playwright に依存しない、ページ関数を実行するための境界。 */
+export interface VideoProfileEvaluator {
+  evaluate<TArgument, TResult>(pageFunction: (argument: TArgument) => Promise<TResult>, argument: TArgument): Promise<TResult>;
+}
+
+/** 時刻と待機を注入し、プロファイル周期を実Chromeなしで検証可能にする。 */
+export interface ProfileCycleClock { now(): number; sleep(milliseconds: number): Promise<void> }
+
+const VALID_MAX_BITRATES = [1_200_000, 1_500_000, 2_000_000] as const;
+const IDENTITY_POLL_MS = 5_000;
+const defaultClock: ProfileCycleClock = { now: () => Date.now(), sleep: (milliseconds) => Bun.sleep(milliseconds) };
+
+/** Playwright Pageをプロファイル変更用の最小境界へ変換する。 */
+export function videoProfileEvaluator(page: import('@playwright/test').Page): VideoProfileEvaluator {
+  return {
+    evaluate: async <TArgument, TResult>(pageFunction: (argument: TArgument) => Promise<TResult>, argument: TArgument): Promise<TResult> => {
+      return await page.evaluate(pageFunction as never, argument as never) as TResult;
+    },
+  };
+}
+
+/** profileとmaxBitrateを外部境界でfail-fastに検証する。 */
+export function validateVideoProfile(profile: unknown, maxBitrate: unknown): asserts profile is ProfileSwitch['profile'] {
+  if (profile !== 'quality' && profile !== 'realtime') throw new Error('video profile must be quality or realtime');
+  if (!VALID_MAX_BITRATES.includes(maxBitrate as typeof VALID_MAX_BITRATES[number])) throw new Error('maxBitrate must be 1200000, 1500000, or 2000000');
+}
+
+/** A/B切替周期を外部境界でfail-fastに検証する。 */
+export function validateProfileCycleSeconds(cycleSeconds: unknown): asserts cycleSeconds is number {
+  if (!Number.isInteger(cycleSeconds) || (cycleSeconds as number) < 60 || (cycleSeconds as number) > 600) throw new Error('cycleSeconds must be an integer between 60 and 600');
+}
+
 /** senderへ映像プロファイルを反映し、読み戻した値が一致しなければ失敗する。 */
-export async function applyVideoProfile(page: import('@playwright/test').Page, profile: ProfileSwitch['profile'], maxBitrate: number, startedAtMs: number): Promise<ProfileSwitch> {
-  const appliedAtMs = await page.evaluate(async ({ selectedProfile, selectedMaxBitrate }) => {
+export async function applyVideoProfile(evaluate: VideoProfileEvaluator, profile: ProfileSwitch['profile'], maxBitrate: number, startedAtMs: number): Promise<ProfileSwitch> {
+  validateVideoProfile(profile, maxBitrate);
+  const applied = await evaluate.evaluate(async ({ selectedProfile, selectedMaxBitrate }) => {
+    // evaluate は外部呼び出し以外からも使われるため、ページ側でも同じ許可集合を検証する。
+    if ((selectedProfile !== 'quality' && selectedProfile !== 'realtime') || ![1_200_000, 1_500_000, 2_000_000].includes(selectedMaxBitrate)) throw new Error('invalid video profile evaluation arguments');
     const tracked = window as PagePeerConnectionWindow;
     const connections = (tracked.__webscreenHarnessPeerConnections ?? []).filter((connection) => connection.connectionState !== 'closed');
     tracked.__webscreenHarnessPeerConnections = connections;
-    // 自動再接続済みでも既存のcaptureSenderConfigと同じ、最新のlive video senderだけを変更する。
-    const connection = connections.toReversed().find((candidate) => candidate.getSenders().some((sender) => sender.track?.kind === 'video' && sender.track.readyState === 'live'));
-    const sender = connection?.getSenders().find((candidate) => candidate.track?.kind === 'video' && candidate.track.readyState === 'live');
+    let sender: RTCRtpSender | undefined;
+    let connectionIndex = -1;
+    for (let index = connections.length - 1; index >= 0 && !sender; index -= 1) {
+      sender = connections[index]!.getSenders().find((candidate) => candidate.track?.kind === 'video' && candidate.track.readyState === 'live');
+      if (sender) connectionIndex = index;
+    }
     if (!sender?.track) throw new Error('video RTCRtpSender was not found for profile switch');
     const parameters = sender.getParameters();
     parameters.encodings = parameters.encodings?.length ? parameters.encodings : [{}];
@@ -33,32 +78,81 @@ export async function applyVideoProfile(page: import('@playwright/test').Page, p
     const expectedDegradation = selectedProfile === 'quality' ? 'maintain-resolution' : 'maintain-framerate';
     const expectedHint = selectedProfile === 'quality' ? 'detail' : 'motion';
     if (actualEncoding?.maxBitrate !== expectedBitrate || actualEncoding.scaleResolutionDownBy !== expectedScale || actual.degradationPreference !== expectedDegradation || sender.track.contentHint !== expectedHint) throw new Error(`profile switch readback mismatch: expected ${selectedProfile}`);
-    return Date.now();
+    return { appliedAtMs: Date.now(), senderIdentity: `${connectionIndex}:${sender.track.id}` };
   }, { selectedProfile: profile, selectedMaxBitrate: maxBitrate });
-  return { observedAtMs: appliedAtMs, elapsedSeconds: (appliedAtMs - startedAtMs) / 1_000, profile, maxBitrate: profile === 'quality' ? 1_200_000 : maxBitrate };
+  return { observedAtMs: applied.appliedAtMs, elapsedSeconds: (applied.appliedAtMs - startedAtMs) / 1_000, profile, maxBitrate: profile === 'quality' ? 1_200_000 : maxBitrate, action: 'applied', senderIdentity: applied.senderIdentity };
 }
 
 /** 初期プロファイルを反映・検証して切替CSVの先頭行へ保存する。 */
-export async function startVideoProfileCycle(page: import('@playwright/test').Page, outDir: string, startedAtMs: number, initialProfile: ProfileSwitch['profile'], realtimeMaxBitrate: number): Promise<ProfileSwitch> {
-  const initial = await applyVideoProfile(page, initialProfile, realtimeMaxBitrate, startedAtMs);
+export async function startVideoProfileCycle(evaluate: VideoProfileEvaluator, outDir: string, startedAtMs: number, initialProfile: ProfileSwitch['profile'], realtimeMaxBitrate: number): Promise<ProfileSwitch> {
+  const initial = await applyVideoProfile(evaluate, initialProfile, realtimeMaxBitrate, startedAtMs);
   await writeFile(join(outDir, 'profile-switches.csv'), formatProfileSwitchesCsv([initial]));
   return initial;
 }
 
-/** 指定間隔でquality/realtimeを交互に切り替え、各成功をCSVへ追記する。 */
-export async function cycleVideoProfiles(page: import('@playwright/test').Page, outDir: string, startedAtMs: number, until: number, initial: ProfileSwitch, realtimeMaxBitrate: number, cycleSeconds: number, signal?: AbortSignal): Promise<ProfileSwitch[]> {
+/** 指定間隔で切替え、sender差し替え時は同プロファイルを再適用してCSVへ記録する。 */
+export async function cycleVideoProfiles(evaluate: VideoProfileEvaluator, outDir: string, startedAtMs: number, until: number, initial: ProfileSwitch, realtimeMaxBitrate: number, cycleSeconds: number, signal?: AbortSignal, clock: ProfileCycleClock = defaultClock): Promise<ProfileSwitch[]> {
+  validateVideoProfile(initial.profile, realtimeMaxBitrate);
+  validateProfileCycleSeconds(cycleSeconds);
   const switches = [initial];
   const outputPath = join(outDir, 'profile-switches.csv');
   let activeProfile = initial.profile;
+  let activeIdentity = initial.senderIdentity;
   let nextSwitchAtMs = startedAtMs + cycleSeconds * 1_000;
-  while (nextSwitchAtMs < until && !signal?.aborted) {
-    while (Date.now() < nextSwitchAtMs && !signal?.aborted) await Bun.sleep(Math.min(1_000, nextSwitchAtMs - Date.now()));
-    if (signal?.aborted || Date.now() >= until) break;
-    activeProfile = activeProfile === 'quality' ? 'realtime' : 'quality';
-    const switched = await applyVideoProfile(page, activeProfile, realtimeMaxBitrate, startedAtMs);
-    switches.push(switched);
-    await appendFile(outputPath, formatProfileSwitchesCsv([switched]).split('\n').slice(1).join('\n'));
-    nextSwitchAtMs += cycleSeconds * 1_000;
+  let nextIdentityPollAtMs = startedAtMs + IDENTITY_POLL_MS;
+  while (!signal?.aborted && clock.now() < until) {
+    const now = clock.now();
+    const nextEventAtMs = Math.min(nextSwitchAtMs, nextIdentityPollAtMs, until);
+    if (now < nextEventAtMs) { await clock.sleep(nextEventAtMs - now); continue; }
+    if (signal?.aborted || clock.now() >= until) break;
+    if (now >= nextIdentityPollAtMs) {
+      const identity = await readLiveVideoSenderIdentity(evaluate);
+      if (signal?.aborted || clock.now() >= until) break;
+      if (activeIdentity !== undefined && identity !== activeIdentity) {
+        const reapplied = await applyVideoProfile(evaluate, activeProfile, realtimeMaxBitrate, startedAtMs);
+        reapplied.action = 'reapplied';
+        ensureChronological(reapplied, switches.at(-1)!, startedAtMs);
+        switches.push(reapplied);
+        activeIdentity = reapplied.senderIdentity;
+        await appendProfileSwitch(outputPath, reapplied);
+      } else activeIdentity = identity;
+      while (nextIdentityPollAtMs <= now) nextIdentityPollAtMs += IDENTITY_POLL_MS;
+    }
+    if (now >= nextSwitchAtMs) {
+      if (signal?.aborted || clock.now() >= until) break;
+      activeProfile = activeProfile === 'quality' ? 'realtime' : 'quality';
+      const switched = await applyVideoProfile(evaluate, activeProfile, realtimeMaxBitrate, startedAtMs);
+      ensureChronological(switched, switches.at(-1)!, startedAtMs);
+      switches.push(switched);
+      activeIdentity = switched.senderIdentity;
+      await appendProfileSwitch(outputPath, switched);
+      while (nextSwitchAtMs <= now) nextSwitchAtMs += cycleSeconds * 1_000;
+    }
   }
   return switches;
+}
+
+async function readLiveVideoSenderIdentity(evaluate: VideoProfileEvaluator): Promise<string> {
+  return evaluate.evaluate(async () => {
+    const tracked = window as PagePeerConnectionWindow;
+    const connections = (tracked.__webscreenHarnessPeerConnections ?? []).filter((connection) => connection.connectionState !== 'closed');
+    tracked.__webscreenHarnessPeerConnections = connections;
+    for (let index = connections.length - 1; index >= 0; index -= 1) {
+      const sender = connections[index]!.getSenders().find((candidate) => candidate.track?.kind === 'video' && candidate.track.readyState === 'live');
+      if (sender?.track) return `${index}:${sender.track.id}`;
+    }
+    throw new Error('video RTCRtpSender was not found while checking profile identity');
+  }, undefined);
+}
+
+async function appendProfileSwitch(outputPath: string, profileSwitch: ProfileSwitch): Promise<void> {
+  await appendFile(outputPath, formatProfileSwitchesCsv([profileSwitch]).split('\n').slice(1).join('\n'));
+}
+
+function ensureChronological(next: ProfileSwitch, previous: ProfileSwitch, startedAtMs: number): void {
+  // 同一ミリ秒に再適用と定刻切替が重なるとCSVの順序が失われるため、記録時だけ最小単位で並べる。
+  if (next.observedAtMs <= previous.observedAtMs) {
+    next.observedAtMs = previous.observedAtMs + 1;
+    next.elapsedSeconds = (next.observedAtMs - startedAtMs) / 1_000;
+  }
 }

--- a/web/scripts/latency-probe-profile.ts
+++ b/web/scripts/latency-probe-profile.ts
@@ -1,0 +1,64 @@
+import { appendFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { formatProfileSwitchesCsv, type ProfileSwitch } from './latency-probe-profile-analysis';
+
+interface PagePeerConnectionWindow extends Window {
+  __webscreenHarnessPeerConnections?: RTCPeerConnection[];
+}
+
+/** senderへ映像プロファイルを反映し、読み戻した値が一致しなければ失敗する。 */
+export async function applyVideoProfile(page: import('@playwright/test').Page, profile: ProfileSwitch['profile'], maxBitrate: number, startedAtMs: number): Promise<ProfileSwitch> {
+  const appliedAtMs = await page.evaluate(async ({ selectedProfile, selectedMaxBitrate }) => {
+    const tracked = window as PagePeerConnectionWindow;
+    const connections = (tracked.__webscreenHarnessPeerConnections ?? []).filter((connection) => connection.connectionState !== 'closed');
+    tracked.__webscreenHarnessPeerConnections = connections;
+    // 自動再接続済みでも既存のcaptureSenderConfigと同じ、最新のlive video senderだけを変更する。
+    const connection = connections.toReversed().find((candidate) => candidate.getSenders().some((sender) => sender.track?.kind === 'video' && sender.track.readyState === 'live'));
+    const sender = connection?.getSenders().find((candidate) => candidate.track?.kind === 'video' && candidate.track.readyState === 'live');
+    if (!sender?.track) throw new Error('video RTCRtpSender was not found for profile switch');
+    const parameters = sender.getParameters();
+    parameters.encodings = parameters.encodings?.length ? parameters.encodings : [{}];
+    const encoding = parameters.encodings[0]!;
+    const expectedScale = selectedProfile === 'quality' ? 1 : undefined;
+    encoding.maxBitrate = selectedProfile === 'quality' ? 1_200_000 : selectedMaxBitrate;
+    if (expectedScale === undefined) delete encoding.scaleResolutionDownBy;
+    else encoding.scaleResolutionDownBy = expectedScale;
+    parameters.degradationPreference = selectedProfile === 'quality' ? 'maintain-resolution' : 'maintain-framerate';
+    await sender.setParameters(parameters);
+    sender.track.contentHint = selectedProfile === 'quality' ? 'detail' : 'motion';
+    const actual = sender.getParameters();
+    const actualEncoding = actual.encodings?.[0];
+    const expectedBitrate = selectedProfile === 'quality' ? 1_200_000 : selectedMaxBitrate;
+    const expectedDegradation = selectedProfile === 'quality' ? 'maintain-resolution' : 'maintain-framerate';
+    const expectedHint = selectedProfile === 'quality' ? 'detail' : 'motion';
+    if (actualEncoding?.maxBitrate !== expectedBitrate || actualEncoding.scaleResolutionDownBy !== expectedScale || actual.degradationPreference !== expectedDegradation || sender.track.contentHint !== expectedHint) throw new Error(`profile switch readback mismatch: expected ${selectedProfile}`);
+    return Date.now();
+  }, { selectedProfile: profile, selectedMaxBitrate: maxBitrate });
+  return { observedAtMs: appliedAtMs, elapsedSeconds: (appliedAtMs - startedAtMs) / 1_000, profile, maxBitrate: profile === 'quality' ? 1_200_000 : maxBitrate };
+}
+
+/** 初期プロファイルを反映・検証して切替CSVの先頭行へ保存する。 */
+export async function startVideoProfileCycle(page: import('@playwright/test').Page, outDir: string, startedAtMs: number, initialProfile: ProfileSwitch['profile'], realtimeMaxBitrate: number): Promise<ProfileSwitch> {
+  const initial = await applyVideoProfile(page, initialProfile, realtimeMaxBitrate, startedAtMs);
+  await writeFile(join(outDir, 'profile-switches.csv'), formatProfileSwitchesCsv([initial]));
+  return initial;
+}
+
+/** 指定間隔でquality/realtimeを交互に切り替え、各成功をCSVへ追記する。 */
+export async function cycleVideoProfiles(page: import('@playwright/test').Page, outDir: string, startedAtMs: number, until: number, initial: ProfileSwitch, realtimeMaxBitrate: number, cycleSeconds: number, signal?: AbortSignal): Promise<ProfileSwitch[]> {
+  const switches = [initial];
+  const outputPath = join(outDir, 'profile-switches.csv');
+  let activeProfile = initial.profile;
+  let nextSwitchAtMs = startedAtMs + cycleSeconds * 1_000;
+  while (nextSwitchAtMs < until && !signal?.aborted) {
+    while (Date.now() < nextSwitchAtMs && !signal?.aborted) await Bun.sleep(Math.min(1_000, nextSwitchAtMs - Date.now()));
+    if (signal?.aborted || Date.now() >= until) break;
+    activeProfile = activeProfile === 'quality' ? 'realtime' : 'quality';
+    const switched = await applyVideoProfile(page, activeProfile, realtimeMaxBitrate, startedAtMs);
+    switches.push(switched);
+    await appendFile(outputPath, formatProfileSwitchesCsv([switched]).split('\n').slice(1).join('\n'));
+    nextSwitchAtMs += cycleSeconds * 1_000;
+  }
+  return switches;
+}

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -10,7 +10,7 @@ import {
 } from './latency-probe-observe';
 import { recordWindowsPlayer, type PlayerResult } from './latency-probe-player';
 import { captureSenderConfig, collectOutletQuality, collectSenderStats, parseSenderCsv, peerConnectionTrackerInitScript } from './latency-probe-quality';
-import { cycleVideoProfiles, startVideoProfileCycle } from './latency-probe-profile';
+import { cycleVideoProfiles, startVideoProfileCycle, validateProfileCycleSeconds, validateVideoProfile, videoProfileEvaluator } from './latency-probe-profile';
 import type { ProfileSwitch } from './latency-probe-profile-analysis';
 import { screenShareUrl, stopSharingBeforeClose } from './latency-probe-screen-share';
 
@@ -19,6 +19,12 @@ export { screenShareUrl } from './latency-probe-screen-share';
 const SOURCE_TITLE = 'WebScreen Latency Source';
 const ACTIVE_FILE = resolve('..', 'docs', 'tmp', 'latency', '.active.json');
 const SOURCE_FILE = Bun.file(new URL('./latency-source.html', import.meta.url));
+const PREVIOUS_RUN_ARTIFACTS = [
+  'cleanup-error.md', 'outlet-audio.csv', 'outlet-audio.json', 'outlet-audio.wav', 'outlet-decode.log', 'outlet-ffmpeg.log',
+  'outlet-quality.csv', 'outlet-quality.log', 'outlet-quality.md', 'outlet.csv', 'player-error.md', 'player-recording.md',
+  'player.csv', 'profile-switches.csv', 'recording.mp4', 'sender-config.json', 'sender-error.md', 'sender.csv', 'server-snap.md',
+  'server-snap', 'summary.md', 'frames',
+] as const;
 
 /** 実行時に固定する遅延ハーネスの引数。 */
 export interface RunOptions {
@@ -34,10 +40,12 @@ function browserLogTail(): string { return browserLog.length ? `\nbrowser consol
 
 /** 実Chromeの画面共有、出口プローブ、出力保存を同じcleanup境界で実行する。 */
 export async function runLatencyProbe(options: RunOptions): Promise<void> {
+  validateRunOptions(options);
   rejectRepositoryProfile(options.profileDir);
   requireCommands(options.player);
   await mkdir(options.outDir, { recursive: true, mode: 0o700 });
   await chmod(options.outDir, 0o700);
+  await clearPreviousRunArtifacts(options.outDir);
   const sourceServer = startSourceServer();
   const state: ControllerState = { sourcePage: null, sourceUrl: sourceServer.url.href, sourceServerUrl: sourceServer.url.href };
   const controllerServer = startControllerServer(state);
@@ -90,8 +98,9 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
     if (options.abCycleSeconds !== null) {
       if (options.maxBitrate === null) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
       // 初期プロファイルの反映・読み戻しに失敗した場合は、出口計測を始めずにrunを失敗させる。
-      const initialProfileSwitch = await startVideoProfileCycle(sharingPage, options.outDir, startedAtMs, options.videoProfile, options.maxBitrate);
-      profileSwitchPump = cycleVideoProfiles(sharingPage, options.outDir, startedAtMs, until, initialProfileSwitch, options.maxBitrate, options.abCycleSeconds, measurementAbort.signal);
+      const evaluator = videoProfileEvaluator(sharingPage);
+      const initialProfileSwitch = await startVideoProfileCycle(evaluator, options.outDir, startedAtMs, options.videoProfile, options.maxBitrate);
+      profileSwitchPump = cycleVideoProfiles(evaluator, options.outDir, startedAtMs, until, initialProfileSwitch, options.maxBitrate, options.abCycleSeconds, measurementAbort.signal);
     }
     senderPump = collectSenderStats(sharingPage, options.outDir, until, measurementAbort.signal);
     outletQualityPump = collectOutletQuality(rtspUrl, options.outDir, startedAtMs, until, options.outletQualitySeconds, measurementAbort.signal);
@@ -179,7 +188,26 @@ export async function analyzeDirectory(directory: string): Promise<void> {
   const switchesPath = join(directory, 'profile-switches.csv');
   const { parseProfileSwitchesCsv } = await import('./latency-probe-profile-analysis');
   const profileSwitches = await Bun.file(switchesPath).exists() ? parseProfileSwitchesCsv(await readFile(switchesPath, 'utf8')) : null;
+  if (profileSwitches && (!Number.isFinite(startedAtMs) || Math.abs(profileSwitches[0]!.observedAtMs - startedAtMs) > 60_000)) {
+    throw new Error('profile-switches.csv initial timestamp must be within 60 seconds of the outlet.csv inferred start time');
+  }
   await writeFile(join(directory, 'summary.md'), formatSummary([...video, ...(audio ?? outlet.filter((sample) => sample.audioLatencyMs !== null || sample.audioLatencyPhaseMs !== null))], player, startedAtMs, sender, profileSwitches));
+}
+
+/** 前回runの解析対象成果物を消し、`--out` 再利用時の混在を防ぐ。 */
+export async function clearPreviousRunArtifacts(outDir: string): Promise<void> {
+  await Promise.all(PREVIOUS_RUN_ARTIFACTS.map((artifact) => rm(join(outDir, artifact), { recursive: true, force: true })));
+}
+
+/** runの公開境界でプロファイル関連値を検証し、副作用の前に不正入力を拒否する。 */
+export function validateRunOptions(options: RunOptions): void {
+  if (options.videoProfile !== 'quality' && options.videoProfile !== 'realtime') throw new Error('videoProfile must be quality or realtime');
+  if (options.maxBitrate !== null) validateVideoProfile(options.videoProfile, options.maxBitrate);
+  if (options.videoProfile === 'realtime' && options.maxBitrate === null) throw new Error('realtime videoProfile requires maxBitrate');
+  if (options.abCycleSeconds !== null) {
+    validateProfileCycleSeconds(options.abCycleSeconds);
+    if (options.maxBitrate === null) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
+  }
 }
 
 async function persistResults(outDir: string, outlet: LatencySample[], startedAtMs: number, player: PlayerResult | null, sender: Parameters<typeof formatSummary>[3], profileSwitches: Parameters<typeof formatSummary>[4]): Promise<void> {

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -10,6 +10,8 @@ import {
 } from './latency-probe-observe';
 import { recordWindowsPlayer, type PlayerResult } from './latency-probe-player';
 import { captureSenderConfig, collectOutletQuality, collectSenderStats, parseSenderCsv, peerConnectionTrackerInitScript } from './latency-probe-quality';
+import { cycleVideoProfiles, startVideoProfileCycle } from './latency-probe-profile';
+import type { ProfileSwitch } from './latency-probe-profile-analysis';
 import { screenShareUrl, stopSharingBeforeClose } from './latency-probe-screen-share';
 
 export { screenShareUrl } from './latency-probe-screen-share';
@@ -19,13 +21,9 @@ const ACTIVE_FILE = resolve('..', 'docs', 'tmp', 'latency', '.active.json');
 const SOURCE_FILE = Bun.file(new URL('./latency-source.html', import.meta.url));
 
 /** 実行時に固定する遅延ハーネスの引数。 */
-export interface RunOptions { minutes: number; source: string; player: 'win2022' | null; profileDir: string; outDir: string
-  videoProfile: 'quality' | 'realtime';
-  maxBitrate: number | null;
-  scrollPixelsPerSecond: number;
-  outletQualitySeconds: number;
-  notifyDiscordChannelId: string | null;
-  serverSnapHost: string | null;
+export interface RunOptions {
+  minutes: number; source: string; player: 'win2022' | null; profileDir: string; outDir: string; videoProfile: 'quality' | 'realtime'; maxBitrate: number | null;
+  abCycleSeconds: number | null; scrollPixelsPerSecond: number; outletQualitySeconds: number; notifyDiscordChannelId: string | null; serverSnapHost: string | null;
 }
 interface ActiveController { endpoint: string; sourceUrl: string }
 interface ControllerState { sourcePage: import('@playwright/test').Page | null; sourceUrl: string; sourceServerUrl: string }
@@ -51,6 +49,7 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
   let audio: Bun.Subprocess | null = null;
   let senderPump: Promise<Awaited<ReturnType<typeof collectSenderStats>>> | null = null;
   let outletQualityPump: Promise<void> | null = null;
+  let profileSwitchPump: Promise<ProfileSwitch[]> | null = null;
   const measurementAbort = new AbortController();
   try {
     browser = await startChrome(options.profileDir);
@@ -88,6 +87,12 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
     state.sourceUrl = target;
     startedAtMs = Date.now();
     const until = startedAtMs + options.minutes * 60_000;
+    if (options.abCycleSeconds !== null) {
+      if (options.maxBitrate === null) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
+      // 初期プロファイルの反映・読み戻しに失敗した場合は、出口計測を始めずにrunを失敗させる。
+      const initialProfileSwitch = await startVideoProfileCycle(sharingPage, options.outDir, startedAtMs, options.videoProfile, options.maxBitrate);
+      profileSwitchPump = cycleVideoProfiles(sharingPage, options.outDir, startedAtMs, until, initialProfileSwitch, options.maxBitrate, options.abCycleSeconds, measurementAbort.signal);
+    }
     senderPump = collectSenderStats(sharingPage, options.outDir, until, measurementAbort.signal);
     outletQualityPump = collectOutletQuality(rtspUrl, options.outDir, startedAtMs, until, options.outletQualitySeconds, measurementAbort.signal);
     const diagnostics: VideoDiagnostics = { firstDecoded: null, lastDecoded: null, lastFailure: null, decodeLog: [], lastLoggedFailureAtMs: null, decodeCount: 0, decodeMsTotal: 0, decodeMsMax: 0 };
@@ -95,9 +100,10 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
       ? captureServerSnapshots(options.serverSnapHost, streamId, options.outDir, startedAtMs, snapshotScheduleSeconds(options.minutes)).catch((error) => { console.warn(`サーバー内スナップショットに失敗しました: ${String(error)}`); return []; })
       : Promise.resolve([]);
     const playerPump = options.player ? recordWindowsPlayer(options.outDir, until).catch((error) => ({ samples: [], warning: `Windows計測は失敗しました: ${String(error)}`, diagnostics: String(error) } satisfies PlayerResult)) : Promise.resolve(null);
-    const [, capturedAudio, player, senderResult] = await Promise.all([
+    const [, capturedAudio, player, senderResult, , profileSwitches] = await Promise.all([
       collectOutletGrabs(rtspUrl, until, outlet, diagnostics, join(options.outDir, 'frames')),
       collectAudio(requirePipe(audio.stdout, 'audio'), until), playerPump, senderPump, outletQualityPump,
+      profileSwitchPump ?? Promise.resolve(null),
     ]);
     outlet.push(...audioSamplesFromCapture(capturedAudio, outlet));
     const audioExitBeforeStop = audio.exitCode;
@@ -111,11 +117,11 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
       audioExitBeforeStop !== null && audioExitBeforeStop !== 0 ? `audio ffmpeg exit=${audioExitBeforeStop}\n${audioStderr}` : null,
     ].filter((failure): failure is string => failure !== null);
     if (failures.length) throw new Error(`出口ffmpegが計測終了前に失敗しました。outlet-ffmpeg.logを保存しました。\n${failures.join('\n')}`);
-    await persistResults(options.outDir, outlet, startedAtMs, player, senderResult.samples);
+    await persistResults(options.outDir, outlet, startedAtMs, player, senderResult.samples, profileSwitches);
   } finally {
     measurementAbort.abort();
     // 各pumpはfinallyでCSVを書き出すため、出力先のcleanup前に終了まで回収する。
-    await Promise.allSettled([senderPump, outletQualityPump].filter((pump): pump is Exclude<typeof pump, null> => pump !== null));
+    await Promise.allSettled([senderPump, outletQualityPump, profileSwitchPump].filter((pump): pump is Exclude<typeof pump, null> => pump !== null));
     audio?.kill();
     // browser.close() だけでは pagehide の停止ビーコンが飛ばず配信がサーバーに残り、次の run が
     // 「既存の配信を終了」経路に入って不安定になる（2026-09-02 実測）。閉じる前に停止ボタンを押す
@@ -170,10 +176,13 @@ export async function analyzeDirectory(directory: string): Promise<void> {
   if (audio) await writeFile(join(directory, 'outlet-audio.csv'), formatLatencyCsv(audio, startedAtMs));
   const senderPath = join(directory, 'sender.csv');
   const sender = await Bun.file(senderPath).exists() ? parseSenderCsv(await readFile(senderPath, 'utf8')) : null;
-  await writeFile(join(directory, 'summary.md'), formatSummary([...video, ...(audio ?? outlet.filter((sample) => sample.audioLatencyMs !== null || sample.audioLatencyPhaseMs !== null))], player, startedAtMs, sender));
+  const switchesPath = join(directory, 'profile-switches.csv');
+  const { parseProfileSwitchesCsv } = await import('./latency-probe-profile-analysis');
+  const profileSwitches = await Bun.file(switchesPath).exists() ? parseProfileSwitchesCsv(await readFile(switchesPath, 'utf8')) : null;
+  await writeFile(join(directory, 'summary.md'), formatSummary([...video, ...(audio ?? outlet.filter((sample) => sample.audioLatencyMs !== null || sample.audioLatencyPhaseMs !== null))], player, startedAtMs, sender, profileSwitches));
 }
 
-async function persistResults(outDir: string, outlet: LatencySample[], startedAtMs: number, player: PlayerResult | null, sender: Parameters<typeof formatSummary>[3]): Promise<void> {
+async function persistResults(outDir: string, outlet: LatencySample[], startedAtMs: number, player: PlayerResult | null, sender: Parameters<typeof formatSummary>[3], profileSwitches: Parameters<typeof formatSummary>[4]): Promise<void> {
   await writeFile(join(outDir, 'outlet.csv'), formatLatencyCsv(outlet, startedAtMs));
   if (player) {
     await writeFile(join(outDir, 'player.csv'), formatLatencyCsv(player.samples, startedAtMs));
@@ -181,7 +190,7 @@ async function persistResults(outDir: string, outlet: LatencySample[], startedAt
     if (player.warning) await writeFile(join(outDir, 'player-error.md'), `${player.warning}\n\n${player.diagnostics}`);
   }
   const playerWarning = player?.warning ? `\n## プレイヤー側\n\n- ${player.warning}\n` : '';
-  await writeFile(join(outDir, 'summary.md'), formatSummary(outlet, player?.samples ?? null, startedAtMs, sender) + playerWarning);
+  await writeFile(join(outDir, 'summary.md'), formatSummary(outlet, player?.samples ?? null, startedAtMs, sender, profileSwitches) + playerWarning);
 }
 
 function startSourceServer(): ReturnType<typeof Bun.serve> {

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -13,7 +13,7 @@ WebScreen配信を実Mac Chromeから開始し、RTSPT出口と任意のWindows�
 Subcommands:
   login [--profile-dir PATH]
   player-check [--seconds N] [--out DIR]
-  run --minutes N --source URL [--video-profile quality|realtime] [--max-bitrate 1200000|1500000|2000000] [--scroll PX_PER_SECOND] [--outlet-quality-seconds N] [--player win2022] [--profile-dir PATH] [--out DIR] [--notify-discord CHANNEL_ID] [--server-snap HOST]
+  run --minutes N --source URL [--video-profile quality|realtime] [--max-bitrate 1200000|1500000|2000000] [--ab-cycle 60..600] [--scroll PX_PER_SECOND] [--outlet-quality-seconds N] [--player win2022] [--profile-dir PATH] [--out DIR] [--notify-discord CHANNEL_ID] [--server-snap HOST]
   source --url URL [--scroll PX_PER_SECOND]
   analyze DIR
 
@@ -26,7 +26,8 @@ run options:
   --out DIR          出力先（既定: docs/tmp/latency/<UTC timestamp>）
   --server-snap HOST 配信サーバーへ SSH し、run 中に ingress / egress のフレームを撮って relay 前後の遅延を server-snap.md に出す
   --video-profile PROFILE quality（既定）または realtime。realtime はproduction画面に設定queryを渡す
-  --max-bitrate BPS  realtime 時だけ有効。1200000 / 1500000 / 2000000 のいずれか
+  --max-bitrate BPS  realtime 時、または --ab-cycle 時に必須。1200000 / 1500000 / 2000000 のいずれか
+  --ab-cycle SECONDS quality/realtimeを指定秒ごとに切替（60〜600）。--max-bitrate が必須
   --scroll PX_PER_SECOND 外部共有ページを指定速度で往復スクロール（0〜2000、既定0）
   --outlet-quality-seconds N
                      出口画質の連続ffmpeg測定窓（5〜120秒、既定20）。遅延用の単発取得とは別系統
@@ -66,7 +67,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
     return { command, url: requiredUrl(values.url, '--url'), scrollPixelsPerSecond: parseScroll(values.scroll) };
   }
   if (command !== 'run') throw new Error(`unknown subcommand: ${command}`);
-  rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'video-profile', 'max-bitrate', 'scroll', 'outlet-quality-seconds']);
+  rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'video-profile', 'max-bitrate', 'ab-cycle', 'scroll', 'outlet-quality-seconds']);
   if (values['server-snap'] !== undefined && !isValidSshHost(values['server-snap'])) throw new Error('--server-snap must be an ssh host name');
   if (values['notify-discord'] !== undefined && !/^\d{15,25}$/.test(values['notify-discord'])) throw new Error('--notify-discord must be a Discord channel id');
   const minutes = Number(values.minutes);
@@ -74,7 +75,10 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
   if (values.player !== undefined && values.player !== 'win2022') throw new Error('--player must be win2022');
   const videoProfile = values['video-profile'] ?? 'quality';
   if (videoProfile !== 'quality' && videoProfile !== 'realtime') throw new Error('--video-profile must be quality or realtime');
-  if (videoProfile === 'quality' && values['max-bitrate'] !== undefined) throw new Error('--max-bitrate is only valid with --video-profile realtime');
+  const abCycleSeconds = values['ab-cycle'] === undefined ? null : Number(values['ab-cycle']);
+  if (abCycleSeconds !== null && (!Number.isInteger(abCycleSeconds) || abCycleSeconds < 60 || abCycleSeconds > 600)) throw new Error('--ab-cycle must be an integer between 60 and 600');
+  if (videoProfile === 'quality' && values['max-bitrate'] !== undefined && abCycleSeconds === null) throw new Error('--max-bitrate is only valid with --video-profile realtime');
+  if (abCycleSeconds !== null && values['max-bitrate'] === undefined) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
   const maxBitrate = values['max-bitrate'] === undefined ? (videoProfile === 'realtime' ? 1_500_000 : null) : Number(values['max-bitrate']);
   if (maxBitrate !== null && ![1_200_000, 1_500_000, 2_000_000].includes(maxBitrate)) throw new Error('--max-bitrate must be 1200000, 1500000, or 2000000');
   const outletQualitySeconds = values['outlet-quality-seconds'] === undefined ? 20 : Number(values['outlet-quality-seconds']);
@@ -83,7 +87,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
   return {
     command, options: {
       minutes, source: requiredUrl(values.source, '--source'), player: values.player === 'win2022' ? 'win2022' : null,
-      videoProfile, maxBitrate, scrollPixelsPerSecond: parseScroll(values.scroll), outletQualitySeconds,
+      videoProfile, maxBitrate, abCycleSeconds, scrollPixelsPerSecond: parseScroll(values.scroll), outletQualitySeconds,
       profileDir: values['profile-dir'] ?? join(homedir(), '.webscreen-harness', 'chrome-profile'),
       notifyDiscordChannelId: values['notify-discord'] ?? null,
       serverSnapHost: values['server-snap'] ?? null,

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -77,6 +77,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
   if (videoProfile !== 'quality' && videoProfile !== 'realtime') throw new Error('--video-profile must be quality or realtime');
   const abCycleSeconds = values['ab-cycle'] === undefined ? null : Number(values['ab-cycle']);
   if (abCycleSeconds !== null && (!Number.isInteger(abCycleSeconds) || abCycleSeconds < 60 || abCycleSeconds > 600)) throw new Error('--ab-cycle must be an integer between 60 and 600');
+  if (abCycleSeconds !== null && minutes * 60 <= abCycleSeconds + 15) throw new Error('--minutes must exceed --ab-cycle plus the 15-second transient exclusion');
   if (videoProfile === 'quality' && values['max-bitrate'] !== undefined && abCycleSeconds === null) throw new Error('--max-bitrate is only valid with --video-profile realtime');
   if (abCycleSeconds !== null && values['max-bitrate'] === undefined) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
   const maxBitrate = values['max-bitrate'] === undefined ? (videoProfile === 'realtime' ? 1_500_000 : null) : Number(values['max-bitrate']);

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   firstBelowLatency,
@@ -10,7 +13,7 @@ import {
   summarizeLatency,
   type LatencySample,
 } from '../../scripts/latency-probe-analysis';
-import { poolProfileSegments, splitByProfile, type ProfileSwitch } from '../../scripts/latency-probe-profile-analysis';
+import { formatProfileSwitchesCsv, parseProfileSwitchesCsv, poolProfileSegments, splitByProfile, type ProfileSwitch } from '../../scripts/latency-probe-profile-analysis';
 import {
   BLOCK_GRID_SIZE,
   bandPassOneKilohertz,
@@ -25,7 +28,8 @@ import {
 } from '../../scripts/latency-probe-codec';
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
-import { screenShareUrl } from '../../scripts/latency-probe-run';
+import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
+import { analyzeDirectory, clearPreviousRunArtifacts, screenShareUrl, validateRunOptions } from '../../scripts/latency-probe-run';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 
 function rasterize(timestampMs: number, cell = 20): { rgb: Uint8Array; width: number; height: number } {
@@ -66,6 +70,108 @@ function scaleNearest(frame: { rgb: Uint8Array; width: number; height: number },
   }
   return { rgb, width, height };
 }
+
+function withLiveVideoSender(trackId = 'sender-a'): { evaluator: VideoProfileEvaluator; parameters: RTCRtpSendParameters; setReadbackMismatch(value: boolean): void; replaceSender(track: string): void; restore(): void } {
+  let parameters = { encodings: [{ scaleResolutionDownBy: 2 }] } as RTCRtpSendParameters;
+  let mismatch = false;
+  const track = { kind: 'video', readyState: 'live', id: trackId, contentHint: '' } as MediaStreamTrack;
+  const sender = {
+    track,
+    getParameters: () => mismatch ? { ...parameters, encodings: [{ ...parameters.encodings?.[0], maxBitrate: 1 }] } : parameters,
+    setParameters: async (next: RTCRtpSendParameters) => { parameters = next; },
+  } as unknown as RTCRtpSender;
+  const connection = { connectionState: 'connected', getSenders: () => [sender] } as unknown as RTCPeerConnection;
+  const global = globalThis as { window: Window & typeof globalThis };
+  const previous = global.window;
+  global.window = { __webscreenHarnessPeerConnections: [connection] } as unknown as Window & typeof globalThis;
+  return {
+    evaluator: { evaluate: async (pageFunction, argument) => pageFunction(argument) },
+    parameters,
+    setReadbackMismatch: (value) => { mismatch = value; },
+    replaceSender: (nextTrackId) => { Object.assign(track, { id: nextTrackId }); },
+    restore: () => { global.window = previous; },
+  };
+}
+
+describe('latency probe video profiles', () => {
+  test('realtimeではscaleを外し、qualityへ戻すと1を読み戻せる', async () => {
+    const harness = withLiveVideoSender();
+    try {
+      await applyVideoProfile(harness.evaluator, 'realtime', 1_500_000, 1_000);
+      expect(harness.parameters.encodings?.[0]?.scaleResolutionDownBy).toBeUndefined();
+      await applyVideoProfile(harness.evaluator, 'quality', 1_500_000, 1_000);
+      expect(harness.parameters.encodings?.[0]?.scaleResolutionDownBy).toBe(1);
+    } finally { harness.restore(); }
+  });
+
+  test('senderの読み戻しが不一致ならプロファイル変更を拒否する', async () => {
+    const harness = withLiveVideoSender();
+    try {
+      harness.setReadbackMismatch(true);
+      await expect(applyVideoProfile(harness.evaluator, 'realtime', 1_500_000, 1_000)).rejects.toThrow('readback mismatch');
+    } finally { harness.restore(); }
+  });
+
+  test('abort済みまたは終了済みの周期はevaluateを呼ばない', async () => {
+    let evaluations = 0;
+    const evaluator: VideoProfileEvaluator = { evaluate: async () => { evaluations += 1; throw new Error('must not evaluate'); } };
+    const initial: ProfileSwitch = { observedAtMs: 1_000, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 };
+    const abortedDuringWait = new AbortController();
+    let now = 1_000;
+    await cycleVideoProfiles(evaluator, tmpdir(), 1_000, 7_000, initial, 1_500_000, 60, abortedDuringWait.signal, {
+      now: () => now,
+      sleep: async (milliseconds) => { now += milliseconds; abortedDuringWait.abort(); },
+    });
+    await cycleVideoProfiles(evaluator, tmpdir(), 1_000, 1_000, initial, 1_500_000, 60);
+    expect(evaluations).toBe(0);
+  });
+
+  test('公開境界は不正なプロファイル・bitrate・周期を副作用前に拒否する', async () => {
+    const evaluator: VideoProfileEvaluator = { evaluate: async () => { throw new Error('must not evaluate'); } };
+    await expect(applyVideoProfile(evaluator, 'other' as 'quality', 1_500_000, 1_000)).rejects.toThrow('video profile');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 999_999, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null })).toThrow('maxBitrate');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 1_500_000, abCycleSeconds: 59, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null })).toThrow('cycleSeconds');
+  });
+
+  test('sender差し替え時は5秒ポーリングで同じプロファイルを再適用する', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'latency-profile-'));
+    const harness = withLiveVideoSender();
+    let now = 1_000;
+    try {
+      const initial = await applyVideoProfile(harness.evaluator, 'quality', 1_500_000, now);
+      await writeFile(join(directory, 'profile-switches.csv'), 'timestamp_utc,elapsed_s,profile,max_bitrate,action\n');
+      const switches = await cycleVideoProfiles(harness.evaluator, directory, now, 7_000, initial, 1_500_000, 60, undefined, {
+        now: () => now,
+        sleep: async (milliseconds) => { now += milliseconds; if (now >= 6_000) harness.replaceSender('sender-b'); },
+      });
+      expect(switches.map((item) => item.action)).toEqual(['applied', 'reapplied']);
+      expect(await readFile(join(directory, 'profile-switches.csv'), 'utf8')).toContain(',reapplied');
+    } finally { harness.restore(); await rm(directory, { recursive: true, force: true }); }
+  });
+});
+
+describe('latency probe output isolation', () => {
+  test('再利用する出力先から前runの解析対象成果物だけを除去する', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'latency-artifacts-'));
+    try {
+      await Promise.all(['profile-switches.csv', 'player.csv', 'player-error.md', 'cleanup-error.md', 'sender-error.md', 'outlet.csv', 'keep.txt'].map((name) => writeFile(join(directory, name), 'old')));
+      await clearPreviousRunArtifacts(directory);
+      await expect(readFile(join(directory, 'profile-switches.csv'), 'utf8')).rejects.toThrow();
+      await expect(readFile(join(directory, 'player.csv'), 'utf8')).rejects.toThrow();
+      expect(await readFile(join(directory, 'keep.txt'), 'utf8')).toBe('old');
+    } finally { await rm(directory, { recursive: true, force: true }); }
+  });
+
+  test('analyzeは別runのprofile切替履歴を拒否する', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'latency-analyze-'));
+    const startedAtMs = 1_756_700_000_000;
+    try {
+      await writeFile(join(directory, 'outlet.csv'), formatLatencyCsv([{ observedAtMs: startedAtMs, videoLatencyMs: 100, audioLatencyMs: null }], startedAtMs));
+      await writeFile(join(directory, 'profile-switches.csv'), `timestamp_utc,elapsed_s,profile,max_bitrate,action\n${new Date(startedAtMs + 60_001).toISOString()},0.000,quality,1200000,applied\n`);
+      await expect(analyzeDirectory(directory)).rejects.toThrow('within 60 seconds');
+    } finally { await rm(directory, { recursive: true, force: true }); }
+  });
+});
 
 describe('latency block code', () => {
   test('48 bit時刻をchecksum付きで往復し、改ざんを拒否する', () => {
@@ -182,6 +288,12 @@ describe('latency CSV analysis', () => {
     expect(splitByProfile(samples, switches, 15)).toMatchObject([{ profile: 'quality', samples }]);
   });
 
+  test('再適用イベントをCSVへ保存し、従来4列CSVも解析できる', () => {
+    const reapplied: ProfileSwitch = { observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000, action: 'reapplied' };
+    expect(parseProfileSwitchesCsv(formatProfileSwitchesCsv([reapplied]))[0]?.action).toBe('reapplied');
+    expect(parseProfileSwitchesCsv(`timestamp_utc,elapsed_s,profile,max_bitrate\n${new Date(startedAtMs).toISOString()},0.000,quality,1200000\n`)[0]?.action).toBe('applied');
+  });
+
   test('同一プロファイルの複数区間をプールする', () => {
     const switches: ProfileSwitch[] = [
       { observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 },
@@ -193,6 +305,18 @@ describe('latency CSV analysis', () => {
 
     expect(poolProfileSegments(segments, 'quality').map((sample) => (sample.observedAtMs - startedAtMs) / 1_000)).toEqual([10, 135, 150]);
     expect(poolProfileSegments(segments, 'realtime').map((sample) => (sample.observedAtMs - startedAtMs) / 1_000)).toEqual([75, 90]);
+  });
+
+  test('過渡除外で標本0の区間もプロファイル再集計に残す', () => {
+    const switches: ProfileSwitch[] = [
+      { observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 },
+      { observedAtMs: startedAtMs + 60_000, elapsedSeconds: 60, profile: 'realtime', maxBitrate: 1_500_000 },
+    ];
+    const outlet = [{ observedAtMs: startedAtMs + 10_000, videoLatencyMs: 100, audioLatencyMs: null }, { observedAtMs: startedAtMs + 65_000, videoLatencyMs: 100, audioLatencyMs: null }];
+
+    expect(splitByProfile(outlet, switches, 15)[1]?.samples).toEqual([]);
+    expect(formatSummary(outlet, null, startedAtMs, null, switches)).toContain('| 2. realtime');
+    expect(formatSummary(outlet, null, startedAtMs, null, switches)).toContain('|  /  / 0 |');
   });
 
   test('送出側のプールは別プロファイルをまたぐcounter差分を混ぜない', () => {
@@ -244,6 +368,8 @@ describe('latency probe CLI contract', () => {
     expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '59', '--max-bitrate', '1500000'])).toThrow('between 60 and 600');
     expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '601', '--max-bitrate', '1500000'])).toThrow('between 60 and 600');
     expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '60'])).toThrow('requires --max-bitrate');
+    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '105', '--max-bitrate', '1500000'])).toThrow('must exceed');
+    expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '104', '--max-bitrate', '1500000'])).toMatchObject({ command: 'run', options: { abCycleSeconds: 104 } });
     expect(() => parseLatencyProbeArgs(['source', '--url', 'https://example.test', '--scroll', '2001'])).toThrow('between 0 and 2000');
   });
 });

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -10,6 +10,7 @@ import {
   summarizeLatency,
   type LatencySample,
 } from '../../scripts/latency-probe-analysis';
+import { poolProfileSegments, splitByProfile, type ProfileSwitch } from '../../scripts/latency-probe-profile-analysis';
 import {
   BLOCK_GRID_SIZE,
   bandPassOneKilohertz,
@@ -25,7 +26,7 @@ import {
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { screenShareUrl } from '../../scripts/latency-probe-run';
-import { parseFreezeLog } from '../../scripts/latency-probe-quality';
+import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 
 function rasterize(timestampMs: number, cell = 20): { rgb: Uint8Array; width: number; height: number } {
   const width = BLOCK_GRID_SIZE * cell + 40;
@@ -160,6 +161,57 @@ describe('latency CSV analysis', () => {
     ], null, startedAtMs);
     expect(summary).toContain('A/V 差（audio - video、絶対値を復元できた近接標本）: 150.0 ms');
   });
+
+  test('2回の切替を3区間に分け、切替後15秒の過渡標本を除外する', () => {
+    const switches: ProfileSwitch[] = [
+      { observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 },
+      { observedAtMs: startedAtMs + 60_000, elapsedSeconds: 60, profile: 'realtime', maxBitrate: 1_500_000 },
+      { observedAtMs: startedAtMs + 120_000, elapsedSeconds: 120, profile: 'quality', maxBitrate: 1_200_000 },
+    ];
+    const samples = [10, 60, 74, 75, 90, 120, 134, 135, 150].map((seconds) => ({ observedAtMs: startedAtMs + seconds * 1_000 }));
+
+    expect(splitByProfile(samples, switches, 15).map((segment) => segment.samples.map((sample) => (sample.observedAtMs - startedAtMs) / 1_000))).toEqual([
+      [10], [75, 90], [135, 150],
+    ]);
+  });
+
+  test('切替なしは1区間のままにする', () => {
+    const switches: ProfileSwitch[] = [{ observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 }];
+    const samples = [{ observedAtMs: startedAtMs + 5_000 }, { observedAtMs: startedAtMs + 30_000 }];
+
+    expect(splitByProfile(samples, switches, 15)).toMatchObject([{ profile: 'quality', samples }]);
+  });
+
+  test('同一プロファイルの複数区間をプールする', () => {
+    const switches: ProfileSwitch[] = [
+      { observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 },
+      { observedAtMs: startedAtMs + 60_000, elapsedSeconds: 60, profile: 'realtime', maxBitrate: 1_500_000 },
+      { observedAtMs: startedAtMs + 120_000, elapsedSeconds: 120, profile: 'quality', maxBitrate: 1_200_000 },
+    ];
+    const samples = [10, 75, 90, 135, 150].map((seconds) => ({ observedAtMs: startedAtMs + seconds * 1_000 }));
+    const segments = splitByProfile(samples, switches, 15);
+
+    expect(poolProfileSegments(segments, 'quality').map((sample) => (sample.observedAtMs - startedAtMs) / 1_000)).toEqual([10, 135, 150]);
+    expect(poolProfileSegments(segments, 'realtime').map((sample) => (sample.observedAtMs - startedAtMs) / 1_000)).toEqual([75, 90]);
+  });
+
+  test('送出側のプールは別プロファイルをまたぐcounter差分を混ぜない', () => {
+    const switches: ProfileSwitch[] = [
+      { observedAtMs: startedAtMs, elapsedSeconds: 0, profile: 'quality', maxBitrate: 1_200_000 },
+      { observedAtMs: startedAtMs + 60_000, elapsedSeconds: 60, profile: 'realtime', maxBitrate: 1_500_000 },
+      { observedAtMs: startedAtMs + 120_000, elapsedSeconds: 120, profile: 'quality', maxBitrate: 1_200_000 },
+    ];
+    const sender = [
+      [0, 0, 0, 0], [10, 300, 300_000, 6_000], [75, 2_250, 2_250_000, 45_000],
+      [90, 2_700, 2_700_000, 54_000], [135, 4_050, 4_050_000, 81_000], [150, 4_500, 4_500_000, 90_000],
+    ].map(([seconds, framesEncoded, bytesSent, qpSum]) => ({
+      observedAtMs: startedAtMs + seconds! * 1_000, framesPerSecond: 30, framesEncoded: framesEncoded!, keyFramesEncoded: 0,
+      frameWidth: 1280, frameHeight: 720, bytesSent: bytesSent!, qpSum: qpSum!, totalEncodeTime: 0,
+      qualityLimitationReason: null, qualityLimitationDurations: { none: null, cpu: null, bandwidth: null, other: null },
+    } satisfies SenderSample));
+
+    expect(formatSummary([], null, startedAtMs, sender, switches)).toContain('| quality（プール） |  /  / 0 | なし | 30.00 | 240000 | 20.00 | 1280x720 |');
+  });
 });
 
 describe('latency probe CLI contract', () => {
@@ -172,6 +224,7 @@ describe('latency probe CLI contract', () => {
     const enabled = parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--notify-discord', '123456789012345', '--server-snap', 'relay-1.example']);
     expect(enabled).toMatchObject({ command: 'run', options: { notifyDiscordChannelId: '123456789012345', serverSnapHost: 'relay-1.example', player: null } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--video-profile', 'realtime', '--max-bitrate', '1500000', '--scroll', '240'])).toMatchObject({ command: 'run', options: { videoProfile: 'realtime', maxBitrate: 1_500_000, scrollPixelsPerSecond: 240 } });
+    expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '60', '--max-bitrate', '1500000'])).toMatchObject({ command: 'run', options: { videoProfile: 'quality', abCycleSeconds: 60, maxBitrate: 1_500_000 } });
   });
 
   test('共有タブへ渡す URL は http(s) かつ資格情報なしに限る', () => {
@@ -188,6 +241,9 @@ describe('latency probe CLI contract', () => {
     expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--server-snap', '-host'])).toThrow('ssh host');
     expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--max-bitrate', '1500000'])).toThrow('only valid');
     expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--video-profile', 'realtime', '--max-bitrate', '999999'])).toThrow('1200000');
+    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '59', '--max-bitrate', '1500000'])).toThrow('between 60 and 600');
+    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '601', '--max-bitrate', '1500000'])).toThrow('between 60 and 600');
+    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '60'])).toThrow('requires --max-bitrate');
     expect(() => parseLatencyProbeArgs(['source', '--url', 'https://example.test', '--scroll', '2001'])).toThrow('between 0 and 2000');
   });
 });


### PR DESCRIPTION
## なぜこの変更が必要か

Issue #177 の VRChat 実機 A/B は、run ごとに配信 URL が変わるため人が毎回 VRChat に貼り直す必要があり、貼付漏れ・前配信終了後の Player Error で 4 本中 3 本が無効になった。1 本の配信の中でプロファイルを自動で切り替えれば、URL を 1 回貼るだけで A/B を複数回往復でき、人の作業を最小化できる。

## 変更内容

- `run --ab-cycle <60..600 秒>`: 共有ページの video sender に `setParameters`（maxBitrate / degradationPreference / scaleResolutionDownBy）と `track.contentHint` を当てて quality ↔ realtime を交互に切り替え、`profile-switches.csv` に記録。読み戻し不一致・setParameters 失敗は run を失敗にする
- summary に「プロファイル区間別」節（切替直後 15 秒は過渡として除外）と quality / realtime プールの集計を追加。`analyze` でも再生成
- 製品側の republish で sender が差し替わった時は 5 秒以内に現在プロファイルを再適用して `reapplied` を記録
- run 開始時に前回の解析成果物（switches / player 等）を削除し、`--out` 再利用時の混在を防ぐ。`analyze` は switches の開始時刻を outlet と照合
- `page.evaluate` を注入可能にして Chrome なしのユニットテストを追加

## 意思決定

### 採用アプローチ
- ハーネス側から sender を直接操作する。理由: 製品コードと URL 発行を変えずに同じ配信で A/B でき、VRChat の再接続を挟まないため純粋なエンコーダ設定差だけを比較できる

### 却下した代替案
- 固定 stream ID の API 追加 → 却下: バックエンド変更が要り、検証用の隠し経路が増える

## テスト

- [x] `bun run typecheck` / `bun run test` 865 pass
- [x] 実 Chrome の smoke run（3 分・60 秒切替）で switches が 60 / 120 秒に記録され、sender に反映（QP 18.1 → 17.4）、区間別節が出ることを確認
- [x] codex レビューゲート（sol high 2 レーン）: P2 4 件・P3 1 件を反映（対応表は PR コメント）

関連: #177

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpHtFTntuVu261NJL46H29
