### PR TITLE
feat(streaming): 遅延ハーネスに --node-host を追加し Cherry を cron の read ノードに入れる

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,18 @@ stream-paths: ## ingress / egress の MediaMTX path 一覧を表示
 	@ssh "$(STREAM_HOST)" 'curl -fsS http://127.0.0.1:9998/v3/paths/list | jq'
 
 latency-probe: MIN ?= 5
+# 変数はレシピ文字列へ展開せず環境変数で渡す（Make 変数にシェル記号が入ってもコマンドにならない）
+latency-probe: export MIN := $(MIN)
+latency-probe: export SOURCE := $(SOURCE)
+latency-probe: export PLAYER := $(PLAYER)
+latency-probe: export NOTIFY_DISCORD := $(NOTIFY_DISCORD)
+latency-probe: export SERVER_SNAP := $(SERVER_SNAP)
+latency-probe: export NODE_HOST := $(NODE_HOST)
 latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \
 	if [[ ! -f "$$script" ]]; then echo 'feat/latency-harness をマージしてください' >&2; exit 1; fi; \
-	if [[ -z "$(SOURCE)" ]]; then echo 'SOURCE=URL を指定してください' >&2; exit 64; fi; \
-	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$(MIN)" --source "$(SOURCE)" $(if $(PLAYER),--player "$(PLAYER)") $(if $(NOTIFY_DISCORD),--notify-discord "$(NOTIFY_DISCORD)") $(if $(SERVER_SNAP),--server-snap "$(SERVER_SNAP)") $(if $(NODE_HOST),--node-host "$(NODE_HOST)")
+	if [[ -z "$$SOURCE" ]]; then echo 'SOURCE=URL を指定してください' >&2; exit 64; fi; \
+	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$$MIN" --source "$$SOURCE" $${PLAYER:+--player "$$PLAYER"} $${NOTIFY_DISCORD:+--notify-discord "$$NOTIFY_DISCORD"} $${SERVER_SNAP:+--server-snap "$$SERVER_SNAP"} $${NODE_HOST:+--node-host "$$NODE_HOST"}
 
 stream-source: ## 遅延測定中の配信元タブの表示先を切り替える（URL=URL）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \

--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,14 @@ stream-paths: ## ingress / egress の MediaMTX path 一覧を表示
 	@ssh "$(STREAM_HOST)" 'curl -fsS http://127.0.0.1:9998/v3/paths/list | jq'
 
 latency-probe: MIN ?= 5
-# 変数はレシピ文字列へ展開せず環境変数で渡す（Make 変数にシェル記号が入ってもコマンドにならない）
-latency-probe: export MIN := $(MIN)
-latency-probe: export SOURCE := $(SOURCE)
-latency-probe: export PLAYER := $(PLAYER)
-latency-probe: export NOTIFY_DISCORD := $(NOTIFY_DISCORD)
-latency-probe: export SERVER_SNAP := $(SERVER_SNAP)
-latency-probe: export NODE_HOST := $(NODE_HOST)
+# 変数はレシピ文字列へ展開せず環境変数で渡す（シェル記号が入ってもコマンドにならない）。
+# $(value) で生の文字列を取り、Make 自身の $(shell ...) 展開も起こさない
+latency-probe: export MIN := $(value MIN)
+latency-probe: export SOURCE := $(value SOURCE)
+latency-probe: export PLAYER := $(value PLAYER)
+latency-probe: export NOTIFY_DISCORD := $(value NOTIFY_DISCORD)
+latency-probe: export SERVER_SNAP := $(value SERVER_SNAP)
+latency-probe: export NODE_HOST := $(value NODE_HOST)
 latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \
 	if [[ ! -f "$$script" ]]; then echo 'feat/latency-harness をマージしてください' >&2; exit 1; fi; \

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ stream-paths: ## ingress / egress の MediaMTX path 一覧を表示
 	@ssh "$(STREAM_HOST)" 'curl -fsS http://127.0.0.1:9998/v3/paths/list | jq'
 
 latency-probe: MIN ?= 5
-latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST）
+latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \
 	if [[ ! -f "$$script" ]]; then echo 'feat/latency-harness をマージしてください' >&2; exit 1; fi; \
 	if [[ -z "$(SOURCE)" ]]; then echo 'SOURCE=URL を指定してください' >&2; exit 64; fi; \
-	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$(MIN)" --source "$(SOURCE)" $(if $(PLAYER),--player "$(PLAYER)") $(if $(NOTIFY_DISCORD),--notify-discord "$(NOTIFY_DISCORD)") $(if $(SERVER_SNAP),--server-snap "$(SERVER_SNAP)")
+	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$(MIN)" --source "$(SOURCE)" $(if $(PLAYER),--player "$(PLAYER)") $(if $(NOTIFY_DISCORD),--notify-discord "$(NOTIFY_DISCORD)") $(if $(SERVER_SNAP),--server-snap "$(SERVER_SNAP)") $(if $(NODE_HOST),--node-host "$(NODE_HOST)")
 
 stream-source: ## 遅延測定中の配信元タブの表示先を切り替える（URL=URL）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \

--- a/Makefile
+++ b/Makefile
@@ -93,18 +93,21 @@ stream-paths: ## ingress / egress の MediaMTX path 一覧を表示
 
 latency-probe: MIN ?= 5
 # 変数はレシピ文字列へ展開せず環境変数で渡す（シェル記号が入ってもコマンドにならない）。
-# $(value) で生の文字列を取り、Make 自身の $(shell ...) 展開も起こさない
-latency-probe: export MIN := $(value MIN)
-latency-probe: export SOURCE := $(value SOURCE)
-latency-probe: export PLAYER := $(value PLAYER)
-latency-probe: export NOTIFY_DISCORD := $(value NOTIFY_DISCORD)
-latency-probe: export SERVER_SNAP := $(value SERVER_SNAP)
-latency-probe: export NODE_HOST := $(value NODE_HOST)
+# $(value) で生の文字列を取り Make 自身の $(shell ...) 展開を起こさず、コマンドライン変数が
+# target-specific 代入を上書きできないよう別名（LP_*）で export する
+# コマンドライン変数は Make が子環境へ export する時に展開するので、元の名前は export しない
+unexport MIN SOURCE PLAYER NOTIFY_DISCORD SERVER_SNAP NODE_HOST
+latency-probe: export LP_MIN := $(value MIN)
+latency-probe: export LP_SOURCE := $(value SOURCE)
+latency-probe: export LP_PLAYER := $(value PLAYER)
+latency-probe: export LP_NOTIFY_DISCORD := $(value NOTIFY_DISCORD)
+latency-probe: export LP_SERVER_SNAP := $(value SERVER_SNAP)
+latency-probe: export LP_NODE_HOST := $(value NODE_HOST)
 latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \
 	if [[ ! -f "$$script" ]]; then echo 'feat/latency-harness をマージしてください' >&2; exit 1; fi; \
-	if [[ -z "$$SOURCE" ]]; then echo 'SOURCE=URL を指定してください' >&2; exit 64; fi; \
-	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$$MIN" --source "$$SOURCE" $${PLAYER:+--player "$$PLAYER"} $${NOTIFY_DISCORD:+--notify-discord "$$NOTIFY_DISCORD"} $${SERVER_SNAP:+--server-snap "$$SERVER_SNAP"} $${NODE_HOST:+--node-host "$$NODE_HOST"}
+	if [[ -z "$$LP_SOURCE" ]]; then echo 'SOURCE=URL を指定してください' >&2; exit 64; fi; \
+	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$$LP_MIN" --source "$$LP_SOURCE" $${LP_PLAYER:+--player "$$LP_PLAYER"} $${LP_NOTIFY_DISCORD:+--notify-discord "$$LP_NOTIFY_DISCORD"} $${LP_SERVER_SNAP:+--server-snap "$$LP_SERVER_SNAP"} $${LP_NODE_HOST:+--node-host "$$LP_NODE_HOST"}
 
 stream-source: ## 遅延測定中の配信元タブの表示先を切り替える（URL=URL）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -32,6 +32,16 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 
 制限: v1の必須範囲はRTSPT出口。Windows側はgdigrabの30 fpsフレーム番号から録画時刻を復元するベストエフォートで、dshow音声・ddagrabは未実装。外部URLへ切り替えた後は時刻ブロックがないため、出口遅延の標本は記録されない。
 
+## 別ノードを origin にして測る（`--node-host`）
+
+`--node-host chi1.web-screen.net` を付けると、本番 Worker の `STREAM_WHIP_ORIGIN` と DNS を変えずに、このハーネスの配信だけを指定ノードへ送る。
+
+- 配信開始 / 再利用 API の応答に含まれる `whipUrl` のホストだけを Playwright の `route` で差し替える（パス `/live/{id}/whip` と https は維持。publish JWT は本番 Worker が署名したものをそのまま使うので、ノード側の ingress は本番 JWKS を参照していれば受け付ける）
+- 出口計測（`ffmpeg` の単発取得・音声・画質）と Discord に流す視聴 URL も `rtsp(t)://<node-host>/live/{id}` になる。VRChat にはこの URL を貼る（`webscreen.tv` と同じく allowlist 外なので条件は同じ）
+- `--server-snap` は別指定（例 `--server-snap webscreen-cherry`）。ノードの SSH alias を渡す
+- 使った host は `sender-config.json` の `harnessNodeHost` / `harnessReadHost` に残る
+- ノード側の前提: ingress + relay が動き、Caddy がそのホストで WHIP ルートを持ち（`web/streaming/Caddyfile.node`）、cron の `MEDIAMTX_READ_EGRESS_API_URLS` にそのノードの Control API が入っていること。入っていないと本番 cron が「viewer 0」と判定し、`STREAM_NO_VIEWER_SECONDS`（600 秒）で配信を終了させる
+
 ## 既知の失敗と診断ファイル
 
 - 出口が止まっても指定時間まで待機し、`outlet-ffmpeg.log` と `outlet-decode.log` にffmpeg・復号状態を残す。

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -37,6 +37,8 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 `--node-host chi1.web-screen.net` を付けると、本番 Worker の `STREAM_WHIP_ORIGIN` と DNS を変えずに、このハーネスの配信だけを指定ノードへ送る。
 
 - 配信開始 / 再利用 API の応答に含まれる `whipUrl` のホストだけを Playwright の `route` で差し替える（パス `/live/{id}/whip` と https は維持。publish JWT は本番 Worker が署名したものをそのまま使うので、ノード側の ingress は本番 JWKS を参照していれば受け付ける）
+- 指定できるのは `web-screen.net` 配下の 1 ラベル（`chi1.web-screen.net` 形式）だけ。本番 Worker が発行した publish JWT を送る先なので、自前ドメイン外・IP・localhost は拒否する
+- 画面の health 待機は本番 Worker が本番 origin（Indigo）の MediaMTX を見るため、別ノードへ publish すると永遠に starting のままになる。ハーネスは `/api/streams/{id}/health` を「呼ばれるごとに egress が増える ready」の合成応答に差し替え、実際の到達確認は出口 ffmpeg（`probeDimensionsFor` / 単発取得）が担う。出口が取れなければ run は失敗する
 - 出口計測（`ffmpeg` の単発取得・音声・画質）と Discord に流す視聴 URL も `rtsp(t)://<node-host>/live/{id}` になる。VRChat にはこの URL を貼る（`webscreen.tv` と同じく allowlist 外なので条件は同じ）
 - `--server-snap` は別指定（例 `--server-snap webscreen-cherry`）。ノードの SSH alias を渡す
 - 使った host は `sender-config.json` の `harnessNodeHost` / `harnessReadHost` に残る

--- a/docs/streaming/vrchat-ab-runbook.md
+++ b/docs/streaming/vrchat-ab-runbook.md
@@ -45,6 +45,23 @@ bun scripts/latency-probe.ts run --minutes 12 --ab-cycle 120 \
 - `--ab-cycle 120` で quality → realtime → … を 2 分ごとに切り替える（6 区間）。`--max-bitrate` は realtime 区間の上限
 - 単一プロファイルで測る時は `--ab-cycle` を外し、`--video-profile quality` または `--video-profile realtime --max-bitrate 1500000`
 
+## ノード比較（Indigo origin と Cherry origin）
+
+Cherry（`chi1.web-screen.net` / `ssh webscreen-cherry`）を origin にした経路を測る時は、通常 run と `--node-host` run を同じ素材で交互に取る（[latency-harness.md](latency-harness.md)「別ノードを origin にして測る」）。
+
+| run | コマンドの差分 | VRChat に貼る URL | 分かること |
+|---|---|---|---|
+| A（基準） | 通常（`--server-snap webscreen-indigo-poc`） | `rtspt://webscreen.tv/live/{id}` | 現行 Indigo の値 |
+| B | `--node-host chi1.web-screen.net --server-snap webscreen-cherry` | Discord に届く `rtspt://chi1.web-screen.net/live/{id}` | ブラウザ → Chicago → VRChat の本命経路 |
+| C | 通常 run のまま、URL だけ Cherry を指定 | `rtspt://88.216.73.71/live/{id}` | Indigo origin + Cherry replica ホップの増分 |
+
+```bash
+cd web
+bun scripts/latency-probe.ts run --minutes 8 --source 'http://127.0.0.1:0/latency-source.html?tones=1' \
+  --video-profile quality --player win2022 --notify-discord 1380914078100488334 \
+  --node-host chi1.web-screen.net --server-snap webscreen-cherry
+```
+
 ## 落とし穴
 
 - run ごとに配信 URL は変わる。古い URL は再生できない

--- a/web/cron/wrangler.jsonc
+++ b/web/cron/wrangler.jsonc
@@ -40,7 +40,7 @@
     "MEDIAMTX_INGRESS_API_URL": "https://stream.web-screen.net",
     "MEDIAMTX_EGRESS_API_URL": "https://stream.web-screen.net",
     // origin を含む全 read egress。2 台目追加時はカンマ区切りで URL を増やす。
-    "MEDIAMTX_READ_EGRESS_API_URLS": "https://stream.web-screen.net"
+    "MEDIAMTX_READ_EGRESS_API_URLS": "https://stream.web-screen.net,https://chi1.web-screen.net"
   },
   "d1_databases": [
     {

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -206,12 +206,20 @@ export async function clearPreviousRunArtifacts(outDir: string): Promise<void> {
 /** runの公開境界でプロファイル関連値を検証し、副作用の前に不正入力を拒否する。 */
 export function validateRunOptions(options: RunOptions): void {
   if (options.videoProfile !== 'quality' && options.videoProfile !== 'realtime') throw new Error('videoProfile must be quality or realtime');
+  if (options.nodeHost !== null) validateNodeHost(options.nodeHost);
   if (options.maxBitrate !== null) validateVideoProfile(options.videoProfile, options.maxBitrate);
   if (options.videoProfile === 'realtime' && options.maxBitrate === null) throw new Error('realtime videoProfile requires maxBitrate');
   if (options.abCycleSeconds !== null) {
     validateProfileCycleSeconds(options.abCycleSeconds);
     if (options.maxBitrate === null) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
   }
+}
+
+/** ハーネスが配信先に選べるノードは自前ドメイン配下だけ（publish JWT を任意ホストへ送らせない）。 */
+export const NODE_HOST_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.web-screen\.net$/;
+
+export function validateNodeHost(nodeHost: string): void {
+  if (!NODE_HOST_PATTERN.test(nodeHost)) throw new Error('nodeHost must be a single label under web-screen.net (e.g. chi1.web-screen.net)');
 }
 
 /**
@@ -228,15 +236,40 @@ export function rewriteWhipUrlHost(body: string, nodeHost: string): string {
   return JSON.stringify({ ...(parsed as Record<string, unknown>), whipUrl: whip.href });
 }
 
+/**
+ * 本番 Worker の health は本番 origin（Indigo）の MediaMTX しか見ないため、別ノードへ publish すると
+ * 永遠に starting のまま republish → 映像未到達エラーになる。ハーネスでは health を「呼ばれるごとに
+ * egress bytes が増える ready」に差し替え、実際の到達確認は出口 ffmpeg（probe / grab）に任せる。
+ */
+export function syntheticHealthBody(attempt: number): string {
+  return JSON.stringify({ state: 'ready', ingressBytes: 1_000 * (attempt + 1), egressBytes: 1_000 * (attempt + 1), audioDetected: null });
+}
+
+/** 本文を書き換えた応答用のヘッダー。圧縮・長さ・validator は元の本文のものなので落とす。 */
+export function headersForRewrittenBody(headers: Record<string, string>): Record<string, string> {
+  const dropped = new Set(['content-encoding', 'content-length', 'transfer-encoding', 'etag', 'last-modified']);
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => !dropped.has(name.toLowerCase())));
+}
+
 /** 本番 Worker と DNS を変えずに、このブラウザの WHIP だけを指定ノードへ向ける（計測専用）。 */
 async function routeWhipToNode(page: import('@playwright/test').Page, nodeHost: string): Promise<void> {
+  validateNodeHost(nodeHost);
+  let healthAttempt = 0;
   await page.route('**/api/streams/**', async (route) => {
+    const url = new URL(route.request().url());
+    if (/^\/api\/streams\/[A-Za-z0-9]{12}\/health\/?$/.test(url.pathname)) {
+      await route.fulfill({ status: 200, headers: { 'content-type': 'application/json; charset=utf-8' }, body: syntheticHealthBody(healthAttempt) });
+      healthAttempt += 1;
+      return;
+    }
     const response = await route.fetch();
     if (!(response.headers()['content-type'] ?? '').includes('application/json')) { await route.fulfill({ response }); return; }
-    const rewritten = rewriteWhipUrlHost(await response.text(), nodeHost);
-    await route.fulfill({ response, body: rewritten, headers: { ...response.headers(), 'content-length': String(Buffer.byteLength(rewritten)) } });
+    const body = await response.text();
+    const rewritten = rewriteWhipUrlHost(body, nodeHost);
+    if (rewritten === body) { await route.fulfill({ response }); return; }
+    await route.fulfill({ status: response.status(), headers: headersForRewrittenBody(response.headers()), body: rewritten });
   });
-  pushBrowserLog(`[harness] whipUrl host -> ${nodeHost}`);
+  pushBrowserLog(`[harness] whipUrl host -> ${nodeHost}（health は合成応答）`);
 }
 
 async function persistResults(outDir: string, outlet: LatencySample[], startedAtMs: number, player: PlayerResult | null, sender: Parameters<typeof formatSummary>[3], profileSwitches: Parameters<typeof formatSummary>[4]): Promise<void> {

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -30,6 +30,8 @@ const PREVIOUS_RUN_ARTIFACTS = [
 export interface RunOptions {
   minutes: number; source: string; player: 'win2022' | null; profileDir: string; outDir: string; videoProfile: 'quality' | 'realtime'; maxBitrate: number | null;
   abCycleSeconds: number | null; scrollPixelsPerSecond: number; outletQualitySeconds: number; notifyDiscordChannelId: string | null; serverSnapHost: string | null; streamId: string | null;
+  /** 配信先ノードのホスト名。null なら本番既定（API 応答の whipUrl と webscreen.tv）を使う。 */
+  nodeHost: string | null;
 }
 interface ActiveController { endpoint: string; sourceUrl: string }
 interface ControllerState { sourcePage: import('@playwright/test').Page | null; sourceUrl: string; sourceServerUrl: string }
@@ -68,17 +70,19 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
     // 共有ページだけに限定する（context 全体に掛けると計測対象外のページの RTCPeerConnection まで置換される）
     await sharingPage.addInitScript(peerConnectionTrackerInitScript());
     attachBrowserLog(sharingPage);
+    if (options.nodeHost) await routeWhipToNode(sharingPage, options.nodeHost);
     await sharingPage.goto(screenShareUrl(options), { waitUntil: 'domcontentloaded', timeout: 30_000 });
     const streamId = await startScreenShare(sharingPage, options.profileDir);
-    await writeFile(join(options.outDir, 'sender-config.json'), JSON.stringify(await captureSenderConfig(sharingPage), null, 2) + '\n');
+    const readHost = options.nodeHost ?? 'webscreen.tv';
+    await writeFile(join(options.outDir, 'sender-config.json'), JSON.stringify({ ...await captureSenderConfig(sharingPage), harnessNodeHost: options.nodeHost, harnessReadHost: readHost }, null, 2) + '\n');
     const target = resolveSourceUrl(options.source, sourceServer.url);
     if (target !== sourceServer.url.href) await sourcePage.goto(target, { waitUntil: 'domcontentloaded' });
     await applyAutoScroll(sourcePage, target, sourceServer.url.href, options.scrollPixelsPerSecond);
     await sourcePage.bringToFront();
-    const rtspUrl = `rtsp://webscreen.tv/live/${streamId}`;
+    const rtspUrl = `rtsp://${readHost}/live/${streamId}`;
     // VRChat へ貼る URL を人に渡す経路（クリップボードと固定ファイル）。run はこの後ブロックするため、
     // 標準出力だけだと貼るタイミングで URL を伝えられない
-    const viewerUrl = `rtspt://webscreen.tv/live/${streamId}`;
+    const viewerUrl = `rtspt://${readHost}/live/${streamId}`;
     console.info(`配信 URL: ${viewerUrl}`);
     await writeFile(join(options.profileDir, 'current-stream-url.txt'), `${viewerUrl}\n`).catch(() => undefined);
     if (process.platform === 'darwin') {
@@ -208,6 +212,31 @@ export function validateRunOptions(options: RunOptions): void {
     validateProfileCycleSeconds(options.abCycleSeconds);
     if (options.maxBitrate === null) throw new Error('--ab-cycle requires --max-bitrate for realtime intervals');
   }
+}
+
+/**
+ * 配信開始 / 再利用 API の応答に含まれる whipUrl のホストだけを差し替える。
+ * パス `/live/{id}/whip` と https は維持するので、画面側の whipUrl 検証（isWhipUrl）はそのまま通る。
+ * whipUrl を持たない応答（エラー・停止 API）は触らず返す。
+ */
+export function rewriteWhipUrlHost(body: string, nodeHost: string): string {
+  let parsed: unknown;
+  try { parsed = JSON.parse(body); } catch { return body; }
+  if (typeof parsed !== 'object' || parsed === null || typeof (parsed as { whipUrl?: unknown }).whipUrl !== 'string') return body;
+  const whip = new URL((parsed as { whipUrl: string }).whipUrl);
+  whip.host = nodeHost;
+  return JSON.stringify({ ...(parsed as Record<string, unknown>), whipUrl: whip.href });
+}
+
+/** 本番 Worker と DNS を変えずに、このブラウザの WHIP だけを指定ノードへ向ける（計測専用）。 */
+async function routeWhipToNode(page: import('@playwright/test').Page, nodeHost: string): Promise<void> {
+  await page.route('**/api/streams/**', async (route) => {
+    const response = await route.fetch();
+    if (!(response.headers()['content-type'] ?? '').includes('application/json')) { await route.fulfill({ response }); return; }
+    const rewritten = rewriteWhipUrlHost(await response.text(), nodeHost);
+    await route.fulfill({ response, body: rewritten, headers: { ...response.headers(), 'content-length': String(Buffer.byteLength(rewritten)) } });
+  });
+  pushBrowserLog(`[harness] whipUrl host -> ${nodeHost}`);
 }
 
 async function persistResults(outDir: string, outlet: LatencySample[], startedAtMs: number, player: PlayerResult | null, sender: Parameters<typeof formatSummary>[3], profileSwitches: Parameters<typeof formatSummary>[4]): Promise<void> {

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -3,7 +3,7 @@ import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-import { analyzeDirectory, loginProfile, runLatencyProbe, switchSource, type RunOptions } from './latency-probe-run';
+import { analyzeDirectory, loginProfile, runLatencyProbe, switchSource, validateNodeHost, type RunOptions } from './latency-probe-run';
 import { checkWindowsRecording } from './latency-probe-player';
 
 const HELP = `Usage: bun scripts/latency-probe.ts <subcommand> [options]
@@ -34,7 +34,7 @@ run options:
                      出口画質の連続ffmpeg測定窓（5〜120秒、既定20）。遅延用の単発取得とは別系統
   --notify-discord CHANNEL_ID
                      配信 URL を Discord の指定チャンネルへ投稿する（VRChat 側の PC で貼るため）
-  --node-host HOST   配信先ノードを差し替える。配信開始 API 応答の whipUrl のホストを HOST にして WHIP を
+  --node-host HOST   配信先ノードを差し替える（web-screen.net 配下の 1 ラベルのみ、例 chi1.web-screen.net）。配信開始 API 応答の whipUrl のホストを HOST にして WHIP を
                      そのノードへ送り、出口計測と VRChat へ渡す URL も rtsp(t)://HOST/live/{id} にする
                      （本番の STREAM_WHIP_ORIGIN と DNS は変えずに別ノードを origin として測る用途）
 
@@ -73,7 +73,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
   if (command !== 'run') throw new Error(`unknown subcommand: ${command}`);
   rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'node-host', 'stream-id', 'video-profile', 'max-bitrate', 'ab-cycle', 'scroll', 'outlet-quality-seconds']);
   if (values['server-snap'] !== undefined && !isValidSshHost(values['server-snap'])) throw new Error('--server-snap must be an ssh host name');
-  if (values['node-host'] !== undefined && !isValidSshHost(values['node-host'])) throw new Error('--node-host must be a DNS host name');
+  if (values['node-host'] !== undefined) validateNodeHost(values['node-host']);
   if (values['notify-discord'] !== undefined && !/^\d{15,25}$/.test(values['notify-discord'])) throw new Error('--notify-discord must be a Discord channel id');
   if (values['stream-id'] !== undefined && !/^[A-Za-z0-9]{12}$/.test(values['stream-id'])) throw new Error('--stream-id must be a 12-character alphanumeric ID');
   const minutes = Number(values.minutes);

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -13,7 +13,7 @@ WebScreen配信を実Mac Chromeから開始し、RTSPT出口と任意のWindows�
 Subcommands:
   login [--profile-dir PATH]
   player-check [--seconds N] [--out DIR]
-  run --minutes N --source URL [--stream-id ID] [--video-profile quality|realtime] [--max-bitrate 1200000|1500000|2000000] [--ab-cycle 60..600] [--scroll PX_PER_SECOND] [--outlet-quality-seconds N] [--player win2022] [--profile-dir PATH] [--out DIR] [--notify-discord CHANNEL_ID] [--server-snap HOST]
+  run --minutes N --source URL [--stream-id ID] [--video-profile quality|realtime] [--max-bitrate 1200000|1500000|2000000] [--ab-cycle 60..600] [--scroll PX_PER_SECOND] [--outlet-quality-seconds N] [--player win2022] [--profile-dir PATH] [--out DIR] [--notify-discord CHANNEL_ID] [--server-snap HOST] [--node-host HOST]
   source --url URL [--scroll PX_PER_SECOND]
   analyze DIR
 
@@ -34,6 +34,9 @@ run options:
                      出口画質の連続ffmpeg測定窓（5〜120秒、既定20）。遅延用の単発取得とは別系統
   --notify-discord CHANNEL_ID
                      配信 URL を Discord の指定チャンネルへ投稿する（VRChat 側の PC で貼るため）
+  --node-host HOST   配信先ノードを差し替える。配信開始 API 応答の whipUrl のホストを HOST にして WHIP を
+                     そのノードへ送り、出口計測と VRChat へ渡す URL も rtsp(t)://HOST/live/{id} にする
+                     （本番の STREAM_WHIP_ORIGIN と DNS は変えずに別ノードを origin として測る用途）
 
 loginはハーネスが開くChromeで一度だけ人がログインするための待機です。player-checkは配信なしでWindows録画だけを試し、実測前に録画経路を確認します。sourceは実行中runの共有タブを切り替えます。analyzeは保存済みCSVからsummary.mdを再生成します。`;
 
@@ -68,8 +71,9 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
     return { command, url: requiredUrl(values.url, '--url'), scrollPixelsPerSecond: parseScroll(values.scroll) };
   }
   if (command !== 'run') throw new Error(`unknown subcommand: ${command}`);
-  rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'stream-id', 'video-profile', 'max-bitrate', 'ab-cycle', 'scroll', 'outlet-quality-seconds']);
+  rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'node-host', 'stream-id', 'video-profile', 'max-bitrate', 'ab-cycle', 'scroll', 'outlet-quality-seconds']);
   if (values['server-snap'] !== undefined && !isValidSshHost(values['server-snap'])) throw new Error('--server-snap must be an ssh host name');
+  if (values['node-host'] !== undefined && !isValidSshHost(values['node-host'])) throw new Error('--node-host must be a DNS host name');
   if (values['notify-discord'] !== undefined && !/^\d{15,25}$/.test(values['notify-discord'])) throw new Error('--notify-discord must be a Discord channel id');
   if (values['stream-id'] !== undefined && !/^[A-Za-z0-9]{12}$/.test(values['stream-id'])) throw new Error('--stream-id must be a 12-character alphanumeric ID');
   const minutes = Number(values.minutes);
@@ -94,6 +98,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
       profileDir: values['profile-dir'] ?? join(homedir(), '.webscreen-harness', 'chrome-profile'),
       notifyDiscordChannelId: values['notify-discord'] ?? null,
       serverSnapHost: values['server-snap'] ?? null,
+      nodeHost: values['node-host'] ?? null,
       streamId: values['stream-id'] ?? null,
       outDir: values.out ?? resolve('..', 'docs', 'tmp', 'latency', timestamp),
     },

--- a/web/streaming/Caddyfile.node
+++ b/web/streaming/Caddyfile.node
@@ -1,0 +1,26 @@
+# Caddyfile for an additional node (read replica, or a node that may also act as origin).
+# The origin node (Indigo) uses ./Caddyfile; every other node installs this file as /etc/caddy/Caddyfile.
+# WEBSCREEN_NODE_HOST is the node-specific host (e.g. chi1.web-screen.net) that resolves to this node only.
+# Tokens are loaded from /etc/caddy/mediamtx-api.env by caddy.service (systemd drop-in EnvironmentFile),
+# and WEBSCREEN_NODE_HOST lives in the same env file.
+{$WEBSCREEN_NODE_HOST} {
+	# WHIP is served here so the node can act as origin when STREAM_WHIP_ORIGIN (or the latency
+	# harness --node-host) points at it. The route is inert while ingress has no publisher.
+	@whip path /live/*/whip /live/*/whip/*
+	handle @whip {
+		reverse_proxy 127.0.0.1:8889
+	}
+	@ingress header Authorization "Bearer {env.MEDIAMTX_API_TOKEN}"
+	handle @ingress {
+		header X-WebScreen-MediaMTX-Role ingress
+		reverse_proxy 127.0.0.1:9997
+	}
+	@egress header Authorization "Bearer {env.MEDIAMTX_EGRESS_API_TOKEN}"
+	handle @egress {
+		header X-WebScreen-MediaMTX-Role egress
+		reverse_proxy 127.0.0.1:9998
+	}
+	handle {
+		respond 401
+	}
+}

--- a/web/streaming/README.md
+++ b/web/streaming/README.md
@@ -53,6 +53,10 @@ If a VPS check fails before the Worker deploy, stop the split units and restore 
 
 ## Read replica node (delta from an origin node)
 
+Use `Caddyfile.node` instead of `Caddyfile` on every node other than the Indigo origin. It serves one node-specific host taken from `WEBSCREEN_NODE_HOST` (add `WEBSCREEN_NODE_HOST=chi1.web-screen.net` to `/etc/caddy/mediamtx-api.env`, which caddy.service reads through a systemd drop-in `EnvironmentFile=`). The host must resolve to this node only (never `webscreen.tv`, which resolves to every read node), so the cron worker can count readers per node and ACME challenges always reach the right machine. Public hostnames stay a single `webscreen.tv` for VRChat (see `docs/streaming/operations.md`, "ホスト名の役割").
+
+If the node also carries `mediamtx-ingress.yml` (so it can become origin), set `webrtcAdditionalHosts` to this node's public IP and open UDP 8189; `Caddyfile.node` already routes `/live/*/whip*` to the local ingress.
+
 A read replica serves the same `rtsp://host/live/{id}` paths without running ingress or the relay hook. When a reader hits a path that has no publisher, MediaMTX invokes `replica-pull.sh`, which walks an ordered `ORIGINS` list and pulls one stream with `ffmpeg -c copy` from that origin's egress (`:554`, TCP). If every origin fails the pull exits non-zero and MediaMTX surfaces the failure to the reader (no silent restart).
 
 Install differences from an origin node:

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -29,7 +29,7 @@ import {
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
-import { analyzeDirectory, clearPreviousRunArtifacts, rewriteWhipUrlHost, screenShareUrl, validateRunOptions } from '../../scripts/latency-probe-run';
+import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, syntheticHealthBody, validateRunOptions } from '../../scripts/latency-probe-run';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 
 function rasterize(timestampMs: number, cell = 20): { rgb: Uint8Array; width: number; height: number } {
@@ -350,8 +350,10 @@ describe('latency probe CLI contract', () => {
     expect(enabled).toMatchObject({ options: { nodeHost: null } });
     const node = parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', 'chi1.web-screen.net']);
     expect(node).toMatchObject({ command: 'run', options: { nodeHost: 'chi1.web-screen.net' } });
-    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', 'https://chi1.web-screen.net'])).toThrow('DNS host');
-    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', '-bad'])).toThrow('DNS host');
+    for (const bad of ['https://chi1.web-screen.net', '-bad', 'attacker.example', 'localhost', '127.0.0.1', 'a.b.web-screen.net', 'web-screen.net', 'chi1.web-screen.net.evil.example']) {
+      expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', bad])).toThrow('web-screen.net');
+    }
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: null, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: 'evil.example' })).toThrow('web-screen.net');
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--video-profile', 'realtime', '--max-bitrate', '1500000', '--scroll', '240'])).toMatchObject({ command: 'run', options: { videoProfile: 'realtime', maxBitrate: 1_500_000, scrollPixelsPerSecond: 240 } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '60', '--max-bitrate', '1500000'])).toMatchObject({ command: 'run', options: { videoProfile: 'quality', abCycleSeconds: 60, maxBitrate: 1_500_000 } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--stream-id', 'Ab12Cd34Ef56'])).toMatchObject({ command: 'run', options: { streamId: 'Ab12Cd34Ef56' } });
@@ -419,6 +421,18 @@ describe('latency probe node host routing', () => {
     expect(rewritten.whipUrl).toBe('https://chi1.web-screen.net/live/AbCdEf123456/whip');
     expect(rewritten.streamUrl).toBe('rtspt://webscreen.tv/live/AbCdEf123456');
     expect(rewritten.status).toBe('live');
+  });
+
+  test('合成 health は呼ばれるごとに egress が増える ready を返す', () => {
+    const first = JSON.parse(syntheticHealthBody(0)) as { state: string; egressBytes: number };
+    const second = JSON.parse(syntheticHealthBody(1)) as { state: string; egressBytes: number };
+    expect(first.state).toBe('ready');
+    expect(second.egressBytes).toBeGreaterThan(first.egressBytes);
+  });
+
+  test('書き換え応答のヘッダーから圧縮・長さ・validator を落とす', () => {
+    const headers = headersForRewrittenBody({ 'Content-Type': 'application/json', 'Content-Encoding': 'br', 'content-length': '123', etag: 'W/"x"', 'cache-control': 'no-store' });
+    expect(headers).toEqual({ 'Content-Type': 'application/json', 'cache-control': 'no-store' });
   });
 
   test('whipUrl を持たない応答と JSON でない本文はそのまま返す', () => {

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -29,7 +29,7 @@ import {
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
-import { analyzeDirectory, clearPreviousRunArtifacts, screenShareUrl, validateRunOptions } from '../../scripts/latency-probe-run';
+import { analyzeDirectory, clearPreviousRunArtifacts, rewriteWhipUrlHost, screenShareUrl, validateRunOptions } from '../../scripts/latency-probe-run';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 
 function rasterize(timestampMs: number, cell = 20): { rgb: Uint8Array; width: number; height: number } {
@@ -129,8 +129,8 @@ describe('latency probe video profiles', () => {
   test('公開境界は不正なプロファイル・bitrate・周期を副作用前に拒否する', async () => {
     const evaluator: VideoProfileEvaluator = { evaluate: async () => { throw new Error('must not evaluate'); } };
     await expect(applyVideoProfile(evaluator, 'other' as 'quality', 1_500_000, 1_000)).rejects.toThrow('video profile');
-    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 999_999, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null })).toThrow('maxBitrate');
-    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 1_500_000, abCycleSeconds: 59, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null })).toThrow('cycleSeconds');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 999_999, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null })).toThrow('maxBitrate');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 1_500_000, abCycleSeconds: 59, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null })).toThrow('cycleSeconds');
   });
 
   test('sender差し替え時は5秒ポーリングで同じプロファイルを再適用する', async () => {
@@ -347,6 +347,11 @@ describe('latency probe CLI contract', () => {
     expect(parseLatencyProbeArgs(['login']).command).toBe('login');
     const enabled = parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--notify-discord', '123456789012345', '--server-snap', 'relay-1.example']);
     expect(enabled).toMatchObject({ command: 'run', options: { notifyDiscordChannelId: '123456789012345', serverSnapHost: 'relay-1.example', player: null } });
+    expect(enabled).toMatchObject({ options: { nodeHost: null } });
+    const node = parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', 'chi1.web-screen.net']);
+    expect(node).toMatchObject({ command: 'run', options: { nodeHost: 'chi1.web-screen.net' } });
+    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', 'https://chi1.web-screen.net'])).toThrow('DNS host');
+    expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', '-bad'])).toThrow('DNS host');
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--video-profile', 'realtime', '--max-bitrate', '1500000', '--scroll', '240'])).toMatchObject({ command: 'run', options: { videoProfile: 'realtime', maxBitrate: 1_500_000, scrollPixelsPerSecond: 240 } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '60', '--max-bitrate', '1500000'])).toMatchObject({ command: 'run', options: { videoProfile: 'quality', abCycleSeconds: 60, maxBitrate: 1_500_000 } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--stream-id', 'Ab12Cd34Ef56'])).toMatchObject({ command: 'run', options: { streamId: 'Ab12Cd34Ef56' } });
@@ -404,5 +409,22 @@ describe('latency probe quality helpers', () => {
       videoProfile: 'quality', maxBitrate: null, streamId: 'Ab12Cd34Ef56',
     }));
     expect([...url.searchParams.entries()]).toEqual([['stream-id', 'Ab12Cd34Ef56']]);
+  });
+});
+
+describe('latency probe node host routing', () => {
+  test('whipUrl のホストだけを差し替え、パスと https と他フィールドは保つ', () => {
+    const body = JSON.stringify({ id: 'AbCdEf123456', whipUrl: 'https://webscreen.tv/live/AbCdEf123456/whip', streamUrl: 'rtspt://webscreen.tv/live/AbCdEf123456', status: 'live' });
+    const rewritten = JSON.parse(rewriteWhipUrlHost(body, 'chi1.web-screen.net')) as Record<string, unknown>;
+    expect(rewritten.whipUrl).toBe('https://chi1.web-screen.net/live/AbCdEf123456/whip');
+    expect(rewritten.streamUrl).toBe('rtspt://webscreen.tv/live/AbCdEf123456');
+    expect(rewritten.status).toBe('live');
+  });
+
+  test('whipUrl を持たない応答と JSON でない本文はそのまま返す', () => {
+    const error = JSON.stringify({ errorCode: 'streamLimitReached' });
+    expect(rewriteWhipUrlHost(error, 'chi1.web-screen.net')).toBe(error);
+    expect(rewriteWhipUrlHost('not json', 'chi1.web-screen.net')).toBe('not json');
+    expect(rewriteWhipUrlHost('[1,2]', 'chi1.web-screen.net')).toBe('[1,2]');
   });
 });


### PR DESCRIPTION
## なぜこの変更が必要か

2 台目ノード Cherry Chicago（88.216.73.71）を origin にした時の VRChat 側レイテンシを測りたい。遅延ハーネス `latency-probe.ts` は本番の画面共有ページを使い、配信先は Worker の `STREAM_WHIP_ORIGIN`（Indigo）に固定されているため、本番設定と DNS を触らずに別ノードへ配信する手段が無かった。
あわせて Cherry を read ノードとして cron に認識させないと、Cherry を視聴する配信は viewer 0 と判定され 600 秒で `no_viewers` 終了する。

## 変更内容

- `web/scripts/latency-probe.ts` / `latency-probe-run.ts`: `--node-host chi1.web-screen.net`。Playwright の `route` で配信開始 / 再利用 API 応答の `whipUrl` のホストだけを差し替え、出口計測と VRChat 用 URL も同じノードに向ける。health は合成 ready 応答に差し替え（本番 health は Indigo しか見ないため）、到達確認は出口 ffmpeg に寄せる
- `web/cron/wrangler.jsonc`: `MEDIAMTX_READ_EGRESS_API_URLS` に `https://chi1.web-screen.net` を追加
- `web/streaming/Caddyfile.node`: Indigo 専用の `Caddyfile` と分けたノード用テンプレ（`WEBSCREEN_NODE_HOST` 環境変数、Control API + WHIP ルート）。README に節を追加
- `Makefile`: `NODE_HOST=` を通す。変数はレシピ文字列へ展開せず `LP_*` 別名の環境変数で渡し、元の名前は `unexport`
- docs: `latency-harness.md` に `--node-host` 節、`vrchat-ab-runbook.md` にノード比較（run A / B / C）の手順

## 意思決定

### 採用アプローチ
- ハーネス側で API 応答を差し替える。理由: 本番 Worker・DNS・他ユーザーに影響を出さずに計測できる。ノード側は本番 JWKS を参照するので publish JWT はそのまま使える
- `--node-host` は `web-screen.net` 配下の 1 ラベルのみ許可。理由: 本番発行の publish JWT を送る先なので任意ホストを許さない

### 却下した代替案
- `STREAM_WHIP_ORIGIN` を一時的に Cherry へ切り替える → 却下: 全ユーザーの配信先が変わる
- preview Worker を立てる → 却下: Discord OAuth・D1 の別環境が要り、計測のための構築が重い

### レビュー指摘への対応
codex レビューゲート（sol high、通常 + セキュリティ）4 周。詳細は後述の対応表コメント。

## テスト

- [x] `bun test tests/scripts/latency-probe.test.ts` 37 pass（CLI 引数・allowlist・whipUrl 書き換え・合成 health・ヘッダー除去）
- [x] `make check`（typecheck / test / build）成功
- [x] `Caddyfile.node` を Cherry 実機の `caddy validate` で確認
- [x] Makefile: `SOURCE='$(shell printf X >&2)'` を env / 引数で渡しても X が出ない、シェル記号入り `NODE_HOST` は bun 側で拒否、`MIN=abc` が bun の引数エラーになる（値が届く）
- [ ] 実機: Cherry の DNS（`chi1.web-screen.net`）と Caddy 証明書が揃ってから、run B（`--node-host`）で配信が Cherry に立つことを確認（Issue noricha-vr/choicast#20）

## マージ条件

**`chi1.web-screen.net` の A レコードと Cherry の Caddy 証明書が有効になってからマージする。** cron の read ノード一覧に到達できないノードが入ると、全配信の `no_viewers` / `kick_pending` 解除が見送られる（fail-closed）。

Refs noricha-vr/choicast#20

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
