### PR TITLE
fix(streams): body なし POST で新規配信が 400 になる workerd 差異を直す

### DIFF
--- a/web/src/pages/api/streams/index.ts
+++ b/web/src/pages/api/streams/index.ts
@@ -33,11 +33,15 @@ export const POST: APIRoute = ({ request }) =>
   });
 
 async function parseCreateRequest(request: Request) {
+  // Body なしの既存クライアントは従来の新規発行として扱う。
+  if (request.body === null) return { ok: true as const, value: {} };
   const contentType = request.headers.get('content-type');
-  // Body なしの既存クライアントは従来の新規発行として扱う。ブラウザの fetch は body なし POST にも
-  // content-length: 0 を付け、workerd ではその request.body が null にならないため長さでも判定する。
-  const isEmptyBody = request.body === null || request.headers.get('content-length') === '0';
-  if (contentType === null && isEmptyBody) return { ok: true as const, value: {} };
+  // ブラウザの fetch は body なし POST にも content-length: 0 を付け、workerd ではその request.body が
+  // 空ストリームになる。宣言値ではなく実本文を 0 バイト上限で読み、本当に空の時だけ body なしと同じに扱う。
+  if (contentType === null) {
+    const empty = await readLimitedJsonBody(request, 0, { emptyValue: {} });
+    if (empty.ok) return { ok: true as const, value: {} };
+  }
   if (!isJsonContentType(contentType)) {
     return { ok: false as const, status: 400 as const, error: {
       errorCode: ERROR_CODES.invalidRequest,

--- a/web/src/pages/api/streams/index.ts
+++ b/web/src/pages/api/streams/index.ts
@@ -33,9 +33,12 @@ export const POST: APIRoute = ({ request }) =>
   });
 
 async function parseCreateRequest(request: Request) {
-  // Body なしの既存クライアントは従来の新規発行として扱う。
-  if (request.body === null) return { ok: true as const, value: {} };
-  if (!isJsonContentType(request.headers.get('content-type'))) {
+  const contentType = request.headers.get('content-type');
+  // Body なしの既存クライアントは従来の新規発行として扱う。ブラウザの fetch は body なし POST にも
+  // content-length: 0 を付け、workerd ではその request.body が null にならないため長さでも判定する。
+  const isEmptyBody = request.body === null || request.headers.get('content-length') === '0';
+  if (contentType === null && isEmptyBody) return { ok: true as const, value: {} };
+  if (!isJsonContentType(contentType)) {
     return { ok: false as const, status: 400 as const, error: {
       errorCode: ERROR_CODES.invalidRequest,
       message: 'Content-Type は application/json である必要があります',

--- a/web/tests/api/streams-start-cancel.test.ts
+++ b/web/tests/api/streams-start-cancel.test.ts
@@ -83,14 +83,49 @@ describe('配信開始token API境界', () => {
     });
   });
 
-  test('content-length: 0 の空ストリーム本文（workerd の body なし POST）も新規発行する', async () => {
+  test.each([
+    ['content-length: 0 の空文字本文', { 'content-length': '0' }, ''],
+    ['長さ宣言なしの空ストリーム本文', {}, new ReadableStream<Uint8Array>({ start(controller) { controller.close(); } })],
+  ])('Content-Type なしでも実本文が空なら新規発行する（workerd の body なし POST）: %s', async (_name, headers, body) => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders(headers),
+        body,
+        duplex: 'half',
+      } as RequestInit)
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  test('Content-Type なしで実本文がある時は content-length: 0 を宣言していても拒否する', async () => {
     const database = await createStreamDatabase();
     setBindings(database);
     const response = await callCreate(
       new Request('https://web-screen.net/api/streams/', {
         method: 'POST',
         headers: authHeaders({ 'content-length': '0' }),
-        body: '',
+        body: JSON.stringify({ id: 'AbCdEf123456' }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ errorCode: 'INVALID_REQUEST' });
+    expect(database.sqlite.query('SELECT COUNT(*) AS count FROM stream_sessions').get()).toEqual({
+      count: 0,
+    });
+  });
+
+  test('body が null なら Content-Type: application/json 付きでも従来どおり新規発行する', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders({ 'content-type': 'application/json' }),
       })
     );
 

--- a/web/tests/api/streams-start-cancel.test.ts
+++ b/web/tests/api/streams-start-cancel.test.ts
@@ -83,6 +83,20 @@ describe('配信開始token API境界', () => {
     });
   });
 
+  test('content-length: 0 の空ストリーム本文（workerd の body なし POST）も新規発行する', async () => {
+    const database = await createStreamDatabase();
+    setBindings(database);
+    const response = await callCreate(
+      new Request('https://web-screen.net/api/streams/', {
+        method: 'POST',
+        headers: authHeaders({ 'content-length': '0' }),
+        body: '',
+      })
+    );
+
+    expect(response.status).toBe(201);
+  });
+
   test.each(['', '   \n\t  '])('空白だけのcreate本文は従来どおり新規発行する: %p', async (body) => {
     const database = await createStreamDatabase();
     setBindings(database);


### PR DESCRIPTION
## なぜこの変更が必要か

#211（本日 15:19 マージ）以降、ブラウザから「画面共有をはじめる」で新規配信を開始すると `POST /api/streams/` が 400 `INVALID_REQUEST`（Content-Type 要求）を返し、配信を開始できない。

原因: ブラウザの fetch は body なし POST にも `content-length: 0` を付け、Cloudflare workerd ではその `request.body` が `null` ではなく空ストリームになる。#211 で追加した「body なし = 従来の新規発行」の判定が `request.body === null` だけだったため、workerd では成立せず Content-Type 検証で落ちていた。bun / Node の `Request` は body が `null` になるためユニットテストでは検出できなかった（ローカル `wrangler dev` + Playwright の QA で発見）。

## 変更内容

- Content-Type なしのリクエストは、宣言値ではなく実本文を 0 バイト上限で読み、本当に空の時だけ body なしと同じ新規発行として扱う
- 境界テストを追加: content-length 0 の空文字 / 長さ宣言なしの空ストリーム → 201、content-length 0 だが本文あり → 400、body null + application/json → 201

## 意思決定

- `content-length === '0'` の宣言値判定はレビューで却下（宣言と実本文が矛盾する入力を素通し / chunked 相当の空ストリームを拒否する）。実本文を読む方式に変更
- クライアント側で常に `Content-Type: application/json` + `{}` を送る案は、配信中の旧クライアントを救えないため採らない

## テスト

- [x] `bun test tests/api/streams-start-cancel.test.ts` 14 pass（追加テストは修正前に fail することを確認）
- [x] `bun test` 897 pass / `bun run typecheck` 成功
- [x] codex レビューゲート 2 レーン（通常 / セキュリティ）: 初回のブロッキング指摘を反映済み

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpHtFTntuVu261NJL46H29
