### PR TITLE
fix(screen-share): タブ共有では no-focus-change を外し配信断を解消する

### DIFF
--- a/web/src/lib/ui/screen-share/capture.ts
+++ b/web/src/lib/ui/screen-share/capture.ts
@@ -44,8 +44,10 @@ export function displayMediaConstraints(profile: AudioProfile): MediaStreamConst
 }
 
 /**
- * 画面選択後もこのページにフォーカスを留めて getDisplayMedia を呼ぶ。
- * Chrome はタブ共有時に共有先タブをアクティブにするため、CaptureController が使える時だけ抑止する。
+ * 共有種別に応じて開始直後のフォーカスを制御しつつ getDisplayMedia を呼ぶ。
+ * window 共有は別 OS ウィンドウが描画を続けるため WebScreen にフォーカスを留める。タブ共有は共有先タブを
+ * 背面のままにすると映像フレーム（キーフレーム）が出ず配信が始まらない（#214 の回帰 → #216）ため、
+ * Chrome 既定（タブを前面化）に任せる。MDN の例も browser には focus-captured-surface を使う。
  */
 export async function getDisplayMediaKeepingFocus(
   constraints: DisplayMediaStreamOptions,
@@ -57,7 +59,7 @@ export async function getDisplayMediaKeepingFocus(
   const stream = await getDisplayMedia({ ...constraints, controller });
   // setFocusBehavior は Promise 解決直後の短い窓でしか受け付けず、monitor 共有では InvalidStateError になる。
   const displaySurface = stream.getVideoTracks()[0]?.getSettings().displaySurface;
-  if (displaySurface === 'browser' || displaySurface === 'window') {
+  if (displaySurface === 'window') {
     try {
       controller.setFocusBehavior('no-focus-change');
     } catch (error) {

--- a/web/tests/ui/screen-share-capture-focus.test.ts
+++ b/web/tests/ui/screen-share-capture-focus.test.ts
@@ -14,12 +14,12 @@ describe('画面選択後のフォーカス維持', () => {
     expect(passed).toEqual([{ video: true }]);
   });
 
-  test.each(['browser', 'window'])('%s 共有では解決直後に no-focus-change を設定する', async (surface) => {
+  test('window 共有では解決直後に no-focus-change を設定する', async () => {
     const controller = fakeController();
     let passedController: unknown;
     await getDisplayMediaKeepingFocus(
       constraints,
-      async (options) => { passedController = options.controller; return fakeStream(surface); },
+      async (options) => { passedController = options.controller; return fakeStream('window'); },
       () => controller.instance
     );
 
@@ -27,16 +27,19 @@ describe('画面選択後のフォーカス維持', () => {
     expect(controller.calls).toEqual(['no-focus-change']);
   });
 
-  test('monitor 共有では setFocusBehavior を呼ばない（InvalidStateError になるため）', async () => {
-    const controller = fakeController();
-    await getDisplayMediaKeepingFocus(constraints, async () => fakeStream('monitor'), () => controller.instance);
+  test.each(['browser', 'monitor'])(
+    '%s 共有では setFocusBehavior を呼ばない（タブは前面化が必要・monitor は不可）',
+    async (surface) => {
+      const controller = fakeController();
+      await getDisplayMediaKeepingFocus(constraints, async () => fakeStream(surface), () => controller.instance);
 
-    expect(controller.calls).toEqual([]);
-  });
+      expect(controller.calls).toEqual([]);
+    }
+  );
 
   test('setFocusBehavior が拒否されても stream は返す', async () => {
     const controller = fakeController(() => { throw new DOMException('late', 'InvalidStateError'); });
-    const stream = fakeStream('browser');
+    const stream = fakeStream('window');
     const originalWarn = console.warn;
     const warnings: unknown[] = [];
     console.warn = (...args: unknown[]) => { warnings.push(args[0]); };


### PR DESCRIPTION
## なぜこの変更が必要か

#214 のデプロイ後、ブラウザからの画面共有が「配信を開始できませんでした / 配信サーバーに接続できませんでした」で全滅した（本番、タブ共有）。#214 で `CaptureController.setFocusBehavior('no-focus-change')` をタブ（browser）共有にも適用したため、共有先タブが背面のままになり映像フレーム（キーフレーム/SPS）が出ず、egress 中継 ffmpeg が `Could not find codec parameters (Video: h264, none): unspecified size` → `dimensions not set` で出口に 1 バイトも書けず、配信が ready にならなかった。

## 根拠

- デプロイ完了(UTC): #213=07:21 / #214=07:38 / #215(テストのみ)=07:44。配信成功=05:17（#214 前）、失敗=07:58・08:20（#214 後、3/3）
- サーバーログ: ingress は H264+Opus 2 トラックを受信し publishing まで進むが、中継 ffmpeg が寸法を取れず出口に何も書けない
- ブラウザ Console: `DELETE .../whip/... 404` → `WHIP publish failed`（republish 経由で msgWhip 表示）

## 変更内容

- `no-focus-change` を `displaySurface === 'window'` のみに限定。タブ（browser）共有は Chrome 既定（共有先タブを前面化）に戻す。monitor は元々対象外
- 待機 UI（starting）とプレビュー保存（#214）は媒体パスに無関係のため維持

## 意思決定

- タブ共有では「WebScreen に留める」と「タブが映像を出す」が両立しない（背面タブは描画されない）。MDN/Chrome 公式例も browser には前面化を使う。まず配信復旧を優先し、フォーカスの扱いは別途ユーザーに委ねる
- 全面 revert ではなく window だけ据え置き（別 OS ウィンドウは背面でも描画継続のため安全）

## テスト

- [x] `bun test` 906 pass / `bun run typecheck` / capture-focus テスト 5 pass（browser・monitor は未呼び出し、window は呼び出し）
- [x] codex レビューゲート（sol high）: ブロッキングなし
- [ ] 本番反映後に実 Chrome でタブ共有 1 回（配信 URL 発行まで到達すること）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpHtFTntuVu261NJL46H29
