### PR TITLE
feat(streaming): read replica ノードの MediaMTX 設定と replica-pull.sh（runOnDemand + 順序付き ORIGINS）を追加する

### DIFF
--- a/web/streaming/README.md
+++ b/web/streaming/README.md
@@ -37,3 +37,43 @@ After A12 passes, the VPS must be ready before any Worker version containing the
 6. Publish one browser stream and confirm ingress and egress bytes both increase. For audio, confirm H.264 + MP3 at 48 kHz stereo with `verify-codecs.sh`.
 
 If a VPS check fails before the Worker deploy, stop the split units and restore the backed-up old unit/config/Caddyfile. If the Worker has already switched to split, roll back the Worker and VPS as one operation; `wrangler rollback` changes only Worker code and does not restore systemd, Caddy, or MediaMTX configuration.
+
+## Read replica node (delta from an origin node)
+
+A read replica serves the same `rtsp://host/live/{id}` paths without running ingress or the relay hook. When a reader hits a path that has no publisher, MediaMTX invokes `replica-pull.sh`, which walks an ordered `ORIGINS` list and pulls one stream with `ffmpeg -c copy` from that origin's egress (`:554`, TCP). If every origin fails the pull exits non-zero and MediaMTX surfaces the failure to the reader (no silent restart).
+
+Install differences from an origin node:
+
+- Configs in `/etc/webscreen/streaming/`: **`mediamtx-egress-replica.yml`** (in place of `mediamtx-egress.yml`); do **not** install `mediamtx-ingress.yml`.
+- Runtime scripts in `/opt/webscreen/streaming/RELEASE/`: **`replica-pull.sh`** in place of `relay.sh`; `audio-profile.sh` and `verify-codecs.sh` are still useful for smoke checks but not sourced by `replica-pull.sh`.
+- Systemd units: enable only **`webscreen-mediamtx-egress-replica.service`**. Do not enable the ingress unit or the original egress unit.
+- Environment file `/etc/webscreen/streaming/replica.env` (root-owned, group `webscreen`, mode `0640`):
+
+  ```sh
+  # Ordered comma-separated `host` or `host:port` entries (default port 554).
+  # The list is walked top-to-bottom on every pull attempt.
+  ORIGINS="origin-a.example,origin-b.example"
+  # Optional: hostnames this replica answers to. If any ORIGINS host matches,
+  # the pull is refused (self-loop guard). Comma-separated, no port.
+  SELF_HOSTS="replica-1.example"
+  ```
+
+- Do **not** include this node's own hostname in `ORIGINS`. The self-loop guard exits `64` if you do, but keep the config correct on the writing side.
+- Publicly open ports on a replica: `22/tcp`, `80/tcp`, `443/tcp` (for the Caddy fronted Control API used by the cron worker), and `554/tcp` (RTSP readers). WHIP (`8189`) is not needed because ingress is not installed.
+- The runtime preflight from the origin section still applies to `replica-pull.sh`:
+
+  ```sh
+  release_dir=/opt/webscreen/streaming/RELEASE
+  test -r "$release_dir/replica-pull.sh"
+  shellcheck "$release_dir/replica-pull.sh" || bash -n "$release_dir/replica-pull.sh"
+  ```
+
+Local smoke check (two MediaMTX processes on one machine):
+
+```sh
+# 1) start an origin egress (mediamtx-egress.yml) on :554 and publish a test stream to it
+# 2) start a replica egress (mediamtx-egress-replica.yml) on an alternate port with
+#    ORIGINS=127.0.0.1:554 and observe:
+ffprobe -rtsp_transport tcp rtsp://127.0.0.1:{replica-port}/live/AbCdEf123456
+# 3) stop the reader and confirm the pull process (replica-pull.sh + child ffmpeg) exits.
+```

--- a/web/streaming/README.md
+++ b/web/streaming/README.md
@@ -53,9 +53,13 @@ Install differences from an origin node:
   # Ordered comma-separated `host` or `host:port` entries (default port 554).
   # The list is walked top-to-bottom on every pull attempt.
   ORIGINS="origin-a.example,origin-b.example"
-  # Optional: hostnames this replica answers to. If any ORIGINS host matches,
-  # the pull is refused (self-loop guard). Comma-separated, no port.
+  # Optional: hostnames this replica answers to. If any ORIGINS host matches
+  # (case-insensitive, port ignored), the pull is refused (self-loop guard).
+  # Hostnames or IPv4 only; IPv6 literals are rejected with exit 64.
   SELF_HOSTS="replica-1.example"
+  # Optional tuning (unsigned integers; anything else exits 64):
+  # REPLICA_SUSTAINED_PULL_SECONDS=5 REPLICA_MAX_RETRIES=3 REPLICA_BASE_BACKOFF_SECONDS=1
+  # RTSP_PORT is injected by MediaMTX (local egress port the pull publishes to; default 554).
   ```
 
 - Do **not** include this node's own hostname in `ORIGINS`. The self-loop guard exits `64` if you do, but keep the config correct on the writing side.

--- a/web/streaming/mediamtx-egress-replica.yml
+++ b/web/streaming/mediamtx-egress-replica.yml
@@ -32,10 +32,11 @@ pathDefaults:
   overridePublisher: false
   # `runOnDemand` fires when a reader connects to a path that has no active publisher.
   # replica-pull.sh reads `MTX_PATH` (`live/{id}`) and pulls from ORIGINS in order.
-  # `runOnDemandRestart: no` keeps a full-origin-exhausted failure surfaced (no silent retry loop);
+  # `runOnDemandRestart: false` keeps a full-origin-exhausted failure surfaced (no silent retry loop);
   # `runOnDemandCloseAfter: 10s` lets a brief zero-reader gap avoid tearing down the pull.
+  # Booleans use true/false like the other MediaMTX files here (YAML 1.2 parsers treat `no` as a string).
   runOnDemand: /opt/webscreen/streaming/replica-pull.sh
-  runOnDemandRestart: no
+  runOnDemandRestart: false
   runOnDemandCloseAfter: 10s
 paths:
   "~^live/[A-Za-z0-9]{12}$": {}

--- a/web/streaming/mediamtx-egress-replica.yml
+++ b/web/streaming/mediamtx-egress-replica.yml
@@ -1,0 +1,41 @@
+# MediaMTX v1.20.1 read-replica egress. The host firewall exposes RTSP :554 for readers,
+# publishing stays loopback-only and is driven by `runOnDemand` -> replica-pull.sh
+# (which fetches from an ordered ORIGINS list and re-publishes to 127.0.0.1:554 with -c copy).
+logLevel: info
+readTimeout: 20s
+writeTimeout: 20s
+api: true
+apiAddress: 127.0.0.1:9998
+rtsp: true
+rtspAddress: :554
+rtspTransports: [tcp]
+rtmp: false
+hls: false
+srt: false
+moq: false
+webrtc: false
+authMethod: internal
+authInternalUsers:
+  - user: any
+    pass: ""
+    ips: [127.0.0.1/32, ::1/128]
+    permissions:
+      - action: publish
+        path: "~^live/[A-Za-z0-9]{12}$"
+      - action: api
+  - user: any
+    pass: ""
+    permissions:
+      - action: read
+        path: "~^live/[A-Za-z0-9]{12}$"
+pathDefaults:
+  overridePublisher: false
+  # `runOnDemand` fires when a reader connects to a path that has no active publisher.
+  # replica-pull.sh reads `MTX_PATH` (`live/{id}`) and pulls from ORIGINS in order.
+  # `runOnDemandRestart: no` keeps a full-origin-exhausted failure surfaced (no silent retry loop);
+  # `runOnDemandCloseAfter: 10s` lets a brief zero-reader gap avoid tearing down the pull.
+  runOnDemand: /opt/webscreen/streaming/replica-pull.sh
+  runOnDemandRestart: no
+  runOnDemandCloseAfter: 10s
+paths:
+  "~^live/[A-Za-z0-9]{12}$": {}

--- a/web/streaming/replica-pull.sh
+++ b/web/streaming/replica-pull.sh
@@ -67,6 +67,31 @@ trim_whitespace() {
   fi
 }
 
+require_unsigned_int() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    echo "replica-pull requires $name to be an unsigned integer" >&2
+    exit 64
+  fi
+}
+
+# The env file is root-owned, but bash arithmetic and IFS splitting still deserve a fail-closed gate:
+# a stray newline or a non-numeric value must stop the pull instead of being silently truncated.
+validate_env() {
+  require_unsigned_int REPLICA_SUSTAINED_PULL_SECONDS "$SUSTAINED_PULL_SECONDS"
+  require_unsigned_int REPLICA_MAX_RETRIES "$MAX_RETRIES"
+  require_unsigned_int REPLICA_BASE_BACKOFF_SECONDS "$BASE_BACKOFF_SECONDS"
+  require_unsigned_int REPLICA_RTSP_CONNECT_TIMEOUT_US "$RTSP_CONNECT_TIMEOUT_US"
+  require_unsigned_int RTSP_PORT "$LOCAL_RTSP_PORT"
+  local name
+  for name in ORIGINS SELF_HOSTS; do
+    if [[ "${!name:-}" == *$'\n'* ]]; then
+      echo "replica-pull refused $name containing a newline (use a single comma-separated line)" >&2
+      exit 64
+    fi
+  done
+}
+
 parse_origins_env() {
   local raw="${ORIGINS:-}"
   if [[ -z "$raw" ]]; then
@@ -78,7 +103,10 @@ parse_origins_env() {
   local entry cleaned
   for entry in "${raw_entries[@]}"; do
     cleaned="$(trim_whitespace "$entry")"
-    [[ -n "$cleaned" ]] && PARSED_ORIGINS+=("$cleaned")
+    [[ -z "$cleaned" ]] && continue
+    # Validate the host syntax up front (rejects IPv6 literals) even when SELF_HOSTS is unset.
+    origin_host "$cleaned" >/dev/null
+    PARSED_ORIGINS+=("$cleaned")
   done
   if (( ${#PARSED_ORIGINS[@]} == 0 )); then
     echo 'replica-pull requires ORIGINS to contain at least one non-empty entry' >&2
@@ -86,9 +114,16 @@ parse_origins_env() {
   fi
 }
 
+# Lower-cased host part of `host` or `host:port`. IPv6 literals are refused: the `%%:*` split and the
+# URL builder below only support one colon, and the self-loop guard would silently miss `[::1]`.
 origin_host() {
   local origin="$1"
-  printf '%s' "${origin%%:*}"
+  if [[ "$origin" == *\[* || "$origin" == *:*:* ]]; then
+    echo "replica-pull does not support IPv6 literals in ORIGINS/SELF_HOSTS ($origin); use a hostname or IPv4" >&2
+    exit 64
+  fi
+  local host="${origin%%:*}"
+  printf '%s' "${host,,}"
 }
 
 enforce_self_loop_guard() {
@@ -102,6 +137,8 @@ enforce_self_loop_guard() {
     for self_host in "${self_entries[@]}"; do
       cleaned_self="$(trim_whitespace "$self_host")"
       [[ -z "$cleaned_self" ]] && continue
+      # Compare host parts case-insensitively; a stray `:port` in SELF_HOSTS must not defeat the guard.
+      cleaned_self="$(origin_host "$cleaned_self")"
       if [[ "$host" == "$cleaned_self" ]]; then
         echo "replica-pull refused an ORIGINS entry that matches SELF_HOSTS ($host)" >&2
         exit 64
@@ -171,6 +208,7 @@ pull_loop() {
 }
 
 stream_id="$(require_stream_id)"
+validate_env
 parse_origins_env
 enforce_self_loop_guard "${PARSED_ORIGINS[@]}"
 pull_loop "$stream_id" "${PARSED_ORIGINS[@]}"

--- a/web/streaming/replica-pull.sh
+++ b/web/streaming/replica-pull.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Read replica pull hook invoked by MediaMTX `runOnDemand`.
+#
+# Behavior:
+#   - Validate `MTX_PATH` as `live/{12-character base62 id}` (same rule as relay.sh).
+#   - Try each origin in `ORIGINS` (comma-separated `host` or `host:port`, default port 554)
+#     in the listed order. We pull with `ffmpeg -c copy` from the origin's egress (:554, TCP RTSP),
+#     never from the origin's ingress: egress already exposes the normalized AAC audio and is the
+#     public read surface, ingress is loopback-only.
+#   - If any `ORIGINS` host matches `SELF_HOSTS`, refuse to start (self-loop guard).
+#   - A quick connection failure (missing path / unreachable) advances to the next origin.
+#     Once a pull sustains beyond `REPLICA_SUSTAINED_PULL_SECONDS`, a later drop is treated as
+#     a post-connect disconnection and re-enters the origin loop with the same
+#     MAX_RETRIES / backoff cadence as relay.sh.
+#   - `runOnDemandRestart: no` is expected on the MediaMTX side; a non-zero exit here means every
+#     origin was tried and none served the path.
+#   - SIGINT / SIGTERM terminate the child ffmpeg and exit 0 (MediaMTX sends SIGINT when the last
+#     reader disconnects, which is a clean shutdown).
+set -euo pipefail
+
+readonly STREAM_PATH_PREFIX='live/'
+readonly STREAM_ID_LENGTH=12
+readonly DEFAULT_ORIGIN_PORT=554
+readonly SUSTAINED_PULL_SECONDS="${REPLICA_SUSTAINED_PULL_SECONDS:-5}"
+readonly MAX_RETRIES="${REPLICA_MAX_RETRIES:-3}"
+readonly BASE_BACKOFF_SECONDS="${REPLICA_BASE_BACKOFF_SECONDS:-1}"
+readonly RTSP_CONNECT_TIMEOUT_US="${REPLICA_RTSP_CONNECT_TIMEOUT_US:-5000000}"
+readonly LOCAL_RTSP_PORT="${RTSP_PORT:-554}"
+readonly FFMPEG_BIN="${FFMPEG_BIN:-ffmpeg}"
+
+PARSED_ORIGINS=()
+child_pid=''
+stopping=0
+
+stop_child() {
+  stopping=1
+  if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    kill -TERM "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+  fi
+  child_pid=''
+}
+
+on_signal() {
+  stop_child
+  exit 0
+}
+
+trap on_signal INT TERM
+
+require_stream_id() {
+  local media_path="${MTX_PATH:-}"
+  local id="${media_path#"$STREAM_PATH_PREFIX"}"
+  if [[ "$media_path" != "$STREAM_PATH_PREFIX$id" ]] || [[ ${#id} -ne $STREAM_ID_LENGTH ]] || [[ ! "$id" =~ ^[A-Za-z0-9]+$ ]]; then
+    echo 'replica-pull refused an invalid MediaMTX path' >&2
+    exit 64
+  fi
+  printf '%s' "$id"
+}
+
+trim_whitespace() {
+  local value="$1"
+  if [[ "$value" =~ ^[[:space:]]*(.*[^[:space:]])[[:space:]]*$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  else
+    printf '%s' ''
+  fi
+}
+
+parse_origins_env() {
+  local raw="${ORIGINS:-}"
+  if [[ -z "$raw" ]]; then
+    echo 'replica-pull requires ORIGINS to be a non-empty comma-separated list of host or host:port entries' >&2
+    exit 64
+  fi
+  local -a raw_entries=()
+  IFS=',' read -r -a raw_entries <<< "$raw"
+  local entry cleaned
+  for entry in "${raw_entries[@]}"; do
+    cleaned="$(trim_whitespace "$entry")"
+    [[ -n "$cleaned" ]] && PARSED_ORIGINS+=("$cleaned")
+  done
+  if (( ${#PARSED_ORIGINS[@]} == 0 )); then
+    echo 'replica-pull requires ORIGINS to contain at least one non-empty entry' >&2
+    exit 64
+  fi
+}
+
+origin_host() {
+  local origin="$1"
+  printf '%s' "${origin%%:*}"
+}
+
+enforce_self_loop_guard() {
+  local raw="${SELF_HOSTS:-}"
+  [[ -z "$raw" ]] && return 0
+  local -a self_entries=()
+  IFS=',' read -r -a self_entries <<< "$raw"
+  local origin host self_host cleaned_self
+  for origin in "$@"; do
+    host="$(origin_host "$origin")"
+    for self_host in "${self_entries[@]}"; do
+      cleaned_self="$(trim_whitespace "$self_host")"
+      [[ -z "$cleaned_self" ]] && continue
+      if [[ "$host" == "$cleaned_self" ]]; then
+        echo "replica-pull refused an ORIGINS entry that matches SELF_HOSTS ($host)" >&2
+        exit 64
+      fi
+    done
+  done
+}
+
+origin_url() {
+  local origin="$1"
+  local id="$2"
+  if [[ "$origin" == *:* ]]; then
+    printf 'rtsp://%s/%s%s' "$origin" "$STREAM_PATH_PREFIX" "$id"
+  else
+    printf 'rtsp://%s:%s/%s%s' "$origin" "$DEFAULT_ORIGIN_PORT" "$STREAM_PATH_PREFIX" "$id"
+  fi
+}
+
+run_ffmpeg_once() {
+  local input_url="$1"
+  local output_url="$2"
+  local status=0
+  "$FFMPEG_BIN" -nostdin \
+    -rtsp_transport tcp -timeout "$RTSP_CONNECT_TIMEOUT_US" -i "$input_url" \
+    -map 0 -c copy \
+    -f rtsp -rtsp_transport tcp "$output_url" &
+  child_pid=$!
+  wait "$child_pid" || status=$?
+  child_pid=''
+  return "$status"
+}
+
+pull_loop() {
+  local id="$1"
+  shift
+  local -a origins=("$@")
+  local output_url="rtsp://127.0.0.1:$LOCAL_RTSP_PORT/$STREAM_PATH_PREFIX$id"
+  local retry_count=0
+  local origin input_url start_seconds duration_seconds
+  while (( retry_count <= MAX_RETRIES )); do
+    for origin in "${origins[@]}"; do
+      (( stopping )) && return 0
+      input_url="$(origin_url "$origin" "$id")"
+      start_seconds=$SECONDS
+      if run_ffmpeg_once "$input_url" "$output_url"; then
+        (( stopping )) && return 0
+        # ffmpeg exited cleanly (MediaMTX closed the pull after the last reader left).
+        return 0
+      fi
+      (( stopping )) && return 0
+      duration_seconds=$(( SECONDS - start_seconds ))
+      if (( duration_seconds >= SUSTAINED_PULL_SECONDS )); then
+        # A sustained pull dropped; reset the retry counter and start over from the top origin.
+        retry_count=0
+        continue 2
+      fi
+      # Quick failure: treat as connection failure and advance to the next origin.
+    done
+    if (( retry_count >= MAX_RETRIES )); then
+      echo 'replica-pull exhausted all origins' >&2
+      return 1
+    fi
+    sleep "$(( BASE_BACKOFF_SECONDS * (retry_count + 1) ))"
+    (( retry_count += 1 ))
+  done
+  return 1
+}
+
+stream_id="$(require_stream_id)"
+parse_origins_env
+enforce_self_loop_guard "${PARSED_ORIGINS[@]}"
+pull_loop "$stream_id" "${PARSED_ORIGINS[@]}"

--- a/web/streaming/systemd/webscreen-mediamtx-egress-replica.service
+++ b/web/streaming/systemd/webscreen-mediamtx-egress-replica.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=WebScreen MediaMTX egress (read replica)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=webscreen
+Group=webscreen
+# ORIGINS (ordered comma list) and optional SELF_HOSTS live here. Keep the file root-owned
+# and readable by the `webscreen` group only.
+EnvironmentFile=/etc/webscreen/streaming/replica.env
+ExecStart=/usr/local/bin/mediamtx /etc/webscreen/streaming/mediamtx-egress-replica.yml
+Restart=on-failure
+RestartSec=3
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/web/tests/streaming/replica-pull.test.ts
+++ b/web/tests/streaming/replica-pull.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const replicaPull = new URL('../../streaming/replica-pull.sh', import.meta.url).pathname;
+const temporaryDirectories: string[] = [];
+const READY_TIMEOUT_MS = 2_000;
+const READY_POLL_INTERVAL_MS = 10;
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+interface FakeFfmpeg {
+  binary: string;
+  argsLog: string;
+  callCountFile: string;
+}
+
+async function fakeFfmpeg(bodyScript: string): Promise<FakeFfmpeg> {
+  const directory = await mkdtemp(join(tmpdir(), 'webscreen-replica-'));
+  temporaryDirectories.push(directory);
+  const binary = join(directory, 'ffmpeg');
+  const argsLog = join(directory, 'args.log');
+  const callCountFile = join(directory, 'call-count');
+  await writeFile(
+    binary,
+    `#!/usr/bin/env bash
+set -u
+ARGS_LOG="${argsLog}"
+CALL_COUNT_FILE="${callCountFile}"
+call_num=0
+if [[ -s "$CALL_COUNT_FILE" ]]; then
+  call_num=$(cat "$CALL_COUNT_FILE")
+fi
+call_num=$((call_num + 1))
+echo "$call_num" > "$CALL_COUNT_FILE"
+{
+  printf '===call%s===\\n' "$call_num"
+  for arg in "$@"; do
+    printf '%s\\n' "$arg"
+  done
+} >> "$ARGS_LOG"
+${bodyScript}
+`,
+    'utf8',
+  );
+  await chmod(binary, 0o755);
+  return { binary, argsLog, callCountFile };
+}
+
+async function readCallCount(fake: FakeFfmpeg): Promise<number> {
+  try {
+    const raw = await readFile(fake.callCountFile, 'utf8');
+    return Number.parseInt(raw.trim(), 10);
+  } catch {
+    return 0;
+  }
+}
+
+async function readArgs(fake: FakeFfmpeg): Promise<string> {
+  try {
+    return await readFile(fake.argsLog, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+async function waitForMarker(marker: string): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await access(marker);
+      return;
+    } catch {
+      await Bun.sleep(READY_POLL_INTERVAL_MS);
+    }
+  }
+  throw new Error(`Timed out waiting for ${marker}`);
+}
+
+describe('MediaMTX replica-pull hook', () => {
+  it('MTX_PATHが12文字base62でなければffmpeg起動前に拒否する', async () => {
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/../../etc',
+        ORIGINS: 'origin-a.example',
+        FFMPEG_BIN: '/bin/false',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await child.exited).toBe(64);
+  });
+
+  it('ORIGINSが空ならffmpeg起動前に拒否する', async () => {
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: '',
+        FFMPEG_BIN: '/bin/false',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await child.exited).toBe(64);
+  });
+
+  it('SELF_HOSTSに一致するORIGINSは自己ループとして拒否する', async () => {
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'replica-1.example,other.example',
+        SELF_HOSTS: 'replica-1.example',
+        FFMPEG_BIN: '/bin/false',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await child.exited).toBe(64);
+  });
+
+  it('1つ目のoriginで接続失敗したら2つ目のorigin URLでffmpegを起動する', async () => {
+    // 1st call: exit 1 quickly to simulate connection failure.
+    // 2nd call: exit 0 to simulate MediaMTX closing the pull cleanly.
+    const fake = await fakeFfmpeg(
+      `if [[ "$call_num" == "1" ]]; then exit 1; fi\nexit 0`,
+    );
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'origin-a.example,origin-b.example:5540',
+        FFMPEG_BIN: fake.binary,
+        REPLICA_MAX_RETRIES: '0',
+        REPLICA_BASE_BACKOFF_SECONDS: '0',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await child.exited).toBe(0);
+    expect(await readCallCount(fake)).toBe(2);
+    const argsBlob = await readArgs(fake);
+    // 1st call targets origin-a (default port 554), 2nd call targets origin-b:5540 (explicit port kept).
+    expect(argsBlob).toContain('rtsp://origin-a.example:554/live/AbCdEf123456');
+    expect(argsBlob).toContain('rtsp://origin-b.example:5540/live/AbCdEf123456');
+    // The re-publish target is the local egress at the default RTSP port.
+    expect(argsBlob).toContain('rtsp://127.0.0.1:554/live/AbCdEf123456');
+    // -c copy semantics are preserved (no re-encode).
+    expect(argsBlob).toContain('-c');
+    expect(argsBlob).toContain('copy');
+  });
+
+  it('全originが失敗したら非0で終了する', async () => {
+    const fake = await fakeFfmpeg('exit 1');
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'dead-a.example,dead-b.example',
+        FFMPEG_BIN: fake.binary,
+        REPLICA_MAX_RETRIES: '0',
+        REPLICA_BASE_BACKOFF_SECONDS: '0',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const exitCode = await child.exited;
+    expect(exitCode).not.toBe(0);
+    // Both origins were attempted once.
+    expect(await readCallCount(fake)).toBe(2);
+  });
+
+  it('SIGTERMで子ffmpegを止めて親を0で終了する', async () => {
+    const fake = await fakeFfmpeg(`
+trap 'printf "%s" terminated > "$TERM_MARKER"; exit 0' TERM
+printf "%s" ready > "$READY_MARKER"
+while :; do sleep 1; done
+`);
+    const marker = join(dirname(fake.binary), 'term-marker');
+    const readyMarker = join(dirname(fake.binary), 'ready-marker');
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'origin-a.example',
+        FFMPEG_BIN: fake.binary,
+        TERM_MARKER: marker,
+        READY_MARKER: readyMarker,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForMarker(readyMarker);
+    expect(await readFile(readyMarker, 'utf8')).toBe('ready');
+    child.kill('SIGTERM');
+    expect(await child.exited).toBe(0);
+    expect(await readFile(marker, 'utf8')).toBe('terminated');
+  });
+});

--- a/web/tests/streaming/replica-pull.test.ts
+++ b/web/tests/streaming/replica-pull.test.ts
@@ -175,6 +175,95 @@ describe('MediaMTX replica-pull hook', () => {
     expect(await readCallCount(fake)).toBe(2);
   });
 
+  it('持続したpullが切れたら先頭originから再試行し、再試行回数はリセットする', async () => {
+    // 1st call: hold for longer than REPLICA_SUSTAINED_PULL_SECONDS (1s) then drop with exit 1.
+    // 2nd call: exit 0 (clean close). The drop must re-enter the loop from origin-a, not advance to origin-b.
+    const fake = await fakeFfmpeg(
+      `if [[ "$call_num" == "1" ]]; then sleep 1.2; exit 1; fi\nexit 0`,
+    );
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'origin-a.example,origin-b.example',
+        FFMPEG_BIN: fake.binary,
+        REPLICA_SUSTAINED_PULL_SECONDS: '1',
+        REPLICA_MAX_RETRIES: '0',
+        REPLICA_BASE_BACKOFF_SECONDS: '0',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await child.exited).toBe(0);
+    expect(await readCallCount(fake)).toBe(2);
+    const argsBlob = await readArgs(fake);
+    const calls = argsBlob.split('===call').filter((chunk) => chunk.length > 0);
+    expect(calls[0]).toContain('rtsp://origin-a.example:554/live/AbCdEf123456');
+    expect(calls[1]).toContain('rtsp://origin-a.example:554/live/AbCdEf123456');
+    expect(argsBlob).not.toContain('origin-b.example');
+  });
+
+  it('SELF_HOSTSの照合は大文字小文字とportの有無を無視し、IPv6リテラルは拒否する', async () => {
+    const fake = await fakeFfmpeg('exit 0');
+    const caseInsensitive = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'Replica-1.Example:554',
+        SELF_HOSTS: 'replica-1.example:554',
+        FFMPEG_BIN: fake.binary,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await caseInsensitive.exited).toBe(64);
+    const ipv6 = Bun.spawn([replicaPull], {
+      env: { ...process.env, MTX_PATH: 'live/AbCdEf123456', ORIGINS: '[::1]:554', FFMPEG_BIN: fake.binary },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await ipv6.exited).toBe(64);
+    const badNumber = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'origin-a.example',
+        REPLICA_MAX_RETRIES: '3; echo pwned',
+        FFMPEG_BIN: fake.binary,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(await badNumber.exited).toBe(64);
+    expect(await readCallCount(fake)).toBe(0);
+  });
+
+  it('SIGINT（MediaMTXの最終reader切断）で子ffmpegを止めて親を0で終了する', async () => {
+    const fake = await fakeFfmpeg(`
+trap 'printf "%s" terminated > "$TERM_MARKER"; exit 0' TERM
+printf "%s" ready > "$READY_MARKER"
+while :; do sleep 1; done
+`);
+    const marker = join(dirname(fake.binary), 'int-term-marker');
+    const readyMarker = join(dirname(fake.binary), 'int-ready-marker');
+    const child = Bun.spawn([replicaPull], {
+      env: {
+        ...process.env,
+        MTX_PATH: 'live/AbCdEf123456',
+        ORIGINS: 'origin-a.example',
+        FFMPEG_BIN: fake.binary,
+        TERM_MARKER: marker,
+        READY_MARKER: readyMarker,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForMarker(readyMarker);
+    child.kill('SIGINT');
+    expect(await child.exited).toBe(0);
+    expect(await readFile(marker, 'utf8')).toBe('terminated');
+  });
+
   it('SIGTERMで子ffmpegを止めて親を0で終了する', async () => {
     const fake = await fakeFfmpeg(`
 trap 'printf "%s" terminated > "$TERM_MARKER"; exit 0' TERM


### PR DESCRIPTION
## なぜこの変更が必要か

配信サーバーを origin 1 + read replica N の 2 台構成にする（docs/streaming/scale-plan.md M1、milestone「配信サーバーを origin 1 + replica 1 の 2 台構成にする」）。
`rtspt://webscreen.tv/live/{id}` を固定したまま視聴容量と転送量を台数比例で増やすには、どのノードに繋いでも任意 path を読める read replica が要る。
origin を Indigo から Cherry Servers へ移す時は新旧 origin が最長 15 分並存するため、静的 `source` ではなく順序付き origin リストから pull する形にする。

Closes noricha-vr/WebScreen#221

## 変更内容

- `web/streaming/replica-pull.sh`: MediaMTX `runOnDemand` から起動。`MTX_PATH` を 12 文字 base62 に検証し、env `ORIGINS`（カンマ区切り、順に試す）の origin egress から `ffmpeg -c copy` でローカル egress へ publish。`SELF_HOSTS` で自己ループ防止。接続失敗は次の origin、持続後の切断は再試行、SIGINT/SIGTERM で子 ffmpeg を止めて終了
- `web/streaming/mediamtx-egress-replica.yml`: egress 設定 + `runOnDemand` / `runOnDemandRestart: no` / `runOnDemandCloseAfter: 10s`
- `web/streaming/systemd/webscreen-mediamtx-egress-replica.service`: `EnvironmentFile=/etc/webscreen/streaming/replica.env`
- `web/streaming/README.md`: replica ノードの構築（origin との差分）・公開ポート・動作確認
- `web/tests/streaming/replica-pull.test.ts`: 不正 path / ORIGINS 空 / SELF_HOSTS 一致 / 1 つ目失敗→2 つ目 / 全失敗で非 0 / SIGTERM で exit 0

## 意思決定

### 採用アプローチ
- 取得元は origin の egress（AAC 変換済み）。ingress からは取らないので replica 側で音声変換が発生しない
- `runOnDemand` + 順序付き origin リスト。Worker / D1 に依存せず、origin 移設中の並存と origin 障害時の切替を同じ仕組みで吸収する

### 却下した代替案
- MediaMTX 公式の静的 `source: rtsp://origin/$G1` + `sourceOnDemand` → 却下: origin が 1 つ固定の間しか使えず、移設時に設定の差し替えが要る

## 本番影響

現行の Indigo origin は新ファイルを参照しないため、マージ・デプロイでの挙動変化はない。有効になるのは 2 台目実機（#219）で replica unit を enable した時点。

## テスト

- [x] `make check`（typecheck / test / build）、`bash -n`、shellcheck 0.11.0
- [x] `make test FILE=tests/streaming/replica-pull.test.ts`（6 pass）、`relay.test.ts` リグレッションなし
- [x] ローカルレビューゲート（codex sol が API 404 のため Opus code-reviewer + security-checker にフォールバック）: 対応表を PR コメントに投稿
- [ ] 実機ゲート（2 台目で VRChat から replica 側に繋いで再生、PC / Quest の A レコード選択挙動）: noricha-vr/choicast#20 の契約後、#224 の runbook と合わせて実施

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgdhLGJGrkEdn98UXLgYac
