### PR TITLE
test: R2権限エラーの再現契約を追加

### DIFF
--- a/docs/r2-delivery.md
+++ b/docs/r2-delivery.md
@@ -25,6 +25,7 @@ WebScreen では VRChat のワールド内で複数人が同時に同じ動画�
 | R2 Custom Domain | ダッシュボード | バケット `webscreen` に `cdn.web-screen.net` を接続（Active） |
 | Transform Rule `cdn: noindex for media` | ダッシュボード | `http.host eq "cdn.web-screen.net"` のとき `X-Robots-Tag: noindex` を付与 |
 | **R2 の CORS** | **`web/r2-cors.json`** | 下記「CORS」節 |
+| R2 S3 API credentials | ダッシュボード + Worker secrets | Object Read & Write、対象バケット `webscreen`。`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` を同一 token の組で管理 |
 
 ダッシュボード管理のものは変更したらこの表も更新すること。
 
@@ -46,6 +47,24 @@ bunx wrangler r2 bucket cors list webscreen   # 確認
 **サイトのオリジンが増減したら必ずここも直す。** 2026-08-27 の本番ドメイン切替では、`https://web-screen.net` の登録漏れで変換が全滅した（`presign` は 200 を返すのに R2 への PUT だけが CORS エラーになるため、原因が分かりにくい）。
 
 `AllowedMethods` に `PUT` が要るのはアップロードのため、`GET` / `HEAD` は動画再生のため。`ExposeHeaders` の `ETag` はアップロード完了の検証に使う。
+
+### CORS に見える R2 API 権限エラー
+
+署名 URL を作る `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` は、対象バケット `webscreen` に対する **Object Read & Write** 権限が必要。対象バケットを限定した token を使う場合は、許可対象に `webscreen` が含まれていることも確認する。CORS と S3 API 権限は別の設定で、CORS が正しくても token に書き込み権限が無ければ署名付き PUT は 403 になる。
+
+R2 が 403 応答へ `Access-Control-Allow-Origin` を付けない場合、ブラウザは応答本文と元の status を JavaScript へ渡さない。画面側では `TypeError: Failed to fetch`、Console では `No 'Access-Control-Allow-Origin' header` と見えるため、表示だけでは「CORS 設定不足」と「署名・権限エラー」を区別できない。2026-09-04 の本番障害は後者で、R2 API token の対象バケット書き込み権限不足だった。
+
+切り分けは次の順序で行う。
+
+1. `wrangler r2 bucket cors list webscreen` で、`https://web-screen.net`、`PUT`、`Content-Type` が許可されていることを確認する。
+2. ブラウザの Network で署名付き PUT 自体を確認する。unsigned `OPTIONS` の成功だけでは、署名と Object Write 権限は検証できない。
+3. Cloudflare の R2 API token 管理画面で、設定中の access key に Object Read & Write と対象バケット `webscreen` が付いていることを確認する。秘密値はログや Issue に貼らない。
+4. token を作り直した場合は、同一 token の `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` を同じ入力から `wrangler secret bulk` で一括更新し、その後 Worker を再デプロイする。秘密値をコマンド引数、git 管理ファイル、ログへ載せない。
+5. ログイン済み画面で実ファイルを変換し、署名付き PUT の成功、`/api/uploads/commit/` の成功、公開プレビューへの遷移を一続きで確認する。
+
+権限確認では実際の署名付き PUT まで通すこと。CORS の一覧と preflight だけを見て復旧扱いにしない。
+
+ローカル E2E は deploy CI のゲートではなく、「別オリジンの 403 応答がブラウザでは CORS 失敗として隠れる」画面契約と、200 応答時の変換フローを固定するもので、Cloudflare 上の token 権限や実署名を検査しない。権限事故の再発検出・復旧判定には、本番と同じ R2 API 資格情報で発行した署名 URL への実 PUT smoke が必要。資格情報を CI に追加して自動化する場合は秘密値の保管・最小権限・probe object の確実な削除を別途設計し、今回は手動 smoke とする。
 
 `X-Robots-Tag` は、プレビューページの `noindex` メタタグだけでは防げない「動画ファイル本体がクローラに直接収集される」経路を塞ぐためのもの（HTML の noindex はその HTML を検索結果から外すだけで、`<video src>` の先には効かない）。
 

--- a/web/.dev.vars.example
+++ b/web/.dev.vars.example
@@ -5,6 +5,11 @@ DISCORD_CLIENT_SECRET=your_discord_client_secret
 # ws_session / ws_oauth_state の HMAC-SHA256 署名鍵
 SESSION_SIGNING_KEY=replace_with_a_long_random_value
 
+# R2 S3 API 署名用。通常の mock E2E では不要なので空のままにする。
+# 本番値をこの git 管理ファイルやローカル開発用ファイルへコピーしない。
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+
 # MediaMTX publish JWT の RS256 秘密鍵（PKCS#8 DER を base64 化した値）。
 # 生成例: openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 | \
 #   openssl pkcs8 -topk8 -nocrypt -outform DER | openssl base64 -A

--- a/web/e2e/upload-cors.spec.ts
+++ b/web/e2e/upload-cors.spec.ts
@@ -1,0 +1,204 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { expect, test, type Page } from '@playwright/test';
+
+import { E2E_FIXTURES } from '../playwright.config';
+
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+interface UploadObservation {
+  preflightHeaders: Readonly<Record<string, string | string[] | undefined>>[];
+  putContentTypes: string[];
+  putBodies: Buffer[];
+  putStatuses: number[];
+}
+
+interface UploadServer {
+  readonly observation: UploadObservation;
+  readonly uploadUrl: string;
+  allowOrigin(origin: string): void;
+  close(): Promise<void>;
+}
+
+function writeCorsHeaders(response: ServerResponse, allowedOrigin: string | null): void {
+  if (allowedOrigin === null) return;
+  response.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+  response.setHeader('Access-Control-Allow-Methods', 'PUT');
+  response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  response.setHeader('Access-Control-Expose-Headers', 'ETag');
+}
+
+function handleUpload(
+  request: IncomingMessage,
+  response: ServerResponse,
+  observation: UploadObservation,
+  allowedOrigin: string | null,
+  putStatus: 200 | 403
+): void {
+  if (request.method === 'OPTIONS') {
+    observation.preflightHeaders.push({ ...request.headers });
+    writeCorsHeaders(response, allowedOrigin);
+    response.writeHead(204).end();
+    return;
+  }
+  if (request.method !== 'PUT') {
+    response.writeHead(404).end();
+    return;
+  }
+
+  const chunks: Buffer[] = [];
+  request.on('data', (chunk: Buffer) => chunks.push(chunk));
+  request.on('end', () => {
+    observation.putContentTypes.push(request.headers['content-type'] ?? '');
+    observation.putBodies.push(Buffer.concat(chunks));
+    observation.putStatuses.push(putStatus);
+    if (putStatus === 200) writeCorsHeaders(response, allowedOrigin);
+    response.setHeader('ETag', '"e2e-upload"');
+    response.writeHead(putStatus).end();
+  });
+}
+
+async function startUploadServer(putStatus: 200 | 403): Promise<UploadServer> {
+  let allowedOrigin: string | null = null;
+  const observation: UploadObservation = {
+    preflightHeaders: [],
+    putContentTypes: [],
+    putBodies: [],
+    putStatuses: [],
+  };
+  const server: Server = createServer((request, response) => {
+    handleUpload(request, response, observation, allowedOrigin, putStatus);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+
+  return {
+    observation,
+    uploadUrl: `http://127.0.0.1:${address.port}/r2-upload`,
+    allowOrigin(origin: string): void {
+      allowedOrigin = origin;
+    },
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    }),
+  };
+}
+
+async function mockUploadApis(page: Page, uploadUrl: string): Promise<() => Promise<number>> {
+  const shortId = E2E_FIXTURES.readyShortId;
+  const publicUrl = `https://cdn.test/movies/${shortId}.mp4`;
+  await page.addInitScript(({ expectedShortId, expectedUploadUrl, expectedPublicUrl }) => {
+    const browserFetch = window.fetch.bind(window);
+    window.fetch = ((input, init) => {
+      const requestUrl = input instanceof Request ? input.url : String(input);
+      const path = new URL(requestUrl, window.location.href).pathname;
+      if (path === '/api/me/') {
+        return Promise.resolve(Response.json({ name: 'noricha' }));
+      }
+      if (path === '/api/uploads/presign/') {
+        return Promise.resolve(Response.json({
+          shortId: expectedShortId,
+          uploadUrl: expectedUploadUrl,
+          publicUrl: expectedPublicUrl,
+        }));
+      }
+      if (path === '/api/uploads/commit/') {
+        const key = 'e2e:upload-commit-calls';
+        sessionStorage.setItem(key, String(Number(sessionStorage.getItem(key) ?? '0') + 1));
+        return Promise.resolve(Response.json({
+          shortId: expectedShortId,
+          publicUrl: expectedPublicUrl,
+          sizeBytes: 1024,
+          expiresAt: null,
+        }));
+      }
+      if (path === '/api/uploads/abandon/') {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return browserFetch(input, init);
+    }) as typeof window.fetch;
+  }, { expectedShortId: shortId, expectedUploadUrl: uploadUrl, expectedPublicUrl: publicUrl });
+  return () => page.evaluate(() => Number(sessionStorage.getItem('e2e:upload-commit-calls') ?? '0'));
+}
+
+function expectPutPreflight(
+  observation: UploadObservation,
+  origin: string
+): void {
+  expect(observation.preflightHeaders).toHaveLength(1);
+  const headers = observation.preflightHeaders[0];
+  expect(headers?.origin).toBe(origin);
+  expect(headers?.['access-control-request-method']?.toString().toLowerCase()).toBe('put');
+  expect(headers?.['access-control-request-headers']?.toString().toLowerCase()).toContain(
+    'content-type'
+  );
+}
+
+test.describe('別 origin upload 応答の UI 契約', () => {
+  test('ACAO なしの 403 はブラウザの CORS 失敗として扱われ、画面に失敗表示を出す', async ({ page }) => {
+    test.setTimeout(180_000);
+    const upload = await startUploadServer(403);
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+
+    try {
+      const commitCalls = await mockUploadApis(page, upload.uploadUrl);
+      await page.goto('/ja/');
+      const appOrigin = new URL(page.url()).origin;
+      upload.allowOrigin(appOrigin);
+      await page.locator('[data-convert-panel] [data-file-input]').setInputFiles({
+        name: 'first.png',
+        mimeType: 'image/png',
+        buffer: ONE_PIXEL_PNG,
+      });
+
+      await expect(page.locator('[data-convert-panel] [data-file-error]')).toBeVisible();
+      expectPutPreflight(upload.observation, appOrigin);
+      expect(upload.observation.putStatuses).toEqual([403]);
+      expect(upload.observation.putContentTypes).toEqual(['video/mp4']);
+      expect(upload.observation.putBodies[0]?.subarray(4, 8).toString('ascii')).toBe('ftyp');
+      expect(await commitCalls()).toBe(0);
+      expect(
+        consoleErrors.some(
+          (message) => message.includes('conversion failed') && message.includes('TypeError')
+        )
+      ).toBe(true);
+    } finally {
+      await upload.close();
+    }
+  });
+
+  test('ACAO ありの 200 なら複数画像を PUT・commit しプレビューへ進む', async ({ page }) => {
+    test.setTimeout(180_000);
+    const upload = await startUploadServer(200);
+
+    try {
+      const commitCalls = await mockUploadApis(page, upload.uploadUrl);
+      await page.goto('/ja/');
+      const appOrigin = new URL(page.url()).origin;
+      upload.allowOrigin(appOrigin);
+      await page.locator('[data-convert-panel] [data-file-input]').setInputFiles([
+        { name: 'first.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG },
+        { name: 'second.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG },
+      ]);
+
+      await expect(page).toHaveURL(new RegExp(`/${E2E_FIXTURES.readyShortId}/$`), {
+        timeout: 120_000,
+      });
+      await expect(page.locator('[data-preview]')).toBeVisible();
+      expectPutPreflight(upload.observation, appOrigin);
+      expect(upload.observation.putStatuses).toEqual([200]);
+      expect(upload.observation.putContentTypes).toEqual(['video/mp4']);
+      expect(upload.observation.putBodies).toHaveLength(1);
+      expect(upload.observation.putBodies[0]?.subarray(4, 8).toString('ascii')).toBe('ftyp');
+      expect(await commitCalls()).toBe(1);
+    } finally {
+      await upload.close();
+    }
+  });
+});

--- a/web/tests/contracts/r2-upload-config.test.ts
+++ b/web/tests/contracts/r2-upload-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+interface CorsRule {
+  allowed: {
+    origins: string[];
+    methods: string[];
+    headers: string[];
+  };
+}
+
+interface CorsConfig {
+  rules: CorsRule[];
+}
+
+async function corsConfig(): Promise<CorsConfig> {
+  return Bun.file(new URL('../../r2-cors.json', import.meta.url)).json() as Promise<CorsConfig>;
+}
+
+describe('R2 browser upload contract', () => {
+  test('本番 origin から video/mp4 を PUT できる CORS 設定を保持する', async () => {
+    const config = await corsConfig();
+    const productionRule = config.rules.find((rule) =>
+      rule.allowed.origins.includes('https://web-screen.net')
+    );
+
+    expect(productionRule).toBeDefined();
+    expect(productionRule?.allowed.methods).toContain('PUT');
+    expect(productionRule?.allowed.headers.map((header) => header.toLowerCase())).toContain(
+      'content-type'
+    );
+  });
+
+  test('本番 upload origin を wildcard に広げない', async () => {
+    const config = await corsConfig();
+
+    expect(config.rules.flatMap((rule) => rule.allowed.origins)).not.toContain('*');
+  });
+});


### PR DESCRIPTION
## なぜこの変更が必要か

本番の画像変換で、R2 への PUT が失敗してブラウザには CORS エラーとして表示されました。実際の原因は、署名 URL に使う R2 S3 API credentials の対象バケット書き込み権限不足でした。同じ症状を CORS 設定不足と誤診しないため、ブラウザ挙動と運用上の切り分けを固定します。

## 変更内容

- 別 origin が PUT に 403 / ACAO なしを返した際、ブラウザが CORS 失敗として扱い、commit せず画面に失敗表示する E2E を追加
- ACAO あり / 200 の場合、画像2枚を MP4 に変換し、PUT・commit・プレビュー遷移まで成功する E2E を追加
- 本番 origin、PUT、Content-Type、wildcard 禁止を `r2-cors.json` の契約テストで固定
- R2 credentials の Object Read & Write、対象バケット、secret の一括更新、実署名 PUT による復旧確認を文書化
- ローカル設定テンプレートへ R2 署名用キー名を追加（秘密値は含めない）

## 意思決定

- 画像は WASM 変換を完了し、失敗地点は R2 PUT だったため、canvas 再変換や Worker upload fallback は追加しません。
- ローカル E2E は 403 が CORS に隠れる UI 契約を検証します。実 token scope は検査できないため、本番復旧判定は実資格情報による署名付き PUT smoke とします。

## テスト

- [x] Playwright 対象 E2E: 2 passed
- [x] Unit tests: 947 passed
- [x] R2 contract tests: 2 passed
- [x] TypeScript typecheck
- [x] Production build
- [x] `git diff --check`
- [x] code review / security review: 未解決 findings なし

## 本番復旧

R2 S3 API credentials に Object Read & Write と対象バケット `webscreen` を設定する外部変更が本体です。この PR は再現契約と運用手順を追加し、本番ランタイムコードは変更しません。
