### PR TITLE
docs(streaming): Cherry Chicago の origin / replica 遅延計測（I26）を記録する

### DIFF
--- a/docs/streaming/operations.md
+++ b/docs/streaming/operations.md
@@ -24,7 +24,7 @@ cron Worker --別 Bearer client--> ingress（publisher kick）/ egress（viewer�
 | ノード | 役割 | 実体 | 常駐 unit |
 |---|---|---|---|
 | Indigo | **origin**（WHIP 受け + relay + read） | WebARENA Indigo `161.34.34.128`（SSH: `ssh webscreen-indigo-poc`、鍵は ~/.ssh/config 参照）。ufw は inactive で、ポート開放は WebARENA ポータルの FW で行う | `webscreen-mediamtx-ingress` / `webscreen-mediamtx-egress` |
-| Cherry | **read replica + origin 機能**（構築中。2026-09-04 契約） | Cherry Servers Cloud VDS 2（Chicago, US）`88.216.73.71`（SSH: `ssh webscreen-cherry`、root、Ed25519 鍵は ~/.ssh/config 参照）。ポータル名 `webscreen-chicago-01` / Resource #988436。4 vCore / 16 GB / NVMe 100 GB / 1 Gbps / 月 10 TB 込み / €29 月（次回請求 2026-10-04）。Ubuntu 24.04。FW は ufw（ポータル FW の有無は構築時に確認）。ノード用ホスト `chi1.web-screen.net` | `webscreen-mediamtx-egress-replica` + `webscreen-mediamtx-ingress`（ingress は単体計測・origin 切替用。WHIP を向けるまで待機） |
+| Cherry | **read replica + origin 機能**（構築済み 2026-09-04。`webscreen.tv` の A レコードには未登録、WHIP も未割当。計測は [verification.md](verification.md) I26） | Cherry Servers Cloud VDS 2（Chicago, US）`88.216.73.71`（SSH: `ssh webscreen-cherry`、root、Ed25519 鍵は ~/.ssh/config 参照）。ポータル名 `webscreen-chicago-01` / Resource #988436。4 vCore / 16 GB / NVMe 100 GB / 1 Gbps / 月 10 TB 込み / €29 月（次回請求 2026-10-04）。Ubuntu 24.04。ufw active（22 / 80 / 443 / 554 tcp + 8189 udp）、ポータル側 FW なし。TCP 554 の接続数上限は unit `webscreen-egress-cap`（nftables）。ノード用ホスト `chi1.web-screen.net`（Caddy = `web/streaming/Caddyfile.node`、アクセスログ有効）。relay は **Indigo 稼働中の AAC 版を複製**（`/opt/webscreen/streaming/releases/indigo-prod-aac-2026-09-04`。リポの `relay.sh` は MP3 候補なので入れない） | `webscreen-mediamtx-ingress`（`webrtcAdditionalHosts` は自 IP）+ `webscreen-mediamtx-egress-replica`（`ORIGINS=161.34.34.128`）+ `webscreen-egress-cap` |
 
 origin ノードの中身:
 

--- a/docs/streaming/region-and-traffic-plan.md
+++ b/docs/streaming/region-and-traffic-plan.md
@@ -88,7 +88,7 @@ NTTPC からは 2026-09-04 に「申告どおり（160 GB/日）の範囲で利�
 | 項目 | いま言えること | 確かめ方 |
 |---|---|---|
 | 1000 TB を超える枠を買えるか | ポータルの 1 注文上限が 1000 TB。ハード上限の公開記載はない | Cherry へ問い合わせ。ただし 1 Gbps × 1 台では月 324 TB が物理上限なので当面不要 |
-| Chicago の実 RTT（日本の自宅回線から） | 2026-09-04 に自宅 Mac から契約したサーバーへ ping 5 回で **平均 184 ms・ロス 0**（調査の引用値 125〜145 ms より大きい。暫定値） | ハーネス（[latency-harness.md](latency-harness.md)）で Cherry を origin にした配信と Indigo 配信を VRChat 実機で A/B し、体感遅延の差で判断する |
+| Chicago の実 RTT（日本の自宅回線から） | **実測済み（2026-09-04）**: ping 平均 184 ms。配信経路では Cherry origin で出口 +0.18 秒（0.776 → 0.951 秒）、Cherry replica 経由で約 +0.4 秒（[verification.md](verification.md) I26） | 体感の許容判断は VRChat 実機で行う（Windows 録画の不調で未取得） |
 | Chicago 実機の耐久 | 未実施 | 500 / 700 viewer、40 人 × 10〜15 配信、pps、72 時間連続 |
 | Cherry 東京の月間転送枠 | ページ上部 100 TB とプラン表 20 TB の表記混在（[#227](https://github.com/noricha-vr/WebScreen/issues/227)） | Chicago を採るなら判断に不要。東京を再検討する時だけ書面確認 |
 

--- a/docs/streaming/verification.md
+++ b/docs/streaming/verification.md
@@ -574,6 +574,27 @@ bun scripts/latency-probe.ts run --minutes 4 --source 'http://127.0.0.1:0/latenc
 - 前の配信が終了した直後に新 URL を貼ると Player Error になり再貼付が要る（2 回再現）。ストリームの SPS / PPS は A / B で一致しており設定差ではない
 - 貼付漏れ・視点ずれで無効になった run が 5 本あり、人の操作が律速だった。URL 固定（#210）と 1 配信内の自動切替（#209）で次回からは 1 回貼るだけで済む
 
+### I26: Cherry Chicago（2 台目）を origin / replica にした時の遅延（2026-09-04）
+
+Cherry Servers Chicago Cloud VDS 2（88.216.73.71、[operations.md](operations.md)「サーバー実体」）を構築し、
+`latency-probe.ts` の `--node-host`（[latency-harness.md](latency-harness.md)）で本番設定を変えずに 3 経路を各 8 分計測した。
+配信元は ms25 の実 Chrome（東京・自宅回線）、計測ページは `latency-source.html?tones=1`、画質は quality 既定。
+自宅 Mac → Cherry の ping は平均 184 ms。生値は `docs/tmp/latency/2026-09-04T08-36-28-429Z`（A）/ `…T08-52-29-325Z`（B）/ `…T09-01-48-942Z`（C）（git 管理外）。
+
+| run | 経路 | 配信元 → ingress | 配信元 → egress（relay 後） | Mac からの出口（rtspt）中央値 / p95 | A との差 |
+|---|---|---:|---:|---:|---:|
+| A | Indigo origin → 日本の視聴者 | 0.55〜0.57 秒 | 0.79〜0.82 秒 | **0.776 秒** / 0.79 秒 | 基準 |
+| B | **Cherry origin** → 日本の視聴者 | 0.62 秒 | 0.87 秒 | **0.951 秒** / 0.96 秒 | **+0.18 秒** |
+| C | Indigo origin → **Cherry replica**（runOnDemand pull）→ 日本の視聴者 | （Indigo 側 0.55 秒） | Cherry egress **1.10〜1.11 秒**（サーバー内 3 round） | 未計測（推定 約 1.18 秒 = Cherry egress + 帰り約 0.08 秒） | **約 +0.4 秒**（推定） |
+
+- **Cherry を origin にしても増分は日本 ⇄ Chicago の往復（約 0.18 秒）だけ**。行き（WHIP）が約 +0.07 秒、帰り（rtspt）が約 +0.08 秒で、ingress → egress の relay コスト（約 0.25 秒）は Indigo と同じ。8 分間の出口は 0.95〜0.97 秒で安定し、p95 のスパイクも A と同程度
+- **replica 経由は約 +0.4 秒**。Indigo egress → Cherry egress の pull 1 ホップで +0.31 秒（往復 0.18 秒 + ffmpeg の起動バッファ）。DNS 均等分散で日本の視聴者が Cherry を引いた時の遅延で、2 台構成の実コストはここに出る
+- replica の立ち上がり: 最初の視聴者が来てから path が ready になるまで 4〜6 秒（`runOnDemand` 起動 → ffmpeg 接続 → キーフレーム）。2 人目以降は即時。最後の視聴者が切れて 10 秒で pull は止まる
+- 測定境界の注意: C の出口は Mac ではなく Cherry サーバー内の単発取得（`--server-snap webscreen-cherry` の egress 値）で、日本への帰り分は B の「出口 − egress」（0.08 秒）を流用した推定。ハーネスに「publish 先と read 先を別ノードにする」オプションが無いため（`--node-host` は両方を同じノードにする）
+- VRChat プレイヤー側（`--player win2022`）は A で録画が期限切れになり標本 0。8 分の gdigrab 録画が VRChat 起動中に完走しない（短い録画は通る）。ultrafast 化と期限延長（#244）でも再現したため、B / C は Windows 録画なしで実施した。プレイヤー側のバッファは経路に依存しないので、経路間の差は出口の差で読む
+- B の Cherry は音声が MP3 候補プロファイル（`web/streaming/relay.sh` の 0.2.0-beta）で動いていた。映像遅延には影響しないが VRChat PC では無音になりうる（I23）。計測後に Indigo 稼働中の AAC 版 relay を Cherry へ複製して切り替え済み（[operations.md](operations.md)）
+- 判断: Cherry は origin としても replica としても使える。遅延だけなら origin を Cherry に移す方が replica 経由より軽い。移設判断は [scale-plan.md](scale-plan.md)「origin 移設」の基準（転送量）と、この +0.18 秒を体感で許容できるかで決める
+
 ## 検証できていないこと
 
 | # | 項目 | 影響 |


### PR DESCRIPTION
## なぜこの変更が必要か

Cherry Chicago を 2 台目ノードとして構築し、origin / replica それぞれの経路で VRChat 向け配信の遅延を実測した。結果と測定境界を verification.md に残さないと、region-and-traffic-plan.md の「Chicago の実 RTT」が未確定のままになり、origin 移設や A レコード 2 本化の判断材料が会話の中にしか無い状態になる。

## 変更内容

- `docs/streaming/verification.md`: I26 として 3 run（A: Indigo origin 0.776 秒 / B: Cherry origin 0.951 秒 / C: Cherry replica 経由 約 1.18 秒推定）の表と、測定境界・未取得項目（VRChat 録画・MP3 プロファイル）・判断を記録
- `docs/streaming/region-and-traffic-plan.md`: 未確定表の「Chicago の実 RTT」を実測済みに更新
- `docs/streaming/operations.md`: Cherry 行を構築後の実状（FW・接続数上限・Caddy・AAC relay の複製元）に更新

## テスト

- [x] ドキュメントのみ。生値のディレクトリ名と summary.md の値を突合

Refs noricha-vr/choicast#20

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
