### PR TITLE
feat: GA4成功イベントと移行前ベースラインを追加

### DIFF
--- a/docs/research/2026-09-03-home-migration-baseline.md
+++ b/docs/research/2026-09-03-home-migration-baseline.md
@@ -1,0 +1,62 @@
+# トップ移行前の成功計測ベースライン（2026-09-03）
+
+トップページの役割を変更する前に、画面共有と動画変換が「開始されたか」ではなく「利用可能な URL まで到達したか」を比較できるよう、GA4 の測定契約と取得手順を固定する。
+
+## 状態
+
+- コード側の計測契約: 実装済み
+- DebugView / Realtime の受信確認: 未実施（GA4 プロパティへのログイン権限が必要）
+- key event の設定: 未実施（GA4 管理画面での変更権限が必要）
+- 移行前 7〜14 日の実測値: 未取得
+
+未取得値は 0 とみなさない。トップ移行は、下記の外部確認と観測期間を満たしてから判断する。
+
+## 成功イベントの定義
+
+| イベント | 成功境界 | 二重送信防止 |
+|---|---|---|
+| `screen_share_start` | `getDisplayMedia` が画面を返した直後 | 画面選択の成功ごと |
+| `screen_share_ready` | 同一配信で初めて health と現 publisher の映像送出を確認できた時 | 同一配信では再接続しても 1 回 |
+| `screen_share_url_copy` | 共有 URL の clipboard 書き込み成功後 | コピー成功ごと |
+| `convert_start` | URL またはファイルの事前検査を通過し、変換状態へ入った時 | 受理された変換ごと |
+| `convert_complete` | MP4 の R2 PUT と `/api/uploads/commit/` が両方成功した後 | 変換ごとに 1 回 |
+
+次のイベント名は後続 UI 用に型だけ予約し、対応する UI が存在するまで発火させない: `convert_url_copy`、`tool_nav_click`、`resume_prompt_impression`、`resume_prompt_click`。
+
+## パラメータとプライバシー境界
+
+送信を許可するのは次の列挙値だけ。
+
+| パラメータ | 許可値 |
+|---|---|
+| `tool` | `screen_share`, `convert` |
+| `source` | `home`, `screen_share_page`, `convert_page`, `header`, `resume` |
+| `input_kind` | `web`, `image`, `pdf` |
+| `locale` | `ja`, `en` |
+
+入力 URL、ファイル名、shortId、配信 ID・token・URL、ユーザー ID・名前、エラー本文・stack、共有内容の情報は送らない。プレビューページは引き続き Analytics タグ自体を出力しない。本番ホスト `web-screen.net` の完全一致以外（localhost、E2E、`*.workers.dev`）では送信しない。
+
+## 移行前に記録する値
+
+DebugView で契約どおりの受信を確認し、`screen_share_ready` と `convert_complete` を key event に設定した翌日を観測開始日にする。連続 7〜14 日について、日別・locale 別に次を記録する。
+
+| 指標 | 算出方法 | 実測値 |
+|---|---|---|
+| 画面共有開始数 | `screen_share_start` の event count | 未取得 |
+| 画面共有成功数 | `screen_share_ready` の event count | 未取得 |
+| 画面共有成功率 | ready / start | 未取得 |
+| 変換開始数 | `convert_start` の event count | 未取得 |
+| 変換成功数 | `convert_complete` の event count | 未取得 |
+| 変換成功率 | complete / start | 未取得 |
+
+URL とファイルの構成差を確認するため、変換指標は `input_kind` でも分ける。少数日の曜日偏りで判断しないため、最低 7 日を必須とする。
+
+## GA4 管理画面での検証手順
+
+1. 本番 `https://web-screen.net/ja/screen-share/` で画面選択、ready、URL コピーまで操作し、DebugView で 3 イベントと許可パラメータだけが届くことを確認する。
+2. 本番のトップで URL 変換とファイル変換を各 1 回完了し、`convert_start` と `convert_complete` が各処理 1 回だけ届くことを確認する。
+3. localhost、workers.dev、プレビュー URL ではイベントも Analytics タグも送られないことを確認する。
+4. Admin の Events で `screen_share_ready` と `convert_complete` を key event に設定する。
+5. Realtime で重複がないことを再確認し、翌日から上表の観測を開始する。
+
+コード側の自動テストは、外部 GA4 への到達ではなく、ホストガード・許可された型・成功境界・計測障害時の製品継続を固定する。外部画面の確認結果と観測期間は、この文書へ日付と値を追記する。

--- a/web/e2e/analytics.spec.ts
+++ b/web/e2e/analytics.spec.ts
@@ -32,6 +32,18 @@ test('プレビューページには計測タグ自体を出力しない', async
   expect(html).not.toContain('googletagmanager.com');
 });
 
+test('GA4初期設定はpage locationと同一origin referrerのquery/hashを送らない', async ({ request }) => {
+  const response = await request.get('/ja/?stream-id=Secret123456');
+  const html = await response.text();
+
+  expect(response.status()).toBe(200);
+  expect(html).toContain('page_location: location.origin + location.pathname');
+  expect(html).toContain('pageReferrer = referrer.origin + referrer.pathname');
+  expect(html).toContain("let pageReferrer = ''");
+  expect(html).not.toContain('page_location: location.href');
+  expect(html).not.toContain('page_referrer: document.referrer');
+});
+
 test('計測タグを足しても cross-origin isolation は維持される', async ({ page }) => {
   // FFmpeg.wasm の SharedArrayBuffer が動く前提そのもの。外部スクリプトの追加で
   // COEP を緩めると、ヘッダーのテストは通ったまま変換だけが壊れる。

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -185,11 +185,23 @@ const GA_TRACKED_HOST = 'web-screen.net';
           // 静的ページはビルド時に生成されるためサーバー側でホストを判定できない。描画時に見る。
           if (location.hostname === gaTrackedHost) {
             window.dataLayer = window.dataLayer || [];
-            function gtag() {
+            window.gtag = function () {
               window.dataLayer.push(arguments);
+            };
+            window.gtag('js', new Date());
+            let pageReferrer = '';
+            try {
+              const referrer = new URL(document.referrer);
+              if (referrer.origin === location.origin) {
+                pageReferrer = referrer.origin + referrer.pathname;
+              }
+            } catch {
+              // 空・不正・外部 referrer は送らない。
             }
-            gtag('js', new Date());
-            gtag('config', gaMeasurementId);
+            window.gtag('config', gaMeasurementId, {
+              page_location: location.origin + location.pathname,
+              page_referrer: pageReferrer,
+            });
 
             // COEP: credentialless 下でも no-cors のサブリソースは読めるため crossorigin を
             // 付けない（付けると CORS モードになり、gtag.js 側が ACAO を返さず逆に落ちる）。

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -182,17 +182,27 @@ const GA_TRACKED_HOST = 'web-screen.net';
           is:inline
           define:vars={{ gaMeasurementId: GA_MEASUREMENT_ID, gaTrackedHost: GA_TRACKED_HOST }}
         >
+          // 12 文字 base62 のセグメントは公開 ID（変換の shortId・配信 ID）。パスに含む URL を
+          // GA4 へ渡すと、公開 URL の唯一の保護である ID が Google 側に残る。
+          // 判定の正本は src/lib/ui/analytics.ts の containsPublicId（ここはインライン用の写し。
+          // インラインスクリプトは import できないため、規則を変える時は両方を直す）。
+          const containsPublicId = (pathname) =>
+            pathname.split('/').some((segment) => /^[0-9A-Za-z]{12}$/.test(segment));
+
           // 静的ページはビルド時に生成されるためサーバー側でホストを判定できない。描画時に見る。
-          if (location.hostname === gaTrackedHost) {
+          // 公開 ID を含むパスでは config ごと送らない（パラメータの省略では gtag が
+          // location.href を自動収集してしまい、逆にフル URL が渡る）。
+          if (location.hostname === gaTrackedHost && !containsPublicId(location.pathname)) {
             window.dataLayer = window.dataLayer || [];
             window.gtag = function () {
               window.dataLayer.push(arguments);
             };
             window.gtag('js', new Date());
+            // 空文字を明示して、gtag の document.referrer 自動収集を打ち消す。
             let pageReferrer = '';
             try {
               const referrer = new URL(document.referrer);
-              if (referrer.origin === location.origin) {
+              if (referrer.origin === location.origin && !containsPublicId(referrer.pathname)) {
                 pageReferrer = referrer.origin + referrer.pathname;
               }
             } catch {

--- a/web/src/lib/ui/analytics.ts
+++ b/web/src/lib/ui/analytics.ts
@@ -1,0 +1,212 @@
+/** GA4 へ送信できるイベント名。未実装 UI のイベントも契約としてここで予約する。 */
+export const ANALYTICS_EVENT_NAMES = [
+  'screen_share_start',
+  'screen_share_ready',
+  'screen_share_url_copy',
+  'convert_start',
+  'convert_complete',
+  'convert_url_copy',
+  'tool_nav_click',
+  'resume_prompt_impression',
+  'resume_prompt_click',
+] as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENT_NAMES)[number];
+export type AnalyticsTool = 'screen_share' | 'convert';
+export type AnalyticsSource = 'home' | 'screen_share_page' | 'convert_page' | 'header' | 'resume';
+export type AnalyticsInputKind = 'web' | 'image' | 'pdf';
+export type AnalyticsLocale = 'ja' | 'en';
+
+export interface AnalyticsConfigParameters {
+  page_location: string;
+  page_referrer: string;
+}
+
+export type ScreenShareAnalyticsEvent = Extract<
+  AnalyticsEventName,
+  'screen_share_start' | 'screen_share_ready' | 'screen_share_url_copy'
+>;
+export type ConversionAnalyticsEvent = Extract<
+  AnalyticsEventName,
+  'convert_start' | 'convert_complete' | 'convert_url_copy'
+>;
+
+interface ScreenShareParameters {
+  tool: 'screen_share';
+  source: 'home' | 'screen_share_page';
+  locale: AnalyticsLocale;
+}
+
+export interface ConversionParameters {
+  tool: 'convert';
+  source: 'home' | 'convert_page';
+  input_kind: AnalyticsInputKind;
+  locale: AnalyticsLocale;
+}
+
+interface ToolNavigationParameters {
+  tool: AnalyticsTool;
+  source: 'header';
+  locale: AnalyticsLocale;
+}
+
+interface ResumeParameters {
+  tool: AnalyticsTool;
+  source: 'resume';
+  locale: AnalyticsLocale;
+}
+
+/** イベントごとに送信を許可するパラメータ。余分なキーを受ける汎用 Record は公開しない。 */
+export interface AnalyticsEventParameterMap {
+  screen_share_start: ScreenShareParameters;
+  screen_share_ready: ScreenShareParameters;
+  screen_share_url_copy: ScreenShareParameters;
+  convert_start: ConversionParameters;
+  convert_complete: ConversionParameters;
+  convert_url_copy: ConversionParameters;
+  tool_nav_click: ToolNavigationParameters;
+  resume_prompt_impression: ResumeParameters;
+  resume_prompt_click: ResumeParameters;
+}
+
+export type AnalyticsEventCall = {
+  [Event in AnalyticsEventName]: [event: Event, parameters: AnalyticsEventParameterMap[Event]];
+}[AnalyticsEventName];
+
+export interface AnalyticsGtag {
+  (command: 'event', ...eventCall: AnalyticsEventCall): void;
+  (command: 'js', initializedAt: Date): void;
+  (command: 'config', measurementId: string, parameters: AnalyticsConfigParameters): void;
+}
+
+export interface AnalyticsEnvironment {
+  hostname: string;
+  gtag?: AnalyticsGtag;
+}
+
+const TRACKED_HOST = 'web-screen.net';
+
+/** query/hashを除いたページ情報だけをGA4初期設定へ渡す。 */
+export function analyticsPageConfig(
+  page: { origin: string; pathname: string },
+  rawReferrer: string
+): AnalyticsConfigParameters {
+  let pageReferrer = '';
+  try {
+    const referrer = new URL(rawReferrer);
+    if (referrer.origin === page.origin) pageReferrer = referrer.origin + referrer.pathname;
+  } catch {
+    // 空・不正・外部 referrer は送らない。
+  }
+  return { page_location: page.origin + page.pathname, page_referrer: pageReferrer };
+}
+
+/** 完全一致した本番ホストだけへ、型付きイベントを安全に送る。 */
+export function dispatchAnalyticsEvent(
+  environment: AnalyticsEnvironment,
+  ...eventCall: AnalyticsEventCall
+): void {
+  if (environment.hostname !== TRACKED_HOST || !environment.gtag) return;
+  if (!isAllowedEventCall(eventCall)) return;
+  try {
+    environment.gtag('event', ...eventCall);
+  } catch {
+    // 計測は補助機能。広告ブロッカーや gtag 障害で製品の操作を失敗させない。
+  }
+}
+
+/** 現在の画面共有ページに対する成功イベントを送る。 */
+export function trackScreenShareEvent(event: ScreenShareAnalyticsEvent): void {
+  const browser = browserEnvironment('screen_share');
+  if (!browser || browser.source === 'convert_page') return;
+  const eventCall = [event, {
+    tool: 'screen_share',
+    source: browser.source,
+    locale: browser.locale,
+  }] as unknown as AnalyticsEventCall;
+  dispatchAnalyticsEvent(browser.environment, ...eventCall);
+}
+
+/** 現在の変換ページに対する成功イベントを送る。 */
+export function trackConversionEvent(
+  event: ConversionAnalyticsEvent,
+  inputKind: AnalyticsInputKind
+): void {
+  const browser = browserEnvironment('convert');
+  if (!browser || browser.source === 'screen_share_page') return;
+  const eventCall = [event, {
+    tool: 'convert',
+    source: browser.source,
+    input_kind: inputKind,
+    locale: browser.locale,
+  }] as unknown as AnalyticsEventCall;
+  dispatchAnalyticsEvent(browser.environment, ...eventCall);
+}
+
+/** 言語付き製品ページだけを、許可済み source / locale へ変換する。 */
+export function pageContext(
+  pathname: string,
+  tool: AnalyticsTool
+): { source: AnalyticsSource; locale: AnalyticsLocale } | null {
+  const match = pathname.match(/^\/(ja|en)(?:\/|$)/);
+  if (!match) return null;
+  const locale = match[1] as AnalyticsLocale;
+  if (pathname === `/${locale}` || pathname === `/${locale}/`) return { source: 'home', locale };
+  if (tool === 'screen_share' && pathname === `/${locale}/screen-share/`) {
+    return { source: 'screen_share_page', locale };
+  }
+  if (tool === 'convert' && pathname === `/${locale}/convert/`) {
+    return { source: 'convert_page', locale };
+  }
+  return null;
+}
+
+function browserEnvironment(tool: AnalyticsTool): {
+  environment: AnalyticsEnvironment;
+  source: 'home' | 'screen_share_page' | 'convert_page';
+  locale: AnalyticsLocale;
+} | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const context = pageContext(window.location.pathname, tool);
+    if (!context || context.source === 'header' || context.source === 'resume') return null;
+    return {
+      environment: { hostname: window.location.hostname, gtag: window.gtag },
+      source: context.source,
+      locale: context.locale,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedEventCall(eventCall: AnalyticsEventCall): boolean {
+  const [event, parameters] = eventCall;
+  if (!parameters || typeof parameters !== 'object') return false;
+  if (!(ANALYTICS_EVENT_NAMES as readonly string[]).includes(event)) return false;
+  if (!['ja', 'en'].includes(parameters.locale)) return false;
+  const keys = Object.keys(parameters).sort().join(',');
+  if (event.startsWith('screen_share_')) {
+    return parameters.tool === 'screen_share' &&
+      ['home', 'screen_share_page'].includes(parameters.source) && keys === 'locale,source,tool';
+  }
+  if (event.startsWith('convert_')) {
+    const value = parameters as ConversionParameters;
+    return value.tool === 'convert' && ['home', 'convert_page'].includes(value.source) &&
+      ['web', 'image', 'pdf'].includes(value.input_kind) && keys === 'input_kind,locale,source,tool';
+  }
+  const allowedTool = ['screen_share', 'convert'].includes(parameters.tool);
+  if (event === 'tool_nav_click') {
+    return allowedTool && parameters.source === 'header' && keys === 'locale,source,tool';
+  }
+  if (event === 'resume_prompt_impression' || event === 'resume_prompt_click') {
+    return allowedTool && parameters.source === 'resume' && keys === 'locale,source,tool';
+  }
+  return false;
+}
+
+declare global {
+  interface Window {
+    gtag?: AnalyticsGtag;
+  }
+}

--- a/web/src/lib/ui/analytics.ts
+++ b/web/src/lib/ui/analytics.ts
@@ -1,3 +1,5 @@
+import { isShortId } from '../contracts/r2key';
+
 /** GA4 へ送信できるイベント名。未実装 UI のイベントも契約としてここで予約する。 */
 export const ANALYTICS_EVENT_NAMES = [
   'screen_share_start',
@@ -86,15 +88,34 @@ export interface AnalyticsEnvironment {
 
 const TRACKED_HOST = 'web-screen.net';
 
-/** query/hashを除いたページ情報だけをGA4初期設定へ渡す。 */
+/**
+ * 公開 ID（変換の shortId・配信 ID。どちらも 12 文字 base62）をパスに含むか。
+ *
+ * 公開 URL は 12 文字のランダム ID だけで守られているため、GA4 へ渡すと保護が Google 側へ漏れる。
+ */
+export function containsPublicId(pathname: string): boolean {
+  return pathname.split('/').some(isShortId);
+}
+
+/**
+ * query/hash と公開 ID を除いたページ情報だけを GA4 初期設定へ渡す。
+ *
+ * 公開 ID を含む現在パスでは null を返し、config 自体を送らせない。パラメータの省略は使えない
+ * （gtag は page_location / page_referrer 未指定時に location.href / document.referrer を
+ * 自動収集するため、省略するとフル URL が渡って逆効果になる）。referrer 側は同じ理由で
+ * 空文字を明示的に送って自動収集を打ち消す。
+ */
 export function analyticsPageConfig(
   page: { origin: string; pathname: string },
   rawReferrer: string
-): AnalyticsConfigParameters {
+): AnalyticsConfigParameters | null {
+  if (containsPublicId(page.pathname)) return null;
   let pageReferrer = '';
   try {
     const referrer = new URL(rawReferrer);
-    if (referrer.origin === page.origin) pageReferrer = referrer.origin + referrer.pathname;
+    if (referrer.origin === page.origin && !containsPublicId(referrer.pathname)) {
+      pageReferrer = referrer.origin + referrer.pathname;
+    }
   } catch {
     // 空・不正・外部 referrer は送らない。
   }
@@ -107,9 +128,10 @@ export function dispatchAnalyticsEvent(
   ...eventCall: AnalyticsEventCall
 ): void {
   if (environment.hostname !== TRACKED_HOST || !environment.gtag) return;
-  if (!isAllowedEventCall(eventCall)) return;
+  const allowed = allowedEventCall(eventCall);
+  if (!allowed) return;
   try {
-    environment.gtag('event', ...eventCall);
+    environment.gtag('event', ...allowed);
   } catch {
     // 計測は補助機能。広告ブロッカーや gtag 障害で製品の操作を失敗させない。
   }
@@ -180,29 +202,47 @@ function browserEnvironment(tool: AnalyticsTool): {
   }
 }
 
-function isAllowedEventCall(eventCall: AnalyticsEventCall): boolean {
+/**
+ * 実行時に許可できる呼び出しだけを、検証済みフィールドから組み直して返す。
+ *
+ * 受け取ったオブジェクトをそのまま gtag へ渡さない。型を迂回した呼び出し元
+ * （trackScreenShareEvent 等の as 経由や、将来の JS からの呼び出し）で余分なキーが
+ * 付いていても、ここを通った値には現れないようにする。
+ */
+function allowedEventCall(eventCall: AnalyticsEventCall): AnalyticsEventCall | null {
+  // 型上は常に2要素だが、実行時は rest 引数なので第3引数以降が届きうる。
+  if (eventCall.length !== 2) return null;
   const [event, parameters] = eventCall;
-  if (!parameters || typeof parameters !== 'object') return false;
-  if (!(ANALYTICS_EVENT_NAMES as readonly string[]).includes(event)) return false;
-  if (!['ja', 'en'].includes(parameters.locale)) return false;
+  if (!parameters || typeof parameters !== 'object') return null;
+  if (!(ANALYTICS_EVENT_NAMES as readonly string[]).includes(event)) return null;
+  const locale = parameters.locale;
+  if (!['ja', 'en'].includes(locale)) return null;
   const keys = Object.keys(parameters).sort().join(',');
+  const { tool, source } = parameters as { tool: string; source: string };
+  // 組み直した値はイベントごとの許可組み合わせを満たすが、この関数の中では
+  // 判定とイベント名の対応を型で表せないため、返す時だけ契約型へ寄せる。
+  const call = (value: object): AnalyticsEventCall => [event, value] as unknown as AnalyticsEventCall;
+
   if (event.startsWith('screen_share_')) {
-    return parameters.tool === 'screen_share' &&
-      ['home', 'screen_share_page'].includes(parameters.source) && keys === 'locale,source,tool';
+    if (tool !== 'screen_share' || !['home', 'screen_share_page'].includes(source)) return null;
+    return keys === 'locale,source,tool' ? call({ tool, source, locale }) : null;
   }
   if (event.startsWith('convert_')) {
-    const value = parameters as ConversionParameters;
-    return value.tool === 'convert' && ['home', 'convert_page'].includes(value.source) &&
-      ['web', 'image', 'pdf'].includes(value.input_kind) && keys === 'input_kind,locale,source,tool';
+    const inputKind = (parameters as ConversionParameters).input_kind;
+    if (tool !== 'convert' || !['home', 'convert_page'].includes(source)) return null;
+    if (!['web', 'image', 'pdf'].includes(inputKind)) return null;
+    return keys === 'input_kind,locale,source,tool'
+      ? call({ tool, source, input_kind: inputKind, locale })
+      : null;
   }
-  const allowedTool = ['screen_share', 'convert'].includes(parameters.tool);
+  if (!['screen_share', 'convert'].includes(tool) || keys !== 'locale,source,tool') return null;
   if (event === 'tool_nav_click') {
-    return allowedTool && parameters.source === 'header' && keys === 'locale,source,tool';
+    return source === 'header' ? call({ tool, source, locale }) : null;
   }
   if (event === 'resume_prompt_impression' || event === 'resume_prompt_click') {
-    return allowedTool && parameters.source === 'resume' && keys === 'locale,source,tool';
+    return source === 'resume' ? call({ tool, source, locale }) : null;
   }
-  return false;
+  return null;
 }
 
 declare global {

--- a/web/src/lib/ui/convert-panel-responses.ts
+++ b/web/src/lib/ui/convert-panel-responses.ts
@@ -1,0 +1,45 @@
+import type { CaptureResponse, CommitResponse, PresignResponse } from '../contracts/api';
+import { isShortId } from '../contracts/r2key';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** presign API の成功応答を検証する。 */
+export function asPresignResponse(value: unknown): PresignResponse {
+  if (!isRecord(value) || typeof value.shortId !== 'string' ||
+      typeof value.uploadUrl !== 'string' || typeof value.publicUrl !== 'string') {
+    throw new Error('Invalid presign response');
+  }
+  return { shortId: value.shortId, uploadUrl: value.uploadUrl, publicUrl: value.publicUrl };
+}
+
+/** commit API の成功応答を検証する。 */
+export function asCommitResponse(value: unknown): CommitResponse {
+  if (!isRecord(value) || typeof value.shortId !== 'string' || !isShortId(value.shortId) ||
+      typeof value.publicUrl !== 'string' || typeof value.sizeBytes !== 'number' ||
+      (typeof value.expiresAt !== 'string' && value.expiresAt !== null)) {
+    throw new Error('Invalid commit response');
+  }
+  return {
+    shortId: value.shortId,
+    publicUrl: value.publicUrl,
+    sizeBytes: value.sizeBytes,
+    expiresAt: value.expiresAt,
+  };
+}
+
+/** capture API の成功応答を検証する。 */
+export function asCaptureResponse(value: unknown): CaptureResponse {
+  if (!isRecord(value) || !Array.isArray(value.images) ||
+      value.images.some((image) => typeof image !== 'string')) {
+    throw new Error('Invalid capture response');
+  }
+  const images = value.images as string[];
+  // totalImages のない旧応答は、返った画像をページ全体として扱う。
+  if (value.totalImages === undefined) return { images, totalImages: images.length };
+  if (!Number.isSafeInteger(value.totalImages) || (value.totalImages as number) < 0) {
+    throw new Error('Invalid capture response');
+  }
+  return { images, totalImages: value.totalImages as number };
+}

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -185,9 +185,11 @@ export async function uploadMp4(
     const committed = asCommitResponse(
       await requestUploadApi('/api/uploads/commit/', { shortId: presign.shortId })
     );
-    dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
+    // 計測は遷移より先に送る。uploaded で完了画面へ切り替わった直後に離脱されると、
+    // 送信が始まる前にページが差し替わって成功が記録されない。
     try { onComplete?.(); }
     catch { /* 計測 observer の失敗で完了済み変換を失敗扱いにしない。 */ }
+    dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
   } catch (error) {
     // サーバーが 4xx / 5xx を返した時だけ取り消す。通信断や、200 なのに本文が
     // 壊れている応答では commit が成功して ready になっている可能性があり、

--- a/web/src/lib/ui/convert-panel.ts
+++ b/web/src/lib/ui/convert-panel.ts
@@ -9,13 +9,9 @@ import {
   ERROR_CODES,
   MAX_CAPTURE_REQUESTS,
   MAX_UPLOAD_BYTES,
-  type CaptureResponse,
-  type CommitResponse,
   type ErrorCode,
-  type PresignResponse,
   type UploadKind,
 } from '../contracts/api';
-import { isShortId } from '../contracts/r2key';
 import { collectCaptures } from './capture-pages';
 import {
   clientErrorHttpStatus,
@@ -42,6 +38,12 @@ import { markAutoCopy } from './auto-copy';
 import { movieNameForFiles, movieNameForUrl } from './upload-name';
 import { renderConvertPanel } from './convert-panel-view';
 import { isUnauthorizedRequestError, JsonRequestError, requestJson } from './request-json';
+import {
+  trackConversionEvent,
+  type ConversionAnalyticsEvent,
+  type AnalyticsInputKind,
+} from './analytics';
+import { asCaptureResponse, asCommitResponse, asPresignResponse } from './convert-panel-responses';
 
 /** data-batch-name-suffix が無いときの接尾辞（ロケール非依存で読める形）。 */
 const DEFAULT_BATCH_NAME_SUFFIX = '+{count}';
@@ -62,57 +64,22 @@ const UPLOAD_STORED_RATIO = 0.8;
 
 type Dispatch = (event: UploadEvent, runGeneration?: number) => void;
 type Navigate = (url: string) => void;
+type EmittedConversionAnalyticsEvent = Extract<
+  ConversionAnalyticsEvent,
+  'convert_start' | 'convert_complete'
+>;
+type TrackConversionAnalytics = (
+  event: EmittedConversionAnalyticsEvent,
+  inputKind: AnalyticsInputKind
+) => void;
 
 export interface ConvertPanelOptions {
   navigate?: Navigate;
+  trackAnalytics?: TrackConversionAnalytics;
 }
 
 function element<T extends HTMLElement>(root: HTMLElement, selector: string): T | null {
   return root.querySelector<T>(selector);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function asPresignResponse(value: unknown): PresignResponse {
-  if (!isRecord(value) || typeof value.shortId !== 'string' || typeof value.uploadUrl !== 'string' || typeof value.publicUrl !== 'string') {
-    throw new Error('Invalid presign response');
-  }
-  return { shortId: value.shortId, uploadUrl: value.uploadUrl, publicUrl: value.publicUrl };
-}
-
-function asCommitResponse(value: unknown): CommitResponse {
-  if (
-    !isRecord(value) ||
-    typeof value.shortId !== 'string' ||
-    !isShortId(value.shortId) ||
-    typeof value.publicUrl !== 'string' ||
-    typeof value.sizeBytes !== 'number' ||
-    (typeof value.expiresAt !== 'string' && value.expiresAt !== null)
-  ) {
-    throw new Error('Invalid commit response');
-  }
-  return {
-    shortId: value.shortId,
-    publicUrl: value.publicUrl,
-    sizeBytes: value.sizeBytes,
-    expiresAt: value.expiresAt,
-  };
-}
-
-function asCaptureResponse(value: unknown): CaptureResponse {
-  if (!isRecord(value) || !Array.isArray(value.images) || value.images.some((image) => typeof image !== 'string')) {
-    throw new Error('Invalid capture response');
-  }
-  const images = value.images as string[];
-  // totalImages を返さないのは分割取得より前の web-capture。その版は長いページを
-  // PAGE_TOO_LONG で失敗させるので、返ってきた分がページ全体とみなして構わない。
-  if (value.totalImages === undefined) return { images, totalImages: images.length };
-  if (!Number.isSafeInteger(value.totalImages) || (value.totalImages as number) < 0) {
-    throw new Error('Invalid capture response');
-  }
-  return { images, totalImages: value.totalImages as number };
 }
 
 /**
@@ -181,7 +148,8 @@ export async function uploadMp4(
   kind: UploadKind,
   dispatch: Dispatch,
   runGeneration: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onComplete?: () => void
 ): Promise<void> {
   if (mp4.size > MAX_UPLOAD_BYTES) {
     reportClientError({ stage: 'upload', errorCode: 'tooLarge' });
@@ -218,6 +186,8 @@ export async function uploadMp4(
       await requestUploadApi('/api/uploads/commit/', { shortId: presign.shortId })
     );
     dispatch({ type: 'uploaded', publicUrl: committed.publicUrl, shortId: committed.shortId }, runGeneration);
+    try { onComplete?.(); }
+    catch { /* 計測 observer の失敗で完了済み変換を失敗扱いにしない。 */ }
   } catch (error) {
     // サーバーが 4xx / 5xx を返した時だけ取り消す。通信断や、200 なのに本文が
     // 壊れている応答では commit が成功して ready になっている可能性があり、
@@ -269,6 +239,9 @@ export function uploadErrorEstimatedImages(error: unknown): number | null {
 
 export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptions = {}): void {
   const navigate: Navigate = options.navigate ?? ((url) => window.location.assign(url));
+  const trackAnalytics: TrackConversionAnalytics = options.trackAnalytics ?? (
+    (event, inputKind) => trackConversionEvent(event, inputKind)
+  );
 
   let state = INITIAL_UPLOAD_STATE;
   let generation = 0;
@@ -301,11 +274,31 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
 
   let activeRun: AbortController | null = null;
 
+  const trackConversion = (
+    event: EmittedConversionAnalyticsEvent,
+    inputKind: AnalyticsInputKind
+  ): void => {
+    try { trackAnalytics(event, inputKind); }
+    catch { /* 計測 observer の失敗で変換を止めない。 */ }
+  };
+
   /** 新しい変換の世代と中止シグナルを起こす。前の変換が残っていれば道連れに止める。 */
   const startRun = (): { generation: number; signal: AbortSignal } => {
     activeRun?.abort();
     activeRun = new AbortController();
     return { generation: ++generation, signal: activeRun.signal };
+  };
+
+  /** 検査済み入力を running 状態へ進め、URL/ファイル共通の開始境界を一度だけ記録する。 */
+  const acceptConversion = (
+    event: UploadEvent,
+    inputKind: AnalyticsInputKind,
+    runGeneration: number
+  ): boolean => {
+    dispatch(event, runGeneration);
+    if (state.phase !== 'converting' || state.kind !== inputKind) return false;
+    trackConversion('convert_start', inputKind);
+    return true;
   };
 
   /** 進行中の変換を捨てて初期表示へ戻す。世代を進めるので遅れて届く報告も無視される。 */
@@ -365,13 +358,13 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
       files: files.map((file) => ({ filename: file.name, sizeBytes: file.size })),
     };
     const next = reduceUpload(state, event);
-    dispatch(event, current);
+    const accepted = acceptConversion(event, preflight.kind, current);
     // 選択の時点で弾かれた入力（大きすぎる・種類が混ざっている等）も報告する。
     // 変換が始まらない失敗は console にすら残らず、運用側から完全に見えないため。
     if (next.phase === 'error' && next.errorCode !== null) {
       reportClientError({ stage: 'convert', errorCode: next.errorCode });
     }
-    if (next.phase !== 'converting' || next.kind === null || next.kind === 'web' || next.kind !== preflight.kind) return;
+    if (!accepted || next.kind === null || next.kind === 'web' || next.kind !== preflight.kind) return;
     const kind = next.kind;
     void convertFilesToMp4(
       files,
@@ -391,7 +384,8 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
           kind,
           dispatch,
           current,
-          signal
+          signal,
+          () => trackConversion('convert_complete', kind)
         )
       )
       .catch((error: unknown) => {
@@ -436,7 +430,7 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
     if (!url) return;
     if (state.phase === 'converting' || state.phase === 'uploading') return;
     const { generation: current, signal } = startRun();
-    dispatch({ type: 'selectUrl', url }, current);
+    if (!acceptConversion({ type: 'selectUrl', url }, 'web', current)) return;
 
     let pseudoRatio = 0;
     const pseudoTimer = window.setInterval(() => {
@@ -468,7 +462,15 @@ export function mountConvertPanel(panel: HTMLElement, options: ConvertPanelOptio
       .then((images) => convertImageUrlsToMp4(images, (progress) => {
         dispatch({ type: 'stageProgress', ...progress }, current);
       }, signal))
-      .then((mp4) => uploadMp4(mp4, movieNameForUrl(url), 'web', dispatch, current, signal))
+      .then((mp4) => uploadMp4(
+        mp4,
+        movieNameForUrl(url),
+        'web',
+        dispatch,
+        current,
+        signal,
+        () => trackConversion('convert_complete', 'web')
+      ))
       .catch((error: unknown) => {
         // 中止は失敗ではない。cancelRun が既に初期表示へ戻している。
         if (signal.aborted) return;

--- a/web/src/lib/ui/screen-share/controller-bindings.ts
+++ b/web/src/lib/ui/screen-share/controller-bindings.ts
@@ -1,0 +1,26 @@
+import type { ScreenShareView } from './view';
+
+export interface ScreenShareActions {
+  start(stopOthers: boolean): void;
+  copyUrl(): void;
+  copyDiagnostics(): void;
+  stop(): void;
+  retry(): void;
+  pageHide(): void;
+}
+
+/** 画面共有 UI の DOM イベントを controller 操作へ結線する。 */
+export function bindScreenShareActions(
+  view: ScreenShareView,
+  onPageHide: (handler: () => void) => void,
+  actions: ScreenShareActions
+): void {
+  view.onClick('[data-screen-start]', () => actions.start(false));
+  view.onClick('[data-screen-copy]', actions.copyUrl);
+  view.onClick('[data-screen-copy-diagnostics]', actions.copyDiagnostics);
+  view.onClick('[data-screen-stop]', actions.stop);
+  view.onClick('[data-screen-retry]', actions.retry);
+  view.onClick('[data-screen-stop-others]', () => actions.start(true));
+  view.onClick('[data-screen-preview-toggle]', () => view.togglePreview());
+  onPageHide(actions.pageHide);
+}

--- a/web/src/lib/ui/screen-share/controller-clock.ts
+++ b/web/src/lib/ui/screen-share/controller-clock.ts
@@ -1,0 +1,20 @@
+import { isExpiryWarning, type LiveStreamSession, secondsUntil } from './session';
+import type { ScreenShareView } from './view';
+
+/** 現在時刻の配信期限表示を更新し、期限切れかを返す。 */
+export function updateStreamClock(
+  view: ScreenShareView,
+  live: LiveStreamSession,
+  expiresBarTotalSeconds: number,
+  now: number
+): boolean {
+  const remaining = secondsUntil(live.extendExpiresAt, now);
+  view.updateClock(
+    live.startedAt,
+    now,
+    remaining,
+    isExpiryWarning(live.extendExpiresAt, now),
+    expiresBarTotalSeconds
+  );
+  return remaining === 0;
+}

--- a/web/src/lib/ui/screen-share/controller-dependencies.ts
+++ b/web/src/lib/ui/screen-share/controller-dependencies.ts
@@ -1,0 +1,24 @@
+import type { ClientErrorReport } from '../../contracts/client-error';
+import type { ScreenShareAnalyticsEvent } from '../analytics';
+import type { requestJson } from '../request-json';
+import type { startWhipPublisher } from '../whip-publisher';
+import type { PreviewPreferenceStore } from './preview-preference';
+
+/** DOM controller の外部境界。テストでは画面・API・WHIP を独立して差し替える。 */
+export interface ScreenShareDependencies {
+  requestJson: typeof requestJson;
+  startWhipPublisher: typeof startWhipPublisher;
+  waitForStreamReady: (streamId: string, signal?: AbortSignal) => Promise<boolean>;
+  getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
+  previewPreference: PreviewPreferenceStore;
+  delay?: (ms: number) => Promise<void>;
+  now: () => number;
+  createStartToken?: () => string;
+  search?: () => string;
+  sendBeacon: (url: string, data?: BodyInit | null) => boolean;
+  onPageHide: (handler: () => void) => void;
+  /** 失敗の匿名報告。既定は client-error-report の reportClientError。 */
+  reportStreamFailure?: (report: ClientErrorReport) => void;
+  /** 成功境界の計測。失敗しても配信操作を止めない。 */
+  trackAnalytics?: (event: ScreenShareAnalyticsEvent) => void;
+}

--- a/web/src/lib/ui/screen-share/controller-diagnostics.ts
+++ b/web/src/lib/ui/screen-share/controller-diagnostics.ts
@@ -1,0 +1,116 @@
+import type { ClientErrorReport } from '../../contracts/client-error';
+import { reportClientError } from '../client-error-report';
+import { isUnauthorizedRequestError } from '../request-json';
+import { WhipPublishError, type VideoPublishStats } from '../whip-publisher';
+import {
+  buildStreamDiagnosticSnapshot,
+  classifyStreamFailure,
+  type StreamFailureKind,
+} from './diagnostics';
+import {
+  displaySurfaceOf,
+  userAgentString,
+  videoSettingsOf,
+} from './controller-helpers';
+import {
+  isStreamAlreadyLiveError,
+  messageKeyForError,
+  retryAfterSecondsForError,
+  ScreenShareView,
+  StreamHealthError,
+} from './view';
+
+/** 失敗診断の状態・匿名報告・表示をcontrollerから分離して所有する。 */
+export class ScreenShareDiagnostics {
+  private streamId: string | null = null;
+  private lastStats: VideoPublishStats | null = null;
+  private snapshot: Record<string, unknown> | null = null;
+
+  constructor(
+    private readonly view: ScreenShareView,
+    private readonly now: () => number,
+    private readonly reportFailure: (report: ClientErrorReport) => void = reportClientError
+  ) {}
+
+  reset(): void {
+    this.streamId = null;
+    this.lastStats = null;
+    this.snapshot = null;
+  }
+
+  setStreamId(streamId: string): void {
+    this.streamId = streamId;
+  }
+
+  rememberStats(stats: VideoPublishStats | null): void {
+    this.lastStats = stats;
+  }
+
+  snapshotJson(): string | null {
+    return this.snapshot ? JSON.stringify(this.snapshot, null, 2) : null;
+  }
+
+  markSuccess(): void {
+    this.snapshot = null;
+    this.view.setDiagnosticsButtonVisible(false);
+  }
+
+  handleStartError(error: unknown, media: MediaStream | null, hasLive: boolean): void {
+    if (isUnauthorizedRequestError(error)) {
+      this.view.show('login');
+      return;
+    }
+    const kind = startFailureKind(error);
+    if (kind) this.recordFailure(kind, this.lastStats, media);
+    else this.snapshot = null;
+    this.showError(error, hasLive);
+  }
+
+  recordFailure(
+    kind: StreamFailureKind,
+    stats: VideoPublishStats | null,
+    media: MediaStream | null
+  ): void {
+    try {
+      const failureCode = classifyStreamFailure({ kind, stats, health: null });
+      this.reportFailure({ stage: 'stream', errorCode: failureCode });
+      this.snapshot = buildStreamDiagnosticSnapshot({
+        streamId: this.streamId,
+        at: new Date(this.now()).toISOString(),
+        userAgent: userAgentString(),
+        displaySurface: displaySurfaceOf(media),
+        video: videoSettingsOf(media),
+        stats,
+        health: null,
+        failureCode,
+      });
+    } catch (error) {
+      console.warn('Failed to record stream failure diagnostics', error);
+    }
+  }
+
+  showError(error: unknown, hasLive: boolean): void {
+    this.view.showError(
+      messageKeyForError(error),
+      hasLive,
+      isStreamAlreadyLiveError(error),
+      retryAfterSecondsForError(error)
+    );
+    this.view.setDiagnosticsButtonVisible(this.snapshot !== null);
+  }
+
+  clearAndShowError(error: unknown, hasLive: boolean): void {
+    this.snapshot = null;
+    this.showError(error, hasLive);
+  }
+}
+
+/** 開始例外のうち、匿名診断へ送る失敗種別だけを返す。 */
+function startFailureKind(error: unknown): StreamFailureKind | null {
+  if (error instanceof StreamHealthError) return 'healthTimeout';
+  if (error instanceof WhipPublishError) return 'publishFailed';
+  if (error instanceof DOMException && (error.name === 'NotAllowedError' || error.name === 'AbortError')) {
+    return 'displayDenied';
+  }
+  return null;
+}

--- a/web/src/lib/ui/screen-share/controller.ts
+++ b/web/src/lib/ui/screen-share/controller.ts
@@ -1,93 +1,66 @@
 import { copyToClipboard } from '../clipboard';
-import { isUnauthorizedRequestError, type requestJson } from '../request-json';
 import { configureCaptureAudioTracks } from '../audio-profile';
 import { keyframeRequestIntervalForSearch, reusableStreamIdForSearch } from '../stream-profile';
-import { WhipPublishError, type startWhipPublisher, type VideoPublishStats, type WhipPublisher } from '../whip-publisher';
-import type { ClientErrorReport } from '../../contracts/client-error';
-import { reportClientError } from '../client-error-report';
+import type { WhipPublisher } from '../whip-publisher';
 import { currentAudioProfile, displayMediaConstraints } from './capture';
-import { isExpiryWarning, LiveStreamSession, releasePublisher, secondsUntil, StartRun } from './session';
+import { LiveStreamSession, releasePublisher, StartRun } from './session';
 import { createStreamApi, type StreamApi } from './stream-api';
-import {
-  buildStreamDiagnosticSnapshot,
-  classifyStreamFailure,
-  type StreamFailureKind,
-} from './diagnostics';
 import { resolveScreenShareVideoSettingsForSearch } from './video-profile';
-import type { PreviewPreferenceStore } from './preview-preference';
 import {
   currentSearch,
   delay,
-  displaySurfaceOf,
   durationUntil,
-  userAgentString,
-  videoSettingsOf,
 } from './controller-helpers';
 import {
-  isStreamAlreadyLiveError,
   isStreamIdNotReusableError,
-  messageKeyForError,
-  retryAfterSecondsForError,
   ScreenShareView,
   StreamHealthError,
 } from './view';
-/** DOM controller の外部境界。テストでは画面・API・WHIP を独立して差し替える。 */
-export interface ScreenShareDependencies {
-  requestJson: typeof requestJson;
-  startWhipPublisher: typeof startWhipPublisher;
-  waitForStreamReady: (streamId: string, signal?: AbortSignal) => Promise<boolean>;
-  getDisplayMedia: typeof navigator.mediaDevices.getDisplayMedia;
-  previewPreference: PreviewPreferenceStore;
-  delay?: (ms: number) => Promise<void>;
-  now: () => number;
-  createStartToken?: () => string;
-  search?: () => string;
-  sendBeacon: (url: string, data?: BodyInit | null) => boolean;
-  onPageHide: (handler: () => void) => void;
-  /** 失敗の匿名報告。既定は client-error-report の reportClientError。 */
-  reportStreamFailure?: (report: ClientErrorReport) => void;
-}
+import { ScreenShareDiagnostics } from './controller-diagnostics';
+import { StreamRemoteCleanup } from './remote-cleanup';
+import { updateStreamClock } from './controller-clock';
+import { StartCoordinator } from './start-coordinator';
+import { publisherReadiness } from './stream-readiness';
+import { bindScreenShareActions } from './controller-bindings';
+import { ScreenShareAnalyticsObserver } from './screen-share-analytics';
+import type { ScreenShareDependencies } from './controller-dependencies';
+export type { ScreenShareDependencies } from './controller-dependencies';
 
 type StartedStream = { live: LiveStreamSession; ready: boolean };
 /** 画面共有 UI のイベントと非同期ライフサイクルを調停する。 */
 export class ScreenShareControllerImpl {
   private readonly view: ScreenShareView;
   private readonly api: StreamApi;
+  private readonly cleanup: StreamRemoteCleanup;
   private live: LiveStreamSession | null = null;
-  private stopping = false;
-  private startGeneration = 0;
-  private startReservation: number | null = null;
-  private activeStart: StartRun | null = null;
+  private readonly starts = new StartCoordinator();
   private expiresBarTotalSeconds = 0;
   private reuseDisabled = false;
-  private readonly reportStreamFailure: (report: ClientErrorReport) => void;
-  // 失敗診断用。lastVideoStats は publisher を閉じる前に採取した値を保持する。
-  private lastStreamId: string | null = null;
-  private lastVideoStats: VideoPublishStats | null = null;
-  private lastDiagnostic: Record<string, unknown> | null = null;
+  private readonly diagnostics: ScreenShareDiagnostics;
+  private readonly analytics: ScreenShareAnalyticsObserver;
   constructor(
     root: HTMLElement,
     private readonly deps: ScreenShareDependencies
   ) {
     this.view = new ScreenShareView(root, deps.previewPreference);
-    this.reportStreamFailure = deps.reportStreamFailure ?? reportClientError;
+    this.diagnostics = new ScreenShareDiagnostics(this.view, deps.now, deps.reportStreamFailure);
+    this.analytics = new ScreenShareAnalyticsObserver(deps.trackAnalytics);
     this.api = createStreamApi(
       deps.requestJson,
       deps.sendBeacon,
       deps.delay,
       deps.waitForStreamReady
     );
+    this.cleanup = new StreamRemoteCleanup(this.api);
   }
   mount(): void {
     // getDisplayMedia はクリック起点で直接呼び、user activation を失わない。
-    this.view.onClick('[data-screen-start]', () => void this.beginStart(false));
-    this.view.onClick('[data-screen-copy]', () => void this.copyUrl());
-    this.view.onClick('[data-screen-copy-diagnostics]', () => void this.copyDiagnostics());
-    this.view.onClick('[data-screen-stop]', () => void this.stop());
-    this.view.onClick('[data-screen-retry]', () => void this.retry());
-    this.view.onClick('[data-screen-stop-others]', () => void this.beginStart(true));
-    this.view.onClick('[data-screen-preview-toggle]', () => this.view.togglePreview());
-    this.deps.onPageHide(() => this.stopForPageHide());
+    bindScreenShareActions(this.view, this.deps.onPageHide, {
+      start: (stopOthers) => void this.beginStart(stopOthers),
+      copyUrl: () => void this.copyUrl(), copyDiagnostics: () => void this.copyDiagnostics(),
+      stop: () => void this.stop(), retry: () => void this.retry(),
+      pageHide: () => this.stopForPageHide(),
+    });
     this.view.show('idle');
   }
   private async beginStart(stopOthers: boolean): Promise<void> {
@@ -103,6 +76,7 @@ export class ScreenShareControllerImpl {
       const media = await this.deps.getDisplayMedia(displayMediaConstraints(profile));
       run = this.registerStart(media, generation);
       if (!run) return;
+      this.analytics.emit('screen_share_start');
       this.view.setBusy('[data-screen-start]', true, 'labelStarting');
       configureCaptureAudioTracks(media, profile);
       // 競合配信の停止中は error ステップの「停止中…」を保ち、完了後に開始待機へ進める。
@@ -116,8 +90,8 @@ export class ScreenShareControllerImpl {
       // idle へ黙って戻さず displayDenied の案内を出す。
       if (this.isActiveStart(generation)) this.handleStartError(error, run?.capture.media ?? null);
     } finally {
-      if (run && this.activeStart === run) this.activeStart = null;
-      this.releaseStartReservation(generation);
+      if (run) this.starts.finish(run);
+      this.starts.release(generation);
       this.view.setBusy(selector, false, idleLabel);
       this.view.setBusy('[data-screen-start]', false, 'labelStart');
       this.view.setDisabled('[data-screen-retry]', false);
@@ -148,14 +122,14 @@ export class ScreenShareControllerImpl {
     stream.startTimers(() => void this.heartbeat(), () => this.updateClock());
     stream.capture.media.getVideoTracks()[0]?.addEventListener('ended', () => void this.stop());
     if (started.ready) {
-      this.markLiveSuccess();
+      this.markLiveSuccess(stream);
       return this.view.show('live');
     }
     // 映像が届かないまま health 未達。現 publisher の stats で分類する（旧値へフォールバックしない）。
     const stats = await stream.publisher.videoStats();
     if (!this.isActiveLive(stream)) return; // videoStats 待機中に停止/pagehide されたら復活させない。
-    this.recordStreamFailure('healthTimeout', stats, stream.capture.media);
-    this.showError(new StreamHealthError());
+    this.diagnostics.recordFailure('healthTimeout', stats, stream.capture.media);
+    this.diagnostics.showError(new StreamHealthError(), true);
   }
 
   private async createAndPublish(run: StartRun): Promise<StartedStream | null> {
@@ -174,10 +148,10 @@ export class ScreenShareControllerImpl {
       throw error;
     }
     // 配信 ID を診断へ引き渡す（journald live/<id>・Cloudflare ログとの突合キー）。
-    this.lastStreamId = created.id;
+    this.diagnostics.setStreamId(created.id);
     if (!this.isActiveRun(run)) {
       this.cancelStart(run);
-      void this.notifyServerStop(created.id);
+      void this.cleanup.stopId(created.id);
       return null;
     }
     return this.publishAndVerify(run, created);
@@ -211,7 +185,7 @@ export class ScreenShareControllerImpl {
         throw error;
       }
       this.cancelStart(run);
-      void this.notifyServerStop(created.id);
+      void this.cleanup.stopId(created.id);
       throw error;
     }
   }
@@ -227,7 +201,7 @@ export class ScreenShareControllerImpl {
     }
     // health は音声込みの path 全体 bytes を見るため、音声だけ流れて H.264 未生成でも
     // ready になりうる。live 確定前に「映像 bytes が実際に出たか」を videoStats で確認する。
-    const initialStats = await stream.publisher.videoStats();
+    const initial = await publisherReadiness(stream.publisher, ready);
     if (!this.isActiveRun(run) || !this.isActiveLive(stream)) {
       this.discardInactiveRun(stream, run);
       return null;
@@ -235,11 +209,11 @@ export class ScreenShareControllerImpl {
     // 厳密に 0 バイト = H.264 未生成。ready でも live にせず no-video 失敗へ落とす。
     // republish しても Chrome は映像を出さないので 2回目の health 待機も省く。
     // undefined（取得不能）は live を妨げない（テレメトリ欠落で健全な配信を弾かない）。
-    if (initialStats?.bytesSent === 0) return { live: stream, ready: false };
-    if (ready) return { live: stream, ready: true };
+    if (initial.stats?.bytesSent === 0) return { live: stream, ready: false };
+    if (initial.ready) return { live: stream, ready: true };
     // republish は close を同期実行する。失敗して publisher が死ぬ経路の診断用に、
     // ここでだけ現 publisher の stats を退避する（republish 成功後の分類には使わない）。
-    this.lastVideoStats = initialStats;
+    this.diagnostics.rememberStats(initial.stats);
     // 復旧 republish が失敗した publisher は PeerConnection を閉じ失敗 Promise をキャッシュし再接続不能。
     // WHIP エラー（サーバー接続不可）で誤誘導せず StreamHealthError（映像未到達）で破棄し、再選択へ導く。
     const replacement = await stream.publisher.republish().catch((error: unknown) => {
@@ -257,7 +231,12 @@ export class ScreenShareControllerImpl {
       this.discardInactiveRun(stream, run);
       return null;
     }
-    return { live: stream, ready: retryReady };
+    const retry = await publisherReadiness(stream.publisher, retryReady);
+    if (!this.isActiveRun(run) || !this.isActiveLive(stream)) {
+      this.discardInactiveRun(stream, run);
+      return null;
+    }
+    return { live: stream, ready: retry.ready };
   }
 
   private async copyUrl(): Promise<void> {
@@ -265,12 +244,13 @@ export class ScreenShareControllerImpl {
     if (!input) return;
     const copied = await copyToClipboard(input.value, input);
     this.view.setButtonLabel('[data-screen-copy]', copied ? 'labelCopied' : 'labelCopy');
+    if (copied) this.analytics.emit('screen_share_url_copy');
   }
 
   private async copyDiagnostics(): Promise<void> {
-    const snapshot = this.lastDiagnostic;
+    const snapshot = this.diagnostics.snapshotJson();
     if (!snapshot) return;
-    const copied = await copyToClipboard(JSON.stringify(snapshot, null, 2), null);
+    const copied = await copyToClipboard(snapshot, null);
     this.view.setButtonLabel(
       '[data-screen-copy-diagnostics]',
       copied ? 'labelDiagnosticsCopied' : 'labelDiagnosticsCopy'
@@ -285,23 +265,23 @@ export class ScreenShareControllerImpl {
       const publisher = await live.publisher.republish();
       if (!this.isActiveLive(live)) return void await releasePublisher(publisher);
       live.publisher = publisher;
-      const ready = await this.api.waitForReady(live.id, live.abortController.signal);
+      const healthReady = await this.api.waitForReady(live.id, live.abortController.signal);
       if (!this.isActiveLive(live)) return;
-      if (ready) {
-        this.markLiveSuccess();
+      const readiness = await publisherReadiness(live.publisher, healthReady);
+      if (!this.isActiveLive(live)) return;
+      if (readiness.ready) {
+        this.markLiveSuccess(live);
         this.view.setUrl(live.streamUrl);
         this.view.show('live');
       } else {
         // 再接続しても映像が届かない。現 publisher の stats で分類する（旧値へフォールバックしない）。
-        const stats = await live.publisher.videoStats();
-        if (!this.isActiveLive(live)) return; // videoStats 待機中に停止されたら復活させない。
-        this.recordStreamFailure('healthTimeout', stats, live.capture.media);
-        this.showError(new StreamHealthError());
+        this.diagnostics.recordFailure('healthTimeout', readiness.stats, live.capture.media);
+        this.diagnostics.showError(new StreamHealthError(), true);
       }
     } catch (error) {
       if (!this.isActiveLive(live)) return;
       const stopped = this.finishLocally('error', error);
-      if (stopped) await this.notifyRemoteStop(stopped);
+      if (stopped) await this.cleanup.stopAll(stopped);
     } finally {
       this.view.setBusy('[data-screen-retry]', false, this.live ? 'labelReconnect' : 'labelRetry');
     }
@@ -309,90 +289,46 @@ export class ScreenShareControllerImpl {
 
   private async stop(): Promise<void> {
     const live = this.finishLocally('idle');
-    if (live) await this.notifyRemoteStop(live);
+    if (live) await this.cleanup.stopAll(live);
   }
 
   private async heartbeat(): Promise<void> {
     const live = this.live;
-    if (!live || this.stopping) return;
+    if (!live || this.starts.isStopping) return;
     try {
       await this.api.heartbeat(live.id, live.abortController.signal);
     } catch (error) {
-      if (!this.stopping && this.live === live) this.handleRuntimeError(error);
+      if (!this.starts.isStopping && this.live === live) this.handleRuntimeError(error);
     }
   }
 
   private updateClock(): void {
     const live = this.live;
     if (!live) return;
-    const now = this.deps.now();
-    const remaining = secondsUntil(live.extendExpiresAt, now);
-    this.view.updateClock(
-      live.startedAt,
-      now,
-      remaining,
-      isExpiryWarning(live.extendExpiresAt, now),
-      this.expiresBarTotalSeconds
-    );
     // cron の kick を待たず、期限ちょうどでこのブラウザの capture と PeerConnection を閉じる。
-    if (remaining === 0) void this.stop();
+    if (updateStreamClock(this.view, live, this.expiresBarTotalSeconds, this.deps.now())) {
+      void this.stop();
+    }
   }
 
   private handleStartError(error: unknown, media: MediaStream | null): void {
-    if (isUnauthorizedRequestError(error)) return this.view.show('login');
-    const kind = startFailureKind(error);
-    // stats は close 前に採取済み（verifyInitialStream）。ここでの publisher は既に閉じている。
-    // 診断対象外のエラー（サーバー業務エラー等）では古い診断を残さずボタンを隠す。
-    if (kind) this.recordStreamFailure(kind, this.lastVideoStats, media);
-    else this.lastDiagnostic = null;
-    this.showError(error);
+    this.diagnostics.handleStartError(error, media, Boolean(this.live));
   }
 
   /** live 表示に到達したら診断を捨てる（後続の別エラーで古い診断をコピーさせない）。 */
-  private markLiveSuccess(): void {
-    this.lastDiagnostic = null;
-    this.view.setDiagnosticsButtonVisible(false);
-  }
-
-  /**
-   * 失敗を匿名報告し、コピー用の診断スナップショットを退避する。
-   * 診断の失敗で失敗表示を壊さないよう、全体を握り潰す（テレメトリ優先で画面を壊さない）。
-   */
-  private recordStreamFailure(
-    kind: StreamFailureKind,
-    stats: VideoPublishStats | null,
-    media: MediaStream | null
-  ): void {
-    try {
-      const failureCode = classifyStreamFailure({ kind, stats, health: null });
-      this.reportStreamFailure({ stage: 'stream', errorCode: failureCode });
-      this.lastDiagnostic = buildStreamDiagnosticSnapshot({
-        streamId: this.lastStreamId,
-        at: new Date(this.deps.now()).toISOString(),
-        userAgent: userAgentString(),
-        displaySurface: displaySurfaceOf(media),
-        video: videoSettingsOf(media),
-        stats,
-        health: null,
-        failureCode,
-      });
-    } catch (error) {
-      console.warn('Failed to record stream failure diagnostics', error);
-    }
+  private markLiveSuccess(stream: LiveStreamSession): void {
+    this.diagnostics.markSuccess();
+    this.analytics.ready(stream);
   }
 
   private handleRuntimeError(error: unknown): void {
     const live = this.finishLocally('error', error);
-    if (live) void this.notifyRemoteStop(live);
+    if (live) void this.cleanup.stopAll(live);
   }
 
   private finishLocally(phase: 'idle' | 'error', error?: unknown): LiveStreamSession | null {
-    if (this.stopping) return null;
-    this.stopping = true;
-    this.startGeneration += 1;
-    const run = this.activeStart;
-    this.activeStart = null;
-    run?.abortController.abort();
+    const run = this.starts.beginStop();
+    if (run === undefined) return null;
     const live = this.live;
     live?.abortController.abort();
     if (live) live.closeLocal();
@@ -400,128 +336,59 @@ export class ScreenShareControllerImpl {
     this.live = null;
     // ランタイム/再接続エラーは分類しない診断対象外の経路なので、古い診断は残さない。
     if (phase === 'error') {
-      this.lastDiagnostic = null;
-      this.showError(error);
+      this.diagnostics.clearAndShowError(error, false);
     } else this.view.show('idle');
     return live;
   }
 
   private stopForPageHide(): void {
-    const run = this.activeStart;
+    const run = this.starts.current;
     const live = this.finishLocally('idle');
     if (live) {
-      void this.notifyLiveServerStop(live, true);
-      void this.notifyWhipDeletion(live);
-    } else if (run) void this.notifyStartCancellation(run, true);
-  }
-
-  private async notifyRemoteStop(live: LiveStreamSession): Promise<void> {
-    await Promise.all([this.notifyLiveServerStop(live), this.notifyWhipDeletion(live)]);
-  }
-
-  private async notifyLiveServerStop(live: LiveStreamSession, beacon = false): Promise<void> {
-    if (!live.claimServerStop()) return;
-    await this.notifyServerStop(live.id, beacon);
-  }
-
-  private async notifyServerStop(id: string, beacon = false): Promise<void> {
-    try { await this.api.stop(id, beacon); }
-    catch (error) { console.warn('Failed to stop stream session remotely', error); }
-  }
-
-  private async notifyStartCancellation(run: StartRun, beacon = false): Promise<void> {
-    if (run.cancellationRequested) return;
-    run.cancellationRequested = true;
-    try { await this.api.cancelStart(run.startToken, beacon); }
-    catch (error) { console.warn('Failed to cancel stream start remotely', error); }
-  }
-
-  private async notifyWhipDeletion(live: LiveStreamSession): Promise<void> {
-    if (!live.claimWhipDelete()) return;
-    await live.publisher.deleteResource().catch((error) => {
-      console.warn('Failed to delete WHIP resource', error);
-    });
+      void this.cleanup.stopLiveServer(live, true);
+      void this.cleanup.deleteWhip(live);
+    } else if (run) void this.cleanup.cancelStart(run, true);
   }
 
   private reserveStart(): number | null {
-    if (this.startReservation !== null || this.activeStart || this.live) return null;
-    this.stopping = false;
+    const generation = this.starts.reserve(Boolean(this.live));
+    if (generation === null) return null;
     // 前回の試行の診断値を持ち越さない（無関係な次の失敗で古い stream id をコピーさせない）。
-    this.lastStreamId = null;
-    this.lastVideoStats = null;
-    this.lastDiagnostic = null;
-    const generation = ++this.startGeneration;
-    this.startReservation = generation;
+    this.diagnostics.reset();
     return generation;
   }
 
   private registerStart(media: MediaStream, generation: number): StartRun | null {
     const token = this.deps.createStartToken?.() ?? globalThis.crypto.randomUUID();
-    const run = new StartRun(generation, token, media);
-    if (this.startReservation !== generation || !this.isActiveStart(generation) ||
-        this.activeStart || this.live) {
-      run.cancel();
-      return null;
-    }
-    this.activeStart = run;
-    return run;
+    return this.starts.register(media, generation, token, Boolean(this.live));
   }
 
   private cancelStart(run: StartRun): void {
-    run.cancel();
-    if (this.activeStart === run) this.activeStart = null;
+    this.starts.cancel(run);
   }
 
   private discardInactiveRun(stream: LiveStreamSession, run: StartRun): null {
     this.cancelStart(run);
     if (this.live === stream) this.live = null;
     stream.closeLocal();
-    void this.notifyRemoteStop(stream);
+    void this.cleanup.stopAll(stream);
     return null;
   }
 
-  private releaseStartReservation(generation: number): void {
-    if (this.startReservation === generation) this.startReservation = null;
-  }
-
   private isActiveStart(generation: number): boolean {
-    return !this.stopping && this.startGeneration === generation;
+    return this.starts.isGenerationActive(generation);
   }
 
   private isActiveRun(run: StartRun): boolean {
-    return this.activeStart === run && this.isActiveStart(run.generation) &&
-      !run.abortController.signal.aborted;
+    return this.starts.isRunActive(run);
   }
 
   private isActiveLive(live: LiveStreamSession): boolean {
-    return !this.stopping && this.live === live;
-  }
-
-  private showError(error: unknown): void {
-    this.view.showError(
-      messageKeyForError(error),
-      Boolean(this.live),
-      isStreamAlreadyLiveError(error),
-      retryAfterSecondsForError(error)
-    );
-    // 診断スナップショットがある失敗（配信の映像/接続系）でだけコピーボタンを出す。
-    this.view.setDiagnosticsButtonVisible(this.lastDiagnostic !== null);
+    return !this.starts.isStopping && this.live === live;
   }
 
   private search(): string {
     return this.deps.search?.() ?? currentSearch();
   }
-}
 
-/**
- * 開始時の例外を診断の失敗種別へ写す。報告すべきでない失敗（サーバー側の業務エラー
- * = capacity・already-live 等の JsonRequestError）は null を返して報告しない。
- */
-function startFailureKind(error: unknown): StreamFailureKind | null {
-  if (error instanceof StreamHealthError) return 'healthTimeout';
-  if (error instanceof WhipPublishError) return 'publishFailed';
-  if (error instanceof DOMException && (error.name === 'NotAllowedError' || error.name === 'AbortError')) {
-    return 'displayDenied';
-  }
-  return null;
 }

--- a/web/src/lib/ui/screen-share/index.ts
+++ b/web/src/lib/ui/screen-share/index.ts
@@ -5,6 +5,7 @@ import { waitForStreamReady } from './stream-api';
 import { startWhipPublisher } from '../whip-publisher';
 import { browserPreviewPreference } from './preview-preference';
 import { getDisplayMediaKeepingFocus } from './capture';
+import { trackScreenShareEvent } from '../analytics';
 
 export type { ScreenShareDependencies } from './controller';
 export {
@@ -35,6 +36,7 @@ const BROWSER_DEPENDENCIES: ScreenShareDependencies = {
   createStartToken: () => globalThis.crypto.randomUUID(),
   sendBeacon: (url, data) => navigator.sendBeacon(url, data),
   onPageHide: (handler) => window.addEventListener('pagehide', handler),
+  trackAnalytics: trackScreenShareEvent,
 };
 
 /** 既定のbrowser依存を備え、従来の1引数constructorを維持する公開Facade。 */

--- a/web/src/lib/ui/screen-share/remote-cleanup.ts
+++ b/web/src/lib/ui/screen-share/remote-cleanup.ts
@@ -1,0 +1,41 @@
+import { type LiveStreamSession, type StartRun } from './session';
+import type { StreamApi } from './stream-api';
+
+/** 画面共有終了時のサーバー・WHIP 資源解放を一元化する。 */
+export class StreamRemoteCleanup {
+  constructor(private readonly api: StreamApi) {}
+
+  async stopAll(live: LiveStreamSession): Promise<void> {
+    await Promise.all([this.stopLiveServer(live), this.deleteWhip(live)]);
+  }
+
+  async stopLiveServer(live: LiveStreamSession, beacon = false): Promise<void> {
+    if (!live.claimServerStop()) return;
+    await this.stopId(live.id, beacon);
+  }
+
+  async stopId(id: string, beacon = false): Promise<void> {
+    try {
+      await this.api.stop(id, beacon);
+    } catch (error) {
+      console.warn('Failed to stop stream session remotely', error);
+    }
+  }
+
+  async cancelStart(run: StartRun, beacon = false): Promise<void> {
+    if (run.cancellationRequested) return;
+    run.cancellationRequested = true;
+    try {
+      await this.api.cancelStart(run.startToken, beacon);
+    } catch (error) {
+      console.warn('Failed to cancel stream start remotely', error);
+    }
+  }
+
+  async deleteWhip(live: LiveStreamSession): Promise<void> {
+    if (!live.claimWhipDelete()) return;
+    await live.publisher.deleteResource().catch((error) => {
+      console.warn('Failed to delete WHIP resource', error);
+    });
+  }
+}

--- a/web/src/lib/ui/screen-share/screen-share-analytics.ts
+++ b/web/src/lib/ui/screen-share/screen-share-analytics.ts
@@ -1,0 +1,23 @@
+import type { ScreenShareAnalyticsEvent } from '../analytics';
+import type { LiveStreamSession } from './session';
+
+/** 画面共有の成功イベントを安全かつ配信単位 one-shot で通知する。 */
+export class ScreenShareAnalyticsObserver {
+  private readonly readyStreams = new WeakSet<LiveStreamSession>();
+
+  constructor(private readonly track?: (event: ScreenShareAnalyticsEvent) => void) {}
+
+  emit(event: ScreenShareAnalyticsEvent): void {
+    try {
+      this.track?.(event);
+    } catch {
+      // 計測 observer の失敗で画面共有を壊さない。
+    }
+  }
+
+  ready(stream: LiveStreamSession): void {
+    if (this.readyStreams.has(stream)) return;
+    this.readyStreams.add(stream);
+    this.emit('screen_share_ready');
+  }
+}

--- a/web/src/lib/ui/screen-share/start-coordinator.ts
+++ b/web/src/lib/ui/screen-share/start-coordinator.ts
@@ -1,0 +1,63 @@
+import { StartRun } from './session';
+
+/** 競合する開始・停止操作の世代と capture 所有権を管理する。 */
+export class StartCoordinator {
+  private stopping = false;
+  private generation = 0;
+  private reservation: number | null = null;
+  private active: StartRun | null = null;
+
+  get current(): StartRun | null { return this.active; }
+  get isStopping(): boolean { return this.stopping; }
+
+  reserve(blocked: boolean): number | null {
+    if (this.reservation !== null || this.active || blocked) return null;
+    this.stopping = false;
+    const generation = ++this.generation;
+    this.reservation = generation;
+    return generation;
+  }
+
+  register(media: MediaStream, generation: number, token: string, blocked: boolean): StartRun | null {
+    const run = new StartRun(generation, token, media);
+    if (this.reservation !== generation || !this.isGenerationActive(generation) ||
+        this.active || blocked) {
+      run.cancel();
+      return null;
+    }
+    this.active = run;
+    return run;
+  }
+
+  cancel(run: StartRun): void {
+    run.cancel();
+    if (this.active === run) this.active = null;
+  }
+
+  finish(run: StartRun): void {
+    if (this.active === run) this.active = null;
+  }
+
+  release(generation: number): void {
+    if (this.reservation === generation) this.reservation = null;
+  }
+
+  isGenerationActive(generation: number): boolean {
+    return !this.stopping && this.generation === generation;
+  }
+
+  isRunActive(run: StartRun): boolean {
+    return this.active === run && this.isGenerationActive(run.generation) &&
+      !run.abortController.signal.aborted;
+  }
+
+  beginStop(): StartRun | null | undefined {
+    if (this.stopping) return undefined;
+    this.stopping = true;
+    this.generation += 1;
+    const run = this.active;
+    this.active = null;
+    run?.abortController.abort();
+    return run;
+  }
+}

--- a/web/src/lib/ui/screen-share/stream-readiness.ts
+++ b/web/src/lib/ui/screen-share/stream-readiness.ts
@@ -1,0 +1,15 @@
+import type { VideoPublishStats, WhipPublisher } from '../whip-publisher';
+
+export interface PublisherReadiness {
+  ready: boolean;
+  stats: VideoPublishStats | null;
+}
+
+/** health 成功を現 publisher の映像送出量で検証する。 */
+export async function publisherReadiness(
+  publisher: WhipPublisher,
+  healthReady: boolean
+): Promise<PublisherReadiness> {
+  const stats = await publisher.videoStats();
+  return { ready: healthReady && stats?.bytesSent !== 0, stats };
+}

--- a/web/tests/ui/analytics.test.ts
+++ b/web/tests/ui/analytics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   ANALYTICS_EVENT_NAMES,
   analyticsPageConfig,
+  containsPublicId,
   dispatchAnalyticsEvent,
   pageContext,
   type AnalyticsEventName,
@@ -30,8 +31,37 @@ describe('GA4 製品イベント契約', () => {
 
   test('外部・不正referrerはGA4へ渡さない', () => {
     const page = { origin: 'https://web-screen.net', pathname: '/en/' };
-    expect(analyticsPageConfig(page, 'https://example.com/private?q=secret').page_referrer).toBe('');
-    expect(analyticsPageConfig(page, 'not a url').page_referrer).toBe('');
+    expect(analyticsPageConfig(page, 'https://example.com/private?q=secret')?.page_referrer).toBe('');
+    expect(analyticsPageConfig(page, 'not a url')?.page_referrer).toBe('');
+  });
+
+  test('公開IDを含む同一origin referrerは空文字で上書きする', () => {
+    // 省略すると gtag が document.referrer を自動収集し、公開 URL がそのまま Google へ渡る。
+    const page = { origin: 'https://web-screen.net', pathname: '/ja/' };
+    expect(analyticsPageConfig(page, 'https://web-screen.net/Ab12Cd34Ef56/')).toEqual({
+      page_location: 'https://web-screen.net/ja/',
+      page_referrer: '',
+    });
+    expect(
+      analyticsPageConfig(page, 'https://web-screen.net/ja/screen-share/')?.page_referrer
+    ).toBe('https://web-screen.net/ja/screen-share/');
+  });
+
+  test('公開IDを含む現在パスでは初期設定自体を送らない', () => {
+    expect(analyticsPageConfig(
+      { origin: 'https://web-screen.net', pathname: '/Ab12Cd34Ef56/' },
+      ''
+    )).toBeNull();
+  });
+
+  test.each([
+    ['/ja/', false],
+    ['/ja/screen-share/', false],
+    ['/en/video-player/', false],
+    ['/Ab12Cd34Ef56/', true],
+    ['/ja/Ab12Cd34Ef56', true],
+  ])('%s の公開ID判定は %s', (pathname, expected) => {
+    expect(containsPublicId(pathname)).toBe(expected);
   });
 
   test('イベント固有でないパラメータは型として受け付けない', () => {
@@ -114,6 +144,37 @@ describe('GA4 製品イベント契約', () => {
     });
 
     expect(calls).toEqual([]);
+  });
+
+  test('イベント名とパラメータ以外の引数を持つ呼び出しを拒否する', () => {
+    const calls: unknown[][] = [];
+    const environment = {
+      hostname: 'web-screen.net',
+      gtag: ((...args: unknown[]) => calls.push(args)) as AnalyticsGtag,
+    };
+    const unsafeDispatch = dispatchAnalyticsEvent as unknown as (
+      target: typeof environment,
+      ...eventCall: unknown[]
+    ) => void;
+
+    unsafeDispatch(environment, 'convert_complete', PARAMETERS, { send_to: 'G-OTHER' });
+    unsafeDispatch(environment, 'convert_complete');
+
+    expect(calls).toEqual([]);
+  });
+
+  test('送信するパラメータは検証済みフィールドから組み直す', () => {
+    const calls: unknown[][] = [];
+    const environment = {
+      hostname: 'web-screen.net',
+      gtag: ((...args: unknown[]) => calls.push(args)) as AnalyticsGtag,
+    };
+
+    dispatchAnalyticsEvent(environment, 'convert_complete', PARAMETERS);
+
+    expect(calls[0][2]).toEqual(PARAMETERS);
+    // 呼び出し元のオブジェクトをそのまま渡すと、後から生えたキーが GA4 へ素通りする。
+    expect(calls[0][2]).not.toBe(PARAMETERS);
   });
 
   test('gtag不在・例外でも呼び出し元へ例外を返さない', () => {

--- a/web/tests/ui/analytics.test.ts
+++ b/web/tests/ui/analytics.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  ANALYTICS_EVENT_NAMES,
+  analyticsPageConfig,
+  dispatchAnalyticsEvent,
+  pageContext,
+  type AnalyticsEventName,
+  type AnalyticsEventParameterMap,
+  type AnalyticsGtag,
+} from '../../src/lib/ui/analytics';
+
+const PARAMETERS: AnalyticsEventParameterMap['convert_complete'] = {
+  tool: 'convert',
+  source: 'home',
+  input_kind: 'image',
+  locale: 'ja',
+};
+
+describe('GA4 製品イベント契約', () => {
+  test('page locationと同一origin referrerからquery/hashを除く', () => {
+    expect(analyticsPageConfig(
+      { origin: 'https://web-screen.net', pathname: '/ja/screen-share/' },
+      'https://web-screen.net/ja/?stream-id=Secret123456#live'
+    )).toEqual({
+      page_location: 'https://web-screen.net/ja/screen-share/',
+      page_referrer: 'https://web-screen.net/ja/',
+    });
+  });
+
+  test('外部・不正referrerはGA4へ渡さない', () => {
+    const page = { origin: 'https://web-screen.net', pathname: '/en/' };
+    expect(analyticsPageConfig(page, 'https://example.com/private?q=secret').page_referrer).toBe('');
+    expect(analyticsPageConfig(page, 'not a url').page_referrer).toBe('');
+  });
+
+  test('イベント固有でないパラメータは型として受け付けない', () => {
+    if (false) {
+      dispatchAnalyticsEvent(
+        { hostname: 'web-screen.net' },
+        'screen_share_ready',
+        {
+          tool: 'screen_share', source: 'screen_share_page', locale: 'ja',
+          // @ts-expect-error screen_share 系へ input_kind は送れない。
+          input_kind: 'image',
+        }
+      );
+      // @ts-expect-error convert 系は input_kind が必須。
+      dispatchAnalyticsEvent({ hostname: 'web-screen.net' }, 'convert_complete', {
+        tool: 'convert', source: 'home', locale: 'ja',
+      });
+    }
+    expect(true).toBe(true);
+  });
+
+  test('許可する9イベントを固定する', () => {
+    expect(ANALYTICS_EVENT_NAMES).toEqual([
+      'screen_share_start',
+      'screen_share_ready',
+      'screen_share_url_copy',
+      'convert_start',
+      'convert_complete',
+      'convert_url_copy',
+      'tool_nav_click',
+      'resume_prompt_impression',
+      'resume_prompt_click',
+    ]);
+  });
+
+  test.each(['localhost', 'preview.web-screen.net', 'webscreen.pages.dev'])(
+    '本番ホスト完全一致でない %s には送らない',
+    (hostname) => {
+      const calls: unknown[][] = [];
+      dispatchAnalyticsEvent(
+        { hostname, gtag: ((...args: unknown[]) => calls.push(args)) as AnalyticsGtag },
+        'convert_complete',
+        PARAMETERS
+      );
+
+      expect(calls).toEqual([]);
+    }
+  );
+
+  test('本番ホストへは許可パラメータだけをそのまま送る', () => {
+    const calls: [string, AnalyticsEventName, AnalyticsEventParameterMap[AnalyticsEventName]][] = [];
+    const gtag = ((
+      command: string,
+      event: AnalyticsEventName,
+      parameters: AnalyticsEventParameterMap[AnalyticsEventName]
+    ) => calls.push([command, event, parameters])) as unknown as AnalyticsGtag;
+
+    dispatchAnalyticsEvent({ hostname: 'web-screen.net', gtag }, 'convert_complete', PARAMETERS);
+
+    expect(calls).toEqual([['event', 'convert_complete', PARAMETERS]]);
+  });
+
+  test('型を迂回した余分なキーやイベント不一致の値も実行時に拒否する', () => {
+    const calls: unknown[][] = [];
+    const environment = {
+      hostname: 'web-screen.net',
+      gtag: ((...args: unknown[]) => calls.push(args)) as AnalyticsGtag,
+    };
+    const unsafeDispatch = dispatchAnalyticsEvent as unknown as (
+      target: typeof environment,
+      event: string,
+      parameters: object
+    ) => void;
+
+    unsafeDispatch(environment, 'screen_share_ready', {
+      tool: 'screen_share', source: 'screen_share_page', locale: 'ja', input_kind: 'image',
+    });
+    unsafeDispatch(environment, 'screen_share_secret', {
+      tool: 'screen_share', source: 'screen_share_page', locale: 'ja',
+    });
+
+    expect(calls).toEqual([]);
+  });
+
+  test('gtag不在・例外でも呼び出し元へ例外を返さない', () => {
+    expect(() => dispatchAnalyticsEvent(
+      { hostname: 'web-screen.net' },
+      'screen_share_ready',
+      { tool: 'screen_share', source: 'screen_share_page', locale: 'en' }
+    )).not.toThrow();
+    expect(() => dispatchAnalyticsEvent(
+      { hostname: 'web-screen.net', gtag: (() => { throw new Error('blocked'); }) as AnalyticsGtag },
+      'screen_share_ready',
+      { tool: 'screen_share', source: 'screen_share_page', locale: 'en' }
+    )).not.toThrow();
+  });
+
+  test('現在パスをhome・専用ページだけへ変換し、他パスは拒否する', () => {
+    expect(pageContext('/ja/', 'convert')).toEqual({ source: 'home', locale: 'ja' });
+    expect(pageContext('/en/screen-share/', 'screen_share')).toEqual({
+      source: 'screen_share_page',
+      locale: 'en',
+    });
+    expect(pageContext('/ja/convert/', 'convert')).toEqual({ source: 'convert_page', locale: 'ja' });
+    expect(pageContext('/ja/preview/', 'convert')).toBeNull();
+    expect(pageContext('/fr/', 'convert')).toBeNull();
+  });
+});

--- a/web/tests/ui/convert-panel-analytics.test.ts
+++ b/web/tests/ui/convert-panel-analytics.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+
+import { uploadMp4 } from '../../src/lib/ui/convert-panel';
+
+const PRESIGN = {
+  shortId: 'Ab12Cd34Ef56',
+  uploadUrl: 'https://upload.test/r2-upload',
+  publicUrl: 'https://cdn.test/movies/Ab12Cd34Ef56.mp4',
+};
+const COMMIT = { ...PRESIGN, sizeBytes: 3, expiresAt: null };
+
+async function runUpload(onComplete: () => void): Promise<void> {
+  await uploadMp4(new Blob(['mp4']), 'slide.mp4', 'image', () => {}, 1, undefined, onComplete);
+}
+
+describe('uploadMp4 analytics', () => {
+  test('R2 PUTとcommit成功後にだけcompleteを1回呼ぶ', async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: string[] = [];
+    const completed: string[] = [];
+    Object.assign(globalThis, { fetch: async (url: string) => {
+      requests.push(url);
+      if (url === '/api/uploads/presign/') return Response.json(PRESIGN);
+      if (url === '/api/uploads/commit/') return Response.json(COMMIT);
+      return new Response(null, { status: 200 });
+    } });
+
+    try {
+      await runUpload(() => completed.push('complete'));
+      expect(requests).toEqual([
+        '/api/uploads/presign/',
+        'https://upload.test/r2-upload',
+        '/api/uploads/commit/',
+      ]);
+      expect(completed).toEqual(['complete']);
+    } finally {
+      Object.assign(globalThis, { fetch: originalFetch });
+    }
+  });
+
+  test('計測observerが失敗してもcommit済み変換は成功のまま返す', async () => {
+    const originalFetch = globalThis.fetch;
+    Object.assign(globalThis, { fetch: async (url: string) => {
+      if (url === '/api/uploads/presign/') return Response.json(PRESIGN);
+      if (url === '/api/uploads/commit/') return Response.json(COMMIT);
+      return new Response(null, { status: 200 });
+    } });
+
+    try {
+      await expect(runUpload(() => { throw new Error('analytics blocked'); })).resolves.toBeUndefined();
+    } finally {
+      Object.assign(globalThis, { fetch: originalFetch });
+    }
+  });
+
+  test.each([
+    ['R2 PUT失敗', 'put'],
+    ['commit HTTP失敗', 'commit-http'],
+    ['commit不正本文', 'commit-invalid'],
+  ] as const)('%sではcompleteを呼ばない', async (_label, failureAt) => {
+    const originalFetch = globalThis.fetch;
+    let completed = 0;
+    Object.assign(globalThis, { fetch: async (url: string) => {
+      if (url === '/api/uploads/presign/') return Response.json(PRESIGN);
+      if (url === 'https://upload.test/r2-upload') {
+        return new Response(null, { status: failureAt === 'put' ? 500 : 200 });
+      }
+      if (url === '/api/uploads/commit/') {
+        return failureAt === 'commit-http'
+          ? Response.json({ errorCode: 'UPLOAD_COMMIT_FAILED' }, { status: 500 })
+          : Response.json({});
+      }
+      return new Response(null, { status: 200 });
+    } });
+
+    try {
+      await runUpload(() => { completed += 1; }).catch(() => undefined);
+      expect(completed).toBe(0);
+    } finally {
+      Object.assign(globalThis, { fetch: originalFetch });
+    }
+  });
+});

--- a/web/tests/ui/convert-panel-analytics.test.ts
+++ b/web/tests/ui/convert-panel-analytics.test.ts
@@ -38,6 +38,34 @@ describe('uploadMp4 analytics', () => {
     }
   });
 
+  test('completeを送ってから画面遷移させる', async () => {
+    // 遷移が先だと、離脱の速い利用者で送信前にページが差し替わる。
+    const originalFetch = globalThis.fetch;
+    const order: string[] = [];
+    Object.assign(globalThis, { fetch: async (url: string) => {
+      if (url === '/api/uploads/presign/') return Response.json(PRESIGN);
+      if (url === '/api/uploads/commit/') return Response.json(COMMIT);
+      return new Response(null, { status: 200 });
+    } });
+
+    try {
+      await uploadMp4(
+        new Blob(['mp4']),
+        'slide.mp4',
+        'image',
+        (action) => order.push(action.type),
+        1,
+        undefined,
+        () => order.push('complete')
+      );
+
+      expect(order.indexOf('complete')).toBeGreaterThan(-1);
+      expect(order.indexOf('complete')).toBeLessThan(order.indexOf('uploaded'));
+    } finally {
+      Object.assign(globalThis, { fetch: originalFetch });
+    }
+  });
+
   test('計測observerが失敗してもcommit済み変換は成功のまま返す', async () => {
     const originalFetch = globalThis.fetch;
     Object.assign(globalThis, { fetch: async (url: string) => {

--- a/web/tests/ui/convert-panel.test.ts
+++ b/web/tests/ui/convert-panel.test.ts
@@ -127,6 +127,41 @@ async function flushPromises(): Promise<void> {
 }
 
 describe('mountConvertPanel', () => {
+  test('URLとファイルは受理されて変換状態へ入った時だけstartを送る', async () => {
+    const browser = installBrowserFakes();
+    const events: string[] = [];
+
+    try {
+      const input = new FakeFileInput();
+      const panel = new FakePanel(input, 'https://example.com/articles/latest');
+      mountConvertPanel(panel as unknown as HTMLElement, {
+        trackAnalytics: (event, kind) => events.push(`${event}:${kind}`),
+      });
+
+      panel.urlForm.dispatch('submit');
+      await flushPromises();
+      expect(events).toEqual(['convert_start:web']);
+
+      panel.abortButton.dispatch('click');
+      input.files = [new File(
+        [new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
+        'slide.png',
+        { type: 'image/png' }
+      )];
+      input.dispatch('change');
+      await flushPromises();
+      expect(events).toEqual(['convert_start:web', 'convert_start:image']);
+
+      panel.abortButton.dispatch('click');
+      input.files = [new File(['unsupported'], 'README.txt', { type: 'text/plain' })];
+      input.dispatch('change');
+      await flushPromises();
+      expect(events).toEqual(['convert_start:web', 'convert_start:image']);
+    } finally {
+      browser.restore();
+    }
+  });
+
   test('遅い1件目のpreflight完了は後続ファイルの状態と変換開始を上書きしない', async () => {
     const browser = installBrowserFakes();
 

--- a/web/tests/ui/screen-share-lifecycle.test.ts
+++ b/web/tests/ui/screen-share-lifecycle.test.ts
@@ -7,6 +7,11 @@ import type { WhipPublisher } from '../../src/lib/ui/whip-publisher';
 describe('画面共有 controller', () => {
   test('フローは常時表示され、開始後は配信ステップを現在地にする', async () => {
     const page = fakeScreenSharePage();
+    const analytics: string[] = [];
+    let livePublisher: WhipPublisher;
+    livePublisher = Object.assign(publisherStub(async () => livePublisher), {
+      videoStats: async () => ({ bytesSent: 1024, framesEncoded: 1 }),
+    });
     const track = { addEventListener: () => undefined, stop: () => undefined };
     const media = {
       getTracks: () => [track],
@@ -15,13 +20,14 @@ describe('画面共有 controller', () => {
     } as unknown as MediaStream;
     new ScreenShareController(page.root, {
       requestJson: (async () => createResponse()) as unknown as ScreenShareDependencies['requestJson'],
-      startWhipPublisher: async () => publisherStub(),
+      startWhipPublisher: async () => livePublisher,
       waitForStreamReady: async () => true,
       getDisplayMedia: async () => media,
       previewPreference: { load: () => null, save: () => undefined },
       now: () => Date.parse('2026-09-01T00:00:00.000Z'),
       sendBeacon: () => true,
       onPageHide: () => undefined,
+      trackAnalytics: (event) => analytics.push(event),
     }).mount();
 
     expect(page.currentFlowItems()).toEqual(['1']);
@@ -30,6 +36,79 @@ describe('画面共有 controller', () => {
     await waitFor(() => !page.step('live').hidden);
 
     expect(page.currentFlowItems()).toEqual(['2']);
+    expect(analytics).toEqual(['screen_share_start', 'screen_share_ready']);
+
+    // 同じ配信の再接続成功では ready を再送しない。
+    page.button('[data-screen-retry]').click();
+    await flushMicrotasks();
+    expect(analytics).toEqual(['screen_share_start', 'screen_share_ready']);
+  });
+
+  test('共有URLのclipboard書き込み成功後だけcopyを送る', async () => {
+    const page = fakeScreenSharePage();
+    const analytics: string[] = [];
+    const originalNavigator = globalThis.navigator;
+    let failCopy = false;
+    Object.assign(globalThis, {
+      navigator: { clipboard: { writeText: async () => {
+        if (failCopy) throw new Error('clipboard denied');
+      } } },
+    });
+
+    try {
+      new ScreenShareController(page.root, {
+        requestJson: (async () => createResponse()) as unknown as ScreenShareDependencies['requestJson'],
+        startWhipPublisher: async () => publisherStub(),
+        waitForStreamReady: async () => true,
+        getDisplayMedia: async () => mediaStub(),
+        previewPreference: { load: () => null, save: () => undefined },
+        now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+        sendBeacon: () => true,
+        onPageHide: () => undefined,
+        trackAnalytics: (event) => analytics.push(event),
+      }).mount();
+
+      page.button('[data-screen-start]').click();
+      await waitFor(() => !page.step('live').hidden);
+      page.button('[data-screen-copy]').click();
+      await flushMicrotasks();
+
+      expect(analytics).toEqual([
+        'screen_share_start',
+        'screen_share_ready',
+        'screen_share_url_copy',
+      ]);
+
+      failCopy = true;
+      page.button('[data-screen-copy]').click();
+      await flushMicrotasks();
+      expect(analytics).toEqual([
+        'screen_share_start',
+        'screen_share_ready',
+        'screen_share_url_copy',
+      ]);
+    } finally {
+      Object.assign(globalThis, { navigator: originalNavigator });
+    }
+  });
+
+  test('計測observerが失敗しても配信開始からlive表示まで継続する', async () => {
+    const page = fakeScreenSharePage();
+    new ScreenShareController(page.root, {
+      requestJson: (async () => createResponse()) as unknown as ScreenShareDependencies['requestJson'],
+      startWhipPublisher: async () => publisherStub(),
+      waitForStreamReady: async () => true,
+      getDisplayMedia: async () => mediaStub(),
+      previewPreference: { load: () => null, save: () => undefined },
+      now: () => Date.parse('2026-09-01T00:00:00.000Z'),
+      sendBeacon: () => true,
+      onPageHide: () => undefined,
+      trackAnalytics: () => { throw new Error('analytics blocked'); },
+    }).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('live').hidden);
+    expect(page.url.value).toBe('rtspt://webscreen.tv/live/Ab12Cd34Ef56');
   });
 
   test('ピッカー選択中は開始・再試行を無効化し、ラベルは span だけ差し替えてアイコンを保つ', async () => {
@@ -111,6 +190,7 @@ describe('画面共有 controller', () => {
     let stopped = 0;
     let createRequests = 0;
     let publisherStarts = 0;
+    const analytics: string[] = [];
     const track = { addEventListener: () => undefined, stop: () => { stopped += 1; } };
     const media = { getTracks: () => [track], getVideoTracks: () => [track], getAudioTracks: () => [] } as unknown as MediaStream;
     const dependencies: ScreenShareDependencies = {
@@ -128,6 +208,7 @@ describe('画面共有 controller', () => {
       now: () => Date.parse('2026-09-01T00:00:00.000Z'),
       sendBeacon: () => true,
       onPageHide: (handler) => { pageHide = handler; },
+      trackAnalytics: (event) => analytics.push(event),
     };
     new ScreenShareController(page.root, dependencies).mount();
 
@@ -139,6 +220,7 @@ describe('画面共有 controller', () => {
     expect(stopped).toBe(1);
     expect(createRequests).toBe(0);
     expect(publisherStarts).toBe(0);
+    expect(analytics).toEqual([]);
   });
 
 });
@@ -150,6 +232,15 @@ function createResponse(): Record<string, unknown> {
     extendExpiresAt: '2026-09-01T01:00:00.000Z', startedAt: '2026-09-01T00:00:00.000Z',
     lastHeartbeatAt: '2026-09-01T00:00:00.000Z', endedAt: null, endReason: null,
   };
+}
+
+function mediaStub(): MediaStream {
+  const track = { addEventListener: () => undefined, stop: () => undefined };
+  return {
+    getTracks: () => [track],
+    getVideoTracks: () => [track],
+    getAudioTracks: () => [],
+  } as unknown as MediaStream;
 }
 
 function fakeScreenSharePage(): {
@@ -211,6 +302,7 @@ class FakeElement {
   paused = false;
   pause(): void { this.paused = true; }
   play(): Promise<void> { this.paused = false; return Promise.resolve(); }
+  select(): void {}
   srcObject: MediaProvider | null = null;
   textContent = '';
   value = '';

--- a/web/tests/ui/screen-share-reconnect.test.ts
+++ b/web/tests/ui/screen-share-reconnect.test.ts
@@ -156,6 +156,53 @@ describe('画面共有の再接続', () => {
     expect(reports).toEqual([{ stage: 'stream', errorCode: 'streamStatsUnavailable' }]);
   });
 
+  test('自動republish後のhealthがreadyでも現publisherの映像が0バイトならreadyを送らない', async () => {
+    const page = fakePage();
+    const analytics: string[] = [];
+    const replacement = Object.assign(publisher(), {
+      videoStats: async () => ({ bytesSent: 0, framesEncoded: 0 }),
+    });
+    const original = Object.assign(publisher(async () => replacement), {
+      videoStats: async () => ({ bytesSent: 100, framesEncoded: 1 }),
+    });
+    let healthChecks = 0;
+    new ScreenShareController(page.root, dependencies({
+      startWhipPublisher: async () => original,
+      waitForStreamReady: async () => ++healthChecks === 2,
+      trackAnalytics: (event) => analytics.push(event),
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+
+    expect(page.step('live').hidden).toBe(true);
+    expect(analytics).toEqual(['screen_share_start']);
+  });
+
+  test('手動retryのhealthがreadyでも現publisherの映像が0バイトならreadyを送らない', async () => {
+    const page = fakePage();
+    const analytics: string[] = [];
+    const replacement = Object.assign(publisher(), {
+      videoStats: async () => ({ bytesSent: 0, framesEncoded: 0 }),
+    });
+    const original = Object.assign(publisher(async () => replacement), {
+      videoStats: async () => ({ bytesSent: 0, framesEncoded: 0 }),
+    });
+    new ScreenShareController(page.root, dependencies({
+      startWhipPublisher: async () => original,
+      waitForStreamReady: async () => true,
+      trackAnalytics: (event) => analytics.push(event),
+    })).mount();
+
+    page.button('[data-screen-start]').click();
+    await waitFor(() => !page.step('error').hidden);
+    page.button('[data-screen-retry]').click();
+    await flushMicrotasks();
+
+    expect(page.step('live').hidden).toBe(true);
+    expect(analytics).toEqual(['screen_share_start']);
+  });
+
   test('videoStats待機中に停止したら idle 維持・error 非表示・publisher解放（復活させない）', async () => {
     const page = fakePage();
     const pendingStats = deferred<{ bytesSent: number; framesEncoded: number }>();


### PR DESCRIPTION
## 概要

画面共有と変換の開始・実成功をGA4で比較できる計測基盤を追加します。

- 9イベントの型付き・実行時許可リスト
- 画面共有の選択成功、映像ready、コピー成功を正確な処理境界で計測
- Web・画像・PDF変換の開始と、R2 PUT + commit成功後の完了を計測
- `page_location` / 同一origin referrerからquery/hashを除去
- localhost、preview、workers.dev、gtag障害時は無送信・製品継続
- 移行前7〜14日観測の手順と未取得ゲートを文書化

## 検証

- `bun run typecheck`
- `bun test` — 949 passed
- Node 22 `bun run build`
- `bunx playwright test e2e/analytics.spec.ts` — 4 passed
- changed-only architecture check — pass
- code / security review — blocking findings resolved

## 外部ゲート

コードの本番反映後にGA4 DebugView/Realtimeで受信を確認し、`screen_share_ready` と `convert_complete` をkey eventに設定します。7〜14日の実測値が揃うまでIssue #191はOPENのままにします。

Refs #191