### PR TITLE
feat(stream-lifecycle): viewer 判定を複数 read egress の reader 合計にし、未観測時は no_viewers を見送る

### DIFF
--- a/docs/streaming/operations.md
+++ b/docs/streaming/operations.md
@@ -57,7 +57,8 @@ versioned 設定、VPS → Worker の cutover、Worker / VPS 一体 rollback は
 - `wrangler tail` は scheduled イベントを取りこぼす（実測）。**tail の沈黙を「動いていない」証拠にしない**
 - 確実な検証: heartbeat 失効済みの合成 live 行を D1 に INSERT → 1〜2 分で `ended / heartbeat_lost` になれば cron・判定・API 呼び出しが一括で実証される（終わったら行を DELETE）
 - cron トリガーを追加したデプロイの後は、CI ログの `schedule:` 表示を信用せず実効を確かめる。不発なら `bunx wrangler triggers deploy -c cron/wrangler.jsonc` の再実行で直った実績あり
-- cron は ingress client で publisher を kick し、egress client で viewer / path を観測する。片側だけの疎通確認で完了にしない
+- cron は ingress client で publisher を kick し、`MEDIAMTX_READ_EGRESS_API_URLS` の全 read egress で viewer / path を観測する。origin を含め、増設時はカンマ区切りで URL を追加する
+- いずれかの read egress が未観測の回は `no_viewers` と `kick_pending` の解除を見送る。`stream_lifecycle_completed` の `egressObserved` / `egressUnobserved` で観測状態を確認する
 
 ## サーバーを移設・増設するとき
 

--- a/web/cron/src/stream.ts
+++ b/web/cron/src/stream.ts
@@ -67,8 +67,6 @@ export async function runStreamCron(
         cron,
         event: 'stream_lifecycle_completed',
         summary,
-        egressObserved: summary.egressObserved,
-        egressUnobserved: summary.egressUnobserved,
         durationMs: Date.now() - startedAt,
       })
     );

--- a/web/cron/src/stream.ts
+++ b/web/cron/src/stream.ts
@@ -18,6 +18,8 @@ export interface StreamCronEnv {
   MEDIAMTX_INGRESS_API_TOKEN?: string;
   MEDIAMTX_EGRESS_API_URL?: string;
   MEDIAMTX_EGRESS_API_TOKEN?: string;
+  /** origin を含む全 read egress の Control API URL（カンマ区切り）。 */
+  MEDIAMTX_READ_EGRESS_API_URLS?: string;
   STREAM_NO_VIEWER_SECONDS?: string;
   STREAM_HEARTBEAT_SECONDS?: string;
 }
@@ -37,11 +39,13 @@ export async function runStreamCron(
       ingressApiToken: env.MEDIAMTX_INGRESS_API_TOKEN,
       egressApiUrl: env.MEDIAMTX_EGRESS_API_URL,
       egressApiToken: env.MEDIAMTX_EGRESS_API_TOKEN,
+      readEgressApiUrls: env.MEDIAMTX_READ_EGRESS_API_URLS,
     });
     const summary = await runStreamLifecycle({
       database: env.DB,
       ingressMediaMtx: mediaMtx?.ingress,
       egressMediaMtx: mediaMtx?.egress,
+      egressMediaMtxs: mediaMtx?.egresses,
       now: new Date(scheduledTime),
       settings: {
         noViewerTimeoutSeconds: positiveInt(
@@ -63,6 +67,8 @@ export async function runStreamCron(
         cron,
         event: 'stream_lifecycle_completed',
         summary,
+        egressObserved: summary.egressObserved,
+        egressUnobserved: summary.egressUnobserved,
         durationMs: Date.now() - startedAt,
       })
     );

--- a/web/cron/wrangler.jsonc
+++ b/web/cron/wrangler.jsonc
@@ -36,7 +36,9 @@
     "STREAM_NO_VIEWER_SECONDS": "600",
     "STREAM_HEARTBEAT_SECONDS": "60",
     "MEDIAMTX_INGRESS_API_URL": "https://stream.web-screen.net",
-    "MEDIAMTX_EGRESS_API_URL": "https://stream.web-screen.net"
+    "MEDIAMTX_EGRESS_API_URL": "https://stream.web-screen.net",
+    // origin を含む全 read egress。2 台目追加時はカンマ区切りで URL を増やす。
+    "MEDIAMTX_READ_EGRESS_API_URLS": "https://stream.web-screen.net"
   },
   "d1_databases": [
     {

--- a/web/src/lib/services/stream-lifecycle.ts
+++ b/web/src/lib/services/stream-lifecycle.ts
@@ -124,12 +124,28 @@ async function collectEgressSnapshots(
       // 旧単一 endpoint は ingress の同じ snapshot を再利用し、余計な API 呼び出しをしない。
       const paths = egress === ingress ? ingressPaths : await egress.listPaths();
       snapshots.push(new Map(paths.map((path) => [path.name, path])));
-    } catch {
-      // read node の一時障害は D1 の期限判定を止めない。件数は summary で必ず記録する。
+    } catch (error) {
+      // read node の一時障害は D1 の期限判定を止めない。件数は summary、種別はログに必ず残す。
       failures += 1;
+      logEgressSnapshotFailure(error);
     }
   }
   return { paths: snapshots, failures };
+}
+
+/** 取得失敗の種別だけを 1 行 JSON で残す（URL・token・message は出さない）。 */
+function logEgressSnapshotFailure(error: unknown): void {
+  console.warn(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      source: 'webscreen-beta-cron',
+      severity: 'warn',
+      kind: 'event',
+      event: 'read_egress_snapshot_failed',
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+      summary: 'read egress listPaths failed; no_viewers and kick_pending clearing are deferred this run.',
+    })
+  );
 }
 
 async function applyViewerChecks(

--- a/web/src/lib/services/stream-lifecycle.ts
+++ b/web/src/lib/services/stream-lifecycle.ts
@@ -21,6 +21,8 @@ export interface StreamLifecycleSummary {
   endedByHeartbeatLost: number;
   endedByNoViewers: number;
   viewersObserved: number;
+  egressObserved: number;
+  egressUnobserved: number;
   publishersKicked: number;
   kickPendingCleared: number;
 }
@@ -41,6 +43,7 @@ export async function runStreamLifecycle(input: {
   mediaMtx?: MediaMtxClient;
   ingressMediaMtx?: MediaMtxClient;
   egressMediaMtx?: MediaMtxClient;
+  egressMediaMtxs?: MediaMtxClient[];
   settings: StreamLifecycleSettings;
   now: Date;
 }): Promise<StreamLifecycleSummary> {
@@ -88,15 +91,45 @@ export async function runStreamLifecycle(input: {
   if (!mediaMtx) throw new Error('MediaMTX configuration is required for active streams');
 
   const ingressPaths = await mediaMtx.ingress.listPaths();
-  const egressPaths =
-    mediaMtx.egress === mediaMtx.ingress
-      ? ingressPaths
-      : await mediaMtx.egress.listPaths();
   const ingressByName = new Map(ingressPaths.map((path) => [path.name, path]));
-  const egressByName = new Map(egressPaths.map((path) => [path.name, path]));
-  await applyViewerChecks(input, rowsAfterD1Checks, egressByName, summary, newlyEnded);
-  await processPendingKicks(input, mediaMtx.ingress, ingressByName, egressByName, newlyEnded, summary);
+  const egressSnapshots = await collectEgressSnapshots(
+    mediaMtx.egresses,
+    mediaMtx.ingress,
+    ingressPaths
+  );
+  summary.egressObserved = egressSnapshots.paths.length;
+  summary.egressUnobserved = egressSnapshots.failures;
+  await applyViewerChecks(input, rowsAfterD1Checks, egressSnapshots.paths, summary, newlyEnded);
+  await processPendingKicks(
+    input,
+    mediaMtx.ingress,
+    ingressByName,
+    egressSnapshots.paths,
+    summary.egressUnobserved,
+    newlyEnded,
+    summary
+  );
   return summary;
+}
+
+async function collectEgressSnapshots(
+  egresses: MediaMtxClient[],
+  ingress: MediaMtxClient,
+  ingressPaths: MediaPath[]
+): Promise<{ paths: Array<Map<string, MediaPath>>; failures: number }> {
+  const snapshots: Array<Map<string, MediaPath>> = [];
+  let failures = 0;
+  for (const egress of egresses) {
+    try {
+      // 旧単一 endpoint は ingress の同じ snapshot を再利用し、余計な API 呼び出しをしない。
+      const paths = egress === ingress ? ingressPaths : await egress.listPaths();
+      snapshots.push(new Map(paths.map((path) => [path.name, path])));
+    } catch {
+      // read node の一時障害は D1 の期限判定を止めない。件数は summary で必ず記録する。
+      failures += 1;
+    }
+  }
+  return { paths: snapshots, failures };
 }
 
 async function applyViewerChecks(
@@ -106,7 +139,7 @@ async function applyViewerChecks(
     now: Date;
   },
   rows: LifecycleRow[],
-  paths: Map<string, MediaPath>,
+  snapshots: Array<Map<string, MediaPath>>,
   summary: StreamLifecycleSummary,
   newlyEnded: Set<string>
 ): Promise<void> {
@@ -116,8 +149,8 @@ async function applyViewerChecks(
   ).toISOString();
   for (const row of rows) {
     if (row.status !== 'live') continue;
-    const path = paths.get(`live/${row.id}`);
-    if ((path?.rtspReaders ?? 0) > 0) {
+    const pathName = `live/${row.id}`;
+    if (totalRtspReaders(snapshots, pathName) > 0) {
       const result = await input.database
         .prepare(
           `UPDATE stream_sessions SET last_viewer_at = ?
@@ -128,6 +161,8 @@ async function applyViewerChecks(
       summary.viewersObserved += result.meta.changes;
       continue;
     }
+    // どれか 1 台でも未観測なら reader 0 を確定できないため、no_viewers を延期する。
+    if (summary.egressUnobserved > 0) continue;
     if (row.last_viewer_at > viewerCutoff) continue;
     const ended = await endStream(
       input.database,
@@ -146,7 +181,8 @@ async function processPendingKicks(
   },
   ingress: MediaMtxClient,
   ingressPaths: Map<string, MediaPath>,
-  egressPaths: Map<string, MediaPath>,
+  egressSnapshots: Array<Map<string, MediaPath>>,
+  egressUnobserved: number,
   newlyEnded: Set<string>,
   summary: StreamLifecycleSummary
 ): Promise<void> {
@@ -164,7 +200,14 @@ async function processPendingKicks(
       summary.publishersKicked += 1;
       continue;
     }
-    if (newlyEnded.has(row.id) || ingressPath || egressPaths.has(pathName)) continue;
+    if (
+      newlyEnded.has(row.id) ||
+      ingressPath ||
+      egressUnobserved > 0 ||
+      egressSnapshots.some((paths) => paths.has(pathName))
+    ) {
+      continue;
+    }
     const cleared = await input.database
       .prepare(
         `UPDATE stream_sessions SET kick_pending = 0
@@ -180,12 +223,20 @@ function resolveMediaMtx(input: {
   mediaMtx?: MediaMtxClient;
   ingressMediaMtx?: MediaMtxClient;
   egressMediaMtx?: MediaMtxClient;
-}): { ingress: MediaMtxClient; egress: MediaMtxClient } | undefined {
-  if (input.ingressMediaMtx && input.egressMediaMtx) {
-    return { ingress: input.ingressMediaMtx, egress: input.egressMediaMtx };
+  egressMediaMtxs?: MediaMtxClient[];
+}): { ingress: MediaMtxClient; egresses: MediaMtxClient[] } | undefined {
+  if (input.ingressMediaMtx && (input.egressMediaMtx || input.egressMediaMtxs)) {
+    return {
+      ingress: input.ingressMediaMtx,
+      egresses: input.egressMediaMtxs ?? [input.egressMediaMtx as MediaMtxClient],
+    };
   }
-  if (input.mediaMtx) return { ingress: input.mediaMtx, egress: input.mediaMtx };
+  if (input.mediaMtx) return { ingress: input.mediaMtx, egresses: [input.mediaMtx] };
   return undefined;
+}
+
+function totalRtspReaders(snapshots: Array<Map<string, MediaPath>>, pathName: string): number {
+  return snapshots.reduce((total, paths) => total + (paths.get(pathName)?.rtspReaders ?? 0), 0);
 }
 
 async function endStream(
@@ -235,6 +286,8 @@ function emptySummary(): StreamLifecycleSummary {
     endedByHeartbeatLost: 0,
     endedByNoViewers: 0,
     viewersObserved: 0,
+    egressObserved: 0,
+    egressUnobserved: 0,
     publishersKicked: 0,
     kickPendingCleared: 0,
   };

--- a/web/src/lib/services/stream-media.ts
+++ b/web/src/lib/services/stream-media.ts
@@ -10,7 +10,10 @@ export function createStreamMediaMtxClient(config: {
 
 export interface StreamMediaMtxClients {
   ingress: MediaMtxClient;
+  /** origin egress。health API はこの client だけを使う。 */
   egress: MediaMtxClient;
+  /** viewer 判定で観測する origin を含むすべての read egress。 */
+  egresses: MediaMtxClient[];
 }
 
 export interface StreamMediaMtxSettings {
@@ -20,9 +23,10 @@ export interface StreamMediaMtxSettings {
   ingressApiToken?: string;
   egressApiUrl?: string;
   egressApiToken?: string;
+  readEgressApiUrls?: string;
 }
 
-/** ingress / egress 優先、旧単一 Control API をfallbackにして client を組み立てる。 */
+/** ingress / read egress 優先、旧単一 Control API をfallbackにして client を組み立てる。 */
 export function createStreamMediaMtxClients(
   settings: StreamMediaMtxSettings,
   createClient: (config: { apiUrl: string; apiToken: string }) => MediaMtxClient =
@@ -32,17 +36,42 @@ export function createStreamMediaMtxClients(
     settings.ingressApiUrl ||
       settings.ingressApiToken ||
       settings.egressApiUrl ||
-      settings.egressApiToken
+      settings.egressApiToken ||
+      settings.readEgressApiUrls
   );
   if (usesSplitEndpoints) {
+    const ingress = createEndpoint(
+      settings.ingressApiUrl,
+      settings.ingressApiToken,
+      'INGRESS',
+      createClient
+    );
+    const egresses = settings.readEgressApiUrls
+      ? createReadEgresses(settings.readEgressApiUrls, settings.egressApiToken, createClient)
+      : [createEndpoint(settings.egressApiUrl, settings.egressApiToken, 'EGRESS', createClient)];
     return {
-      ingress: createEndpoint(settings.ingressApiUrl, settings.ingressApiToken, 'INGRESS', createClient),
-      egress: createEndpoint(settings.egressApiUrl, settings.egressApiToken, 'EGRESS', createClient),
+      ingress,
+      egress: egresses[0] as MediaMtxClient,
+      egresses,
     };
   }
   if (!settings.legacyApiUrl && !settings.legacyApiToken) return undefined;
   const legacy = createEndpoint(settings.legacyApiUrl, settings.legacyApiToken, 'legacy', createClient);
-  return { ingress: legacy, egress: legacy };
+  return { ingress: legacy, egress: legacy, egresses: [legacy] };
+}
+
+function createReadEgresses(
+  value: string,
+  apiToken: string | undefined,
+  createClient: (config: { apiUrl: string; apiToken: string }) => MediaMtxClient
+): MediaMtxClient[] {
+  const apiUrls = value.split(',').map((apiUrl) => apiUrl.trim());
+  if (apiUrls.length === 0 || apiUrls.some((apiUrl) => apiUrl.length === 0)) {
+    throw new Error('MEDIAMTX_READ_EGRESS_API_URLS must contain one or more URLs');
+  }
+  return [...new Set(apiUrls)].map((apiUrl) =>
+    createEndpoint(apiUrl, apiToken, 'READ_EGRESS', createClient)
+  );
 }
 
 function createEndpoint(

--- a/web/src/lib/services/stream-media.ts
+++ b/web/src/lib/services/stream-media.ts
@@ -46,32 +46,34 @@ export function createStreamMediaMtxClients(
       'INGRESS',
       createClient
     );
-    const egresses = settings.readEgressApiUrls
-      ? createReadEgresses(settings.readEgressApiUrls, settings.egressApiToken, createClient)
-      : [createEndpoint(settings.egressApiUrl, settings.egressApiToken, 'EGRESS', createClient)];
-    return {
-      ingress,
-      egress: egresses[0] as MediaMtxClient,
-      egresses,
-    };
+    // origin egress は MEDIAMTX_EGRESS_API_URL が正。read 一覧はそれに replica を足したもので、
+    // 一覧だけが設定された場合のみ先頭を origin と見なす（health API が replica を見る誤配線を防ぐ）。
+    const readApiUrls = settings.readEgressApiUrls
+      ? parseReadEgressApiUrls(settings.readEgressApiUrls)
+      : [];
+    const originApiUrl = settings.egressApiUrl ?? readApiUrls[0];
+    const egress = createEndpoint(originApiUrl, settings.egressApiToken, 'EGRESS', createClient);
+    const egresses = [
+      egress,
+      ...readApiUrls
+        .filter((apiUrl) => apiUrl !== originApiUrl)
+        .map((apiUrl) => createEndpoint(apiUrl, settings.egressApiToken, 'READ_EGRESS', createClient)),
+    ];
+    return { ingress, egress, egresses };
   }
   if (!settings.legacyApiUrl && !settings.legacyApiToken) return undefined;
   const legacy = createEndpoint(settings.legacyApiUrl, settings.legacyApiToken, 'legacy', createClient);
   return { ingress: legacy, egress: legacy, egresses: [legacy] };
 }
 
-function createReadEgresses(
-  value: string,
-  apiToken: string | undefined,
-  createClient: (config: { apiUrl: string; apiToken: string }) => MediaMtxClient
-): MediaMtxClient[] {
-  const apiUrls = value.split(',').map((apiUrl) => apiUrl.trim());
-  if (apiUrls.length === 0 || apiUrls.some((apiUrl) => apiUrl.length === 0)) {
-    throw new Error('MEDIAMTX_READ_EGRESS_API_URLS must contain one or more URLs');
+/** カンマ区切りの read egress URL を、空要素（末尾カンマ等）を拒否して重複なしで返す。 */
+function parseReadEgressApiUrls(value: string): string[] {
+  const apiUrls = value.split(',').map((apiUrl) => apiUrl.trim().replace(/\/+$/, ''));
+  const emptyIndex = apiUrls.findIndex((apiUrl) => apiUrl.length === 0);
+  if (emptyIndex !== -1) {
+    throw new Error(`MEDIAMTX_READ_EGRESS_API_URLS has an empty entry at index ${emptyIndex}`);
   }
-  return [...new Set(apiUrls)].map((apiUrl) =>
-    createEndpoint(apiUrl, apiToken, 'READ_EGRESS', createClient)
-  );
+  return [...new Set(apiUrls)];
 }
 
 function createEndpoint(

--- a/web/tests/cron/stream-worker.test.ts
+++ b/web/tests/cron/stream-worker.test.ts
@@ -28,9 +28,11 @@ describe('配信 lifecycle cron の振り分け', () => {
     expect(logs[0]).toMatchObject({
       event: 'stream_lifecycle_completed',
       severity: 'info',
+    });
+    expect(logs[0]?.['summary']).toMatchObject({
+      deletedStartCancellations: 0,
       egressObserved: 0,
       egressUnobserved: 0,
     });
-    expect(logs[0]?.['summary']).toMatchObject({ deletedStartCancellations: 0 });
   });
 });

--- a/web/tests/cron/stream-worker.test.ts
+++ b/web/tests/cron/stream-worker.test.ts
@@ -25,7 +25,12 @@ describe('配信 lifecycle cron の振り分け', () => {
     }
 
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toMatchObject({ event: 'stream_lifecycle_completed', severity: 'info' });
+    expect(logs[0]).toMatchObject({
+      event: 'stream_lifecycle_completed',
+      severity: 'info',
+      egressObserved: 0,
+      egressUnobserved: 0,
+    });
     expect(logs[0]?.['summary']).toMatchObject({ deletedStartCancellations: 0 });
   });
 });

--- a/web/tests/services/stream-lifecycle.test.ts
+++ b/web/tests/services/stream-lifecycle.test.ts
@@ -214,6 +214,72 @@ describe('配信セッション lifecycle', () => {
     expect(row(second)).toMatchObject({ status: 'live', last_viewer_at: NOW.toISOString() });
   });
 
+  it('replicaだけのRTSP readerも合計してviewer猶予を更新する', async () => {
+    const database = await createStreamDatabase();
+    await insertLive(database, {
+      extendAt: '2026-09-01T04:00:00.000Z',
+      viewerAt: '2026-09-01T01:50:00.000Z',
+    });
+    const summary = await runStreamLifecycle({
+      database,
+      ingressMediaMtx: new FakeMediaMtx(),
+      egressMediaMtxs: [
+        new FakeMediaMtx(),
+        new FakeMediaMtx([{ name: 'live/AbCdEf123456', publisherId: null, rtspReaders: 1 }]),
+      ],
+      settings: SETTINGS,
+      now: NOW,
+    });
+
+    expect(row(database)).toMatchObject({ status: 'live', last_viewer_at: NOW.toISOString() });
+    expect(summary).toMatchObject({ viewersObserved: 1, egressObserved: 2, egressUnobserved: 0 });
+  });
+
+  it('read egressが未観測の回はno_viewersを発火せず件数を残す', async () => {
+    const database = await createStreamDatabase();
+    await insertLive(database, {
+      extendAt: '2026-09-01T04:00:00.000Z',
+      viewerAt: '2026-09-01T01:50:00.000Z',
+    });
+    const summary = await runStreamLifecycle({
+      database,
+      ingressMediaMtx: new FakeMediaMtx(),
+      egressMediaMtxs: [new FakeMediaMtx(), new FakeMediaMtx([], new Error('replica unavailable'))],
+      settings: SETTINGS,
+      now: NOW,
+    });
+
+    expect(row(database)).toMatchObject({ status: 'live' });
+    expect(summary).toMatchObject({ endedByNoViewers: 0, egressObserved: 1, egressUnobserved: 1 });
+  });
+
+  it('read egressが未観測でもextendとheartbeatのD1停止判定は続ける', async () => {
+    const extendDatabase = await createStreamDatabase();
+    await insertLive(extendDatabase, { extendAt: NOW.toISOString() });
+    const heartbeatDatabase = await createStreamDatabase();
+    await insertLive(heartbeatDatabase, {
+      extendAt: '2026-09-01T04:00:00.000Z',
+      heartbeatAt: '2026-09-01T01:59:00.000Z',
+    });
+    const input = (database: StreamSqliteAdapter) => ({
+      database,
+      ingressMediaMtx: new FakeMediaMtx(),
+      egressMediaMtxs: [new FakeMediaMtx([], new Error('replica unavailable'))],
+      settings: SETTINGS,
+      now: NOW,
+    });
+
+    const [extendSummary, heartbeatSummary] = await Promise.all([
+      runStreamLifecycle(input(extendDatabase)),
+      runStreamLifecycle(input(heartbeatDatabase)),
+    ]);
+
+    expect(row(extendDatabase)).toMatchObject({ status: 'ended', end_reason: 'extend_timeout' });
+    expect(extendSummary).toMatchObject({ endedByExtendTimeout: 1, egressUnobserved: 1 });
+    expect(row(heartbeatDatabase)).toMatchObject({ status: 'ended', end_reason: 'heartbeat_lost' });
+    expect(heartbeatSummary).toMatchObject({ endedByHeartbeatLost: 1, egressUnobserved: 1 });
+  });
+
   it('ingressをkickした次のcronでegress path不在を確認してからpendingを解除する', async () => {
     const database = await createStreamDatabase();
     await insertLive(database, { extendAt: '2026-09-01T04:00:00.000Z' });
@@ -246,6 +312,27 @@ describe('配信セッション lifecycle', () => {
       now: NOW,
     });
     expect(row(database).kick_pending).toBe(0);
+  });
+
+  it('全read egressのどれかにpathが残る間はkick_pendingを解除しない', async () => {
+    const database = await createStreamDatabase();
+    await insertLive(database, { extendAt: '2026-09-01T04:00:00.000Z' });
+    database.sqlite
+      .query("UPDATE stream_sessions SET status='ended', ended_at=?, end_reason='user_stop', kick_pending=1")
+      .run(NOW.toISOString());
+
+    await runStreamLifecycle({
+      database,
+      ingressMediaMtx: new FakeMediaMtx(),
+      egressMediaMtxs: [
+        new FakeMediaMtx(),
+        new FakeMediaMtx([{ name: 'live/AbCdEf123456', publisherId: null, rtspReaders: 1 }]),
+      ],
+      settings: SETTINGS,
+      now: NOW,
+    });
+
+    expect(row(database).kick_pending).toBe(1);
   });
 
   it('閾値を30秒へ変更するとreaderゼロ30秒で終了する', async () => {

--- a/web/tests/services/stream-lifecycle.test.ts
+++ b/web/tests/services/stream-lifecycle.test.ts
@@ -335,6 +335,26 @@ describe('配信セッション lifecycle', () => {
     expect(row(database).kick_pending).toBe(1);
   });
 
+  it('read egressの取得に失敗した回はkick_pendingを解除しない', async () => {
+    const database = await createStreamDatabase();
+    await insertLive(database, { extendAt: '2026-09-01T04:00:00.000Z' });
+    database.sqlite
+      .query("UPDATE stream_sessions SET status='ended', ended_at=?, end_reason='user_stop', kick_pending=1")
+      .run(NOW.toISOString());
+
+    const summary = await runStreamLifecycle({
+      database,
+      ingressMediaMtx: new FakeMediaMtx(),
+      egressMediaMtxs: [new FakeMediaMtx(), new FakeMediaMtx([], new Error('unreachable'))],
+      settings: SETTINGS,
+      now: NOW,
+    });
+
+    expect(summary.egressUnobserved).toBe(1);
+    expect(summary.kickPendingCleared).toBe(0);
+    expect(row(database).kick_pending).toBe(1);
+  });
+
   it('閾値を30秒へ変更するとreaderゼロ30秒で終了する', async () => {
     const database = await createStreamDatabase();
     await insertLive(database, {

--- a/web/tests/services/stream-media.test.ts
+++ b/web/tests/services/stream-media.test.ts
@@ -29,7 +29,32 @@ describe('MediaMTX endpoint wiring', () => {
       }
     );
     expect(clients?.ingress).not.toBe(clients?.egress);
+    expect(clients?.egresses).toHaveLength(1);
     expect(configured).toEqual(['https://ingress.example', 'https://egress.example']);
+  });
+
+  it('read egress一覧を個別clientへ展開し、先頭をorigin egressとして返す', () => {
+    const configured: string[] = [];
+    const clients = createStreamMediaMtxClients(
+      {
+        ingressApiUrl: 'https://ingress.example',
+        ingressApiToken: 'ingress-token',
+        egressApiToken: 'egress-token',
+        readEgressApiUrls: 'https://origin.example, https://replica.example',
+      },
+      (config) => {
+        configured.push(config.apiUrl);
+        return fakeClient();
+      }
+    );
+
+    expect(clients?.egress).toBe(clients?.egresses[0]);
+    expect(clients?.egresses).toHaveLength(2);
+    expect(configured).toEqual([
+      'https://ingress.example',
+      'https://origin.example',
+      'https://replica.example',
+    ]);
   });
 
   it('split endpointが未設定なら旧単一endpointを両roleへ互換利用する', () => {
@@ -38,5 +63,7 @@ describe('MediaMTX endpoint wiring', () => {
       () => fakeClient()
     );
     expect(clients?.ingress).toBe(clients?.egress);
+    expect(clients?.egresses).toHaveLength(1);
+    expect(clients?.egresses[0]).toBe(clients?.egress);
   });
 });

--- a/web/tests/services/stream-media.test.ts
+++ b/web/tests/services/stream-media.test.ts
@@ -57,6 +57,45 @@ describe('MediaMTX endpoint wiring', () => {
     ]);
   });
 
+  it('MEDIAMTX_EGRESS_API_URL があれば read 一覧の順序に関わらず origin egress として優先し重複を除く', () => {
+    const configured: string[] = [];
+    const clients = createStreamMediaMtxClients(
+      {
+        ingressApiUrl: 'https://ingress.example',
+        ingressApiToken: 'ingress-token',
+        egressApiUrl: 'https://origin.example',
+        egressApiToken: 'egress-token',
+        readEgressApiUrls: 'https://replica.example, https://origin.example/',
+      },
+      (config) => {
+        configured.push(config.apiUrl);
+        return fakeClient();
+      }
+    );
+
+    expect(clients?.egress).toBe(clients?.egresses[0]);
+    expect(clients?.egresses).toHaveLength(2);
+    expect(configured).toEqual([
+      'https://ingress.example',
+      'https://origin.example',
+      'https://replica.example',
+    ]);
+  });
+
+  it('read 一覧の空要素（末尾カンマ）は位置付きで拒否する', () => {
+    expect(() =>
+      createStreamMediaMtxClients(
+        {
+          ingressApiUrl: 'https://ingress.example',
+          ingressApiToken: 'ingress-token',
+          egressApiToken: 'egress-token',
+          readEgressApiUrls: 'https://origin.example,',
+        },
+        () => fakeClient()
+      )
+    ).toThrow('empty entry at index 1');
+  });
+
   it('split endpointが未設定なら旧単一endpointを両roleへ互換利用する', () => {
     const clients = createStreamMediaMtxClients(
       { legacyApiUrl: 'https://legacy.example', legacyApiToken: 'legacy-token' },


### PR DESCRIPTION
## なぜこの変更が必要か

配信サーバーを origin 1 + read replica N の 2 台構成にする（docs/streaming/scale-plan.md M1、milestone「配信サーバーを origin 1 + replica 1 の 2 台構成にする」）。
replica を足すと、視聴者が replica 側に居ても origin の egress では reader が 0 に見え、cron が 10 分で `no_viewers` として配信を誤終了する。
cron の viewer 判定を「全 read egress の reader 合計」にし、観測できなかった回は終了判定を見送る。

Closes #222

## 変更内容

- cron env `MEDIAMTX_READ_EGRESS_API_URLS`（カンマ区切り。origin を含む全 read egress の Control API URL、token は既存 `MEDIAMTX_EGRESS_API_TOKEN` を共有）を追加。未設定なら従来の単一 egress、legacy 単一 endpoint も維持
- `runStreamLifecycle` が各 read egress を 1 回ずつ `listPaths()` し、path ごとに `rtspReaders` を合計して `last_viewer_at` を更新
- 1 台でも取得に失敗した回は `no_viewers` 終了と `kick_pending` 解除を見送り、`egressObserved` / `egressUnobserved` を summary と構造化ログに出す。heartbeat / extend の D1 判定は従来どおり
- publisher kick は origin ingress のみ（変更なし）。health API は origin egress のみ（変更なし）
- `web/cron/wrangler.jsonc` に本番値（現行 egress 1 本）、docs/streaming/operations.md の cron 節に env の意味を追記

## 意思決定

### 採用アプローチ
- 観測失敗を「reader 0」と読まない（fail-safe 側）。API 障害だけで実配信を切るリスクの方が、終了が 1 分遅れるより高い。失敗は握り潰さず件数をログに残す
- token は role 別共有。ノードが動的になると per-node secret を Worker で持てないため（scale-plan.md）

### 却下した代替案
- D1 `media_nodes` から read ノード一覧を引く → 却下: origin 1 台の間は env で足りる（M3 で移行）

## テスト

- [x] `make check`（typecheck / test / build）
- [x] ユニット: replica にだけ reader が居る path の `last_viewer_at` 更新 / 1 台取得失敗時の `no_viewers` 見送り / 同回の extend_timeout・heartbeat_lost 継続 / `kick_pending` 維持 / legacy・未設定互換
- [x] ローカルレビューゲート（codex sol が API 404 のため Opus code-reviewer + security-checker にフォールバック）: 対応表を PR コメントに投稿
- [ ] 本番デプロイ後: operations.md の手順（heartbeat 失効の合成 live 行）で cron が 1〜2 分で `heartbeat_lost` にすることを確認（デプロイ後に実施）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgdhLGJGrkEdn98UXLgYac
