### PR TITLE
feat(latency-probe): --read-host で視聴先だけを別ノードに差し替え、同一 DC 内 replica の遅延（run D）を記録する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,18 +96,19 @@ latency-probe: MIN ?= 5
 # $(value) で生の文字列を取り Make 自身の $(shell ...) 展開を起こさず、コマンドライン変数が
 # target-specific 代入を上書きできないよう別名（LP_*）で export する
 # コマンドライン変数は Make が子環境へ export する時に展開するので、元の名前は export しない
-unexport MIN SOURCE PLAYER NOTIFY_DISCORD SERVER_SNAP NODE_HOST
+unexport MIN SOURCE PLAYER NOTIFY_DISCORD SERVER_SNAP NODE_HOST READ_HOST
 latency-probe: export LP_MIN := $(value MIN)
 latency-probe: export LP_SOURCE := $(value SOURCE)
 latency-probe: export LP_PLAYER := $(value PLAYER)
 latency-probe: export LP_NOTIFY_DISCORD := $(value NOTIFY_DISCORD)
 latency-probe: export LP_SERVER_SNAP := $(value SERVER_SNAP)
 latency-probe: export LP_NODE_HOST := $(value NODE_HOST)
-latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST）
+latency-probe: export LP_READ_HOST := $(value READ_HOST)
+latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST、READ_HOST=HOST[:PORT]）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \
 	if [[ ! -f "$$script" ]]; then echo 'feat/latency-harness をマージしてください' >&2; exit 1; fi; \
 	if [[ -z "$$LP_SOURCE" ]]; then echo 'SOURCE=URL を指定してください' >&2; exit 64; fi; \
-	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$$LP_MIN" --source "$$LP_SOURCE" $${LP_PLAYER:+--player "$$LP_PLAYER"} $${LP_NOTIFY_DISCORD:+--notify-discord "$$LP_NOTIFY_DISCORD"} $${LP_SERVER_SNAP:+--server-snap "$$LP_SERVER_SNAP"} $${LP_NODE_HOST:+--node-host "$$LP_NODE_HOST"}
+	cd "$(WEB_DIR)" && bun scripts/latency-probe.ts run --minutes "$$LP_MIN" --source "$$LP_SOURCE" $${LP_PLAYER:+--player "$$LP_PLAYER"} $${LP_NOTIFY_DISCORD:+--notify-discord "$$LP_NOTIFY_DISCORD"} $${LP_SERVER_SNAP:+--server-snap "$$LP_SERVER_SNAP"} $${LP_NODE_HOST:+--node-host "$$LP_NODE_HOST"} $${LP_READ_HOST:+--read-host "$$LP_READ_HOST"}
 
 stream-source: ## 遅延測定中の配信元タブの表示先を切り替える（URL=URL）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -42,6 +42,7 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 - 出口計測（`ffmpeg` の単発取得・音声・画質）と Discord に流す視聴 URL も `rtsp(t)://<node-host>/live/{id}` になる。VRChat にはこの URL を貼る（`webscreen.tv` と同じく allowlist 外なので条件は同じ）
 - `--server-snap` は別指定（例 `--server-snap webscreen-cherry`）。ノードの SSH alias を渡す
 - 使った host は `sender-config.json` の `harnessNodeHost` / `harnessReadHost` に残る
+- `--read-host HOST[:PORT]` で視聴先だけを別に指定できる（`--node-host` と併用して「A に配信、B から視聴」を測る。web-screen.net 配下の 1 ラベル + 任意ポート）。ポート付きは自宅回線から届かないことがある（2026-09-04 に 5554 が不通。554 は通る）ので、届かない時はノード側でポートを入れ替える
 - ノード側の前提: ingress + relay が動き、Caddy がそのホストで WHIP ルートを持ち（`web/streaming/Caddyfile.node`）、cron の `MEDIAMTX_READ_EGRESS_API_URLS` にそのノードの Control API が入っていること。入っていないと本番 cron が「viewer 0」と判定し、`STREAM_NO_VIEWER_SECONDS`（600 秒）で配信を終了させる
 
 ## 既知の失敗と診断ファイル

--- a/docs/streaming/verification.md
+++ b/docs/streaming/verification.md
@@ -586,9 +586,12 @@ Cherry Servers Chicago Cloud VDS 2（88.216.73.71、[operations.md](operations.m
 | A | Indigo origin → 日本の視聴者 | 0.55〜0.57 秒 | 0.79〜0.82 秒 | **0.776 秒** / 0.79 秒 | 基準 |
 | B | **Cherry origin** → 日本の視聴者 | 0.62 秒 | 0.87 秒 | **0.951 秒** / 0.96 秒 | **+0.18 秒** |
 | C | Indigo origin → **Cherry replica**（runOnDemand pull）→ 日本の視聴者 | （Indigo 側 0.55 秒） | Cherry egress **1.10〜1.11 秒**（サーバー内 3 round） | 未計測（推定 約 1.18 秒 = Cherry egress + 帰り約 0.08 秒） | **約 +0.4 秒**（推定） |
+| D | **Cherry origin → 同じ Chicago 内の replica**（同一ノードの別 MediaMTX、`ORIGINS=127.0.0.1`）→ 日本の視聴者 | 0.64 秒 | replica egress **1.14 秒**（origin egress は B と同じ 0.87 秒） | **1.206 秒** / 1.23 秒 | **+0.43 秒** |
 
 - **Cherry を origin にしても増分は日本 ⇄ Chicago の往復（約 0.18 秒）だけ**。行き（WHIP）が約 +0.07 秒、帰り（rtspt）が約 +0.08 秒で、ingress → egress の relay コスト（約 0.25 秒）は Indigo と同じ。8 分間の出口は 0.95〜0.97 秒で安定し、p95 のスパイクも A と同程度
-- **replica 経由は約 +0.4 秒**。Indigo egress → Cherry egress の pull 1 ホップで +0.31 秒（往復 0.18 秒 + ffmpeg の起動バッファ）。DNS 均等分散で日本の視聴者が Cherry を引いた時の遅延で、2 台構成の実コストはここに出る
+- **replica 経由は約 +0.4 秒**。Indigo egress → Cherry egress の pull 1 ホップで +0.31 秒。DNS 均等分散で日本の視聴者が Cherry を引いた時の遅延で、2 台構成の実コストはここに出る
+- **pull 1 ホップのコストはネットワーク距離ではなく ffmpeg の取り寄せバッファが主**。D（同一 DC、往復 1 ms 未満）でも +0.27 秒（server-snap の egress 差）で、C（日本 ⇄ Chicago 往復 0.18 秒込み）の +0.31 秒とほぼ同じ。`replica-pull.sh` の ffmpeg 入力側（probe / analyze / キーフレーム待ち）を詰めれば縮む余地がある
+- 想定する最終構成「日本 → Cherry origin → Chicago 内 replica → 日本」は **1.21 秒**（Indigo 直の 0.78 秒 + 0.43 秒）。D の計測は Cherry 上で origin egress を 5554、replica を 554 に一時入れ替えて行い（自宅回線から 5554 が届かなかったため）、計測後に戻した。生値: `docs/tmp/latency/2026-09-04T12-33-12-779Z`
 - replica の立ち上がり: 最初の視聴者が来てから path が ready になるまで 4〜6 秒（`runOnDemand` 起動 → ffmpeg 接続 → キーフレーム）。2 人目以降は即時。最後の視聴者が切れて 10 秒で pull は止まる
 - 測定境界の注意: C の出口は Mac ではなく Cherry サーバー内の単発取得（`--server-snap webscreen-cherry` の egress 値）で、日本への帰り分は B の「出口 − egress」（0.08 秒）を流用した推定。ハーネスに「publish 先と read 先を別ノードにする」オプションが無いため（`--node-host` は両方を同じノードにする）
 - VRChat プレイヤー側（`--player win2022`）は A で録画が期限切れになり標本 0。8 分の gdigrab 録画が VRChat 起動中に完走しない（短い録画は通る）。ultrafast 化と期限延長（#244）でも再現したため、B / C は Windows 録画なしで実施した。プレイヤー側のバッファは経路に依存しないので、経路間の差は出口の差で読む

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -32,6 +32,8 @@ export interface RunOptions {
   abCycleSeconds: number | null; scrollPixelsPerSecond: number; outletQualitySeconds: number; notifyDiscordChannelId: string | null; serverSnapHost: string | null; streamId: string | null;
   /** 配信先ノードのホスト名。null なら本番既定（API 応答の whipUrl と webscreen.tv）を使う。 */
   nodeHost: string | null;
+  /** 視聴先だけを差し替える `host` または `host:port`。null なら nodeHost、それも null なら webscreen.tv。 */
+  readHost: string | null;
 }
 interface ActiveController { endpoint: string; sourceUrl: string }
 interface ControllerState { sourcePage: import('@playwright/test').Page | null; sourceUrl: string; sourceServerUrl: string }
@@ -73,7 +75,7 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
     if (options.nodeHost) await routeWhipToNode(sharingPage, options.nodeHost);
     await sharingPage.goto(screenShareUrl(options), { waitUntil: 'domcontentloaded', timeout: 30_000 });
     const streamId = await startScreenShare(sharingPage, options.profileDir);
-    const readHost = options.nodeHost ?? 'webscreen.tv';
+    const readHost = options.readHost ?? options.nodeHost ?? 'webscreen.tv';
     await writeFile(join(options.outDir, 'sender-config.json'), JSON.stringify({ ...await captureSenderConfig(sharingPage), harnessNodeHost: options.nodeHost, harnessReadHost: readHost }, null, 2) + '\n');
     const target = resolveSourceUrl(options.source, sourceServer.url);
     if (target !== sourceServer.url.href) await sourcePage.goto(target, { waitUntil: 'domcontentloaded' });
@@ -207,6 +209,7 @@ export async function clearPreviousRunArtifacts(outDir: string): Promise<void> {
 export function validateRunOptions(options: RunOptions): void {
   if (options.videoProfile !== 'quality' && options.videoProfile !== 'realtime') throw new Error('videoProfile must be quality or realtime');
   if (options.nodeHost !== null) validateNodeHost(options.nodeHost);
+  if (options.readHost !== null) validateReadHost(options.readHost);
   if (options.maxBitrate !== null) validateVideoProfile(options.videoProfile, options.maxBitrate);
   if (options.videoProfile === 'realtime' && options.maxBitrate === null) throw new Error('realtime videoProfile requires maxBitrate');
   if (options.abCycleSeconds !== null) {
@@ -217,6 +220,15 @@ export function validateRunOptions(options: RunOptions): void {
 
 /** ハーネスが配信先に選べるノードは自前ドメイン配下だけ（publish JWT を任意ホストへ送らせない）。 */
 export const NODE_HOST_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.web-screen\.net$/;
+
+/** 視聴先は nodeHost と同じ allowlist に任意のポート（1〜65535）を許す。 */
+export function validateReadHost(readHost: string): void {
+  const [host, port, ...rest] = readHost.split(':');
+  if (rest.length > 0 || host === undefined) throw new Error('readHost must be host or host:port');
+  validateNodeHost(host);
+  if (port !== undefined && !/^[1-9][0-9]{0,4}$/.test(port)) throw new Error('readHost port must be an integer');
+  if (port !== undefined && Number(port) > 65_535) throw new Error('readHost port must be 1..65535');
+}
 
 export function validateNodeHost(nodeHost: string): void {
   if (!NODE_HOST_PATTERN.test(nodeHost)) throw new Error('nodeHost must be a single label under web-screen.net (e.g. chi1.web-screen.net)');

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -3,7 +3,7 @@ import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-import { analyzeDirectory, loginProfile, runLatencyProbe, switchSource, validateNodeHost, type RunOptions } from './latency-probe-run';
+import { analyzeDirectory, loginProfile, runLatencyProbe, switchSource, validateNodeHost, validateReadHost, type RunOptions } from './latency-probe-run';
 import { checkWindowsRecording } from './latency-probe-player';
 
 const HELP = `Usage: bun scripts/latency-probe.ts <subcommand> [options]
@@ -13,7 +13,7 @@ WebScreen配信を実Mac Chromeから開始し、RTSPT出口と任意のWindows�
 Subcommands:
   login [--profile-dir PATH]
   player-check [--seconds N] [--out DIR]
-  run --minutes N --source URL [--stream-id ID] [--video-profile quality|realtime] [--max-bitrate 1200000|1500000|2000000] [--ab-cycle 60..600] [--scroll PX_PER_SECOND] [--outlet-quality-seconds N] [--player win2022] [--profile-dir PATH] [--out DIR] [--notify-discord CHANNEL_ID] [--server-snap HOST] [--node-host HOST]
+  run --minutes N --source URL [--stream-id ID] [--video-profile quality|realtime] [--max-bitrate 1200000|1500000|2000000] [--ab-cycle 60..600] [--scroll PX_PER_SECOND] [--outlet-quality-seconds N] [--player win2022] [--profile-dir PATH] [--out DIR] [--notify-discord CHANNEL_ID] [--server-snap HOST] [--node-host HOST] [--read-host HOST[:PORT]]
   source --url URL [--scroll PX_PER_SECOND]
   analyze DIR
 
@@ -37,6 +37,9 @@ run options:
   --node-host HOST   配信先ノードを差し替える（web-screen.net 配下の 1 ラベルのみ、例 chi1.web-screen.net）。配信開始 API 応答の whipUrl のホストを HOST にして WHIP を
                      そのノードへ送り、出口計測と VRChat へ渡す URL も rtsp(t)://HOST/live/{id} にする
                      （本番の STREAM_WHIP_ORIGIN と DNS は変えずに別ノードを origin として測る用途）
+  --read-host HOST[:PORT]
+                     出口計測と VRChat へ渡す URL の視聴先だけを差し替える（web-screen.net 配下の 1 ラベル + 任意のポート）。
+                     --node-host と組み合わせると「A ノードに配信して B ノード（または別ポートの replica）から視聴」を測れる
 
 loginはハーネスが開くChromeで一度だけ人がログインするための待機です。player-checkは配信なしでWindows録画だけを試し、実測前に録画経路を確認します。sourceは実行中runの共有タブを切り替えます。analyzeは保存済みCSVからsummary.mdを再生成します。`;
 
@@ -71,9 +74,10 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
     return { command, url: requiredUrl(values.url, '--url'), scrollPixelsPerSecond: parseScroll(values.scroll) };
   }
   if (command !== 'run') throw new Error(`unknown subcommand: ${command}`);
-  rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'node-host', 'stream-id', 'video-profile', 'max-bitrate', 'ab-cycle', 'scroll', 'outlet-quality-seconds']);
+  rejectUnknown(values, ['minutes', 'source', 'player', 'profile-dir', 'out', 'notify-discord', 'server-snap', 'node-host', 'read-host', 'stream-id', 'video-profile', 'max-bitrate', 'ab-cycle', 'scroll', 'outlet-quality-seconds']);
   if (values['server-snap'] !== undefined && !isValidSshHost(values['server-snap'])) throw new Error('--server-snap must be an ssh host name');
   if (values['node-host'] !== undefined) validateNodeHost(values['node-host']);
+  if (values['read-host'] !== undefined) validateReadHost(values['read-host']);
   if (values['notify-discord'] !== undefined && !/^\d{15,25}$/.test(values['notify-discord'])) throw new Error('--notify-discord must be a Discord channel id');
   if (values['stream-id'] !== undefined && !/^[A-Za-z0-9]{12}$/.test(values['stream-id'])) throw new Error('--stream-id must be a 12-character alphanumeric ID');
   const minutes = Number(values.minutes);
@@ -99,6 +103,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
       notifyDiscordChannelId: values['notify-discord'] ?? null,
       serverSnapHost: values['server-snap'] ?? null,
       nodeHost: values['node-host'] ?? null,
+      readHost: values['read-host'] ?? null,
       streamId: values['stream-id'] ?? null,
       outDir: values.out ?? resolve('..', 'docs', 'tmp', 'latency', timestamp),
     },

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -29,7 +29,7 @@ import {
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
-import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, syntheticHealthBody, validateRunOptions } from '../../scripts/latency-probe-run';
+import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, syntheticHealthBody, validateReadHost, validateRunOptions } from '../../scripts/latency-probe-run';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 import { recordingDeadlineSeconds } from '../../scripts/latency-probe-player';
 
@@ -130,8 +130,8 @@ describe('latency probe video profiles', () => {
   test('公開境界は不正なプロファイル・bitrate・周期を副作用前に拒否する', async () => {
     const evaluator: VideoProfileEvaluator = { evaluate: async () => { throw new Error('must not evaluate'); } };
     await expect(applyVideoProfile(evaluator, 'other' as 'quality', 1_500_000, 1_000)).rejects.toThrow('video profile');
-    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 999_999, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null })).toThrow('maxBitrate');
-    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 1_500_000, abCycleSeconds: 59, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null })).toThrow('cycleSeconds');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 999_999, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null, readHost: null })).toThrow('maxBitrate');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 1_500_000, abCycleSeconds: 59, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null, readHost: null })).toThrow('cycleSeconds');
   });
 
   test('sender差し替え時は5秒ポーリングで同じプロファイルを再適用する', async () => {
@@ -354,7 +354,12 @@ describe('latency probe CLI contract', () => {
     for (const bad of ['https://chi1.web-screen.net', '-bad', 'attacker.example', 'localhost', '127.0.0.1', 'a.b.web-screen.net', 'web-screen.net', 'chi1.web-screen.net.evil.example']) {
       expect(() => parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', bad])).toThrow('web-screen.net');
     }
-    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: null, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: 'evil.example' })).toThrow('web-screen.net');
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: null, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: 'evil.example', readHost: null })).toThrow('web-screen.net');
+    expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--node-host', 'chi1.web-screen.net', '--read-host', 'chi1.web-screen.net:5554'])).toMatchObject({ options: { nodeHost: 'chi1.web-screen.net', readHost: 'chi1.web-screen.net:5554' } });
+    expect(() => validateReadHost('chi1.web-screen.net')).not.toThrow();
+    for (const bad of ['evil.example:554', 'chi1.web-screen.net:0', 'chi1.web-screen.net:70000', 'chi1.web-screen.net:5554:1', '88.216.73.71:554']) {
+      expect(() => validateReadHost(bad)).toThrow();
+    }
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--video-profile', 'realtime', '--max-bitrate', '1500000', '--scroll', '240'])).toMatchObject({ command: 'run', options: { videoProfile: 'realtime', maxBitrate: 1_500_000, scrollPixelsPerSecond: 240 } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--ab-cycle', '60', '--max-bitrate', '1500000'])).toMatchObject({ command: 'run', options: { videoProfile: 'quality', abCycleSeconds: 60, maxBitrate: 1_500_000 } });
     expect(parseLatencyProbeArgs(['run', '--minutes', '2', '--source', 'https://example.test', '--stream-id', 'Ab12Cd34Ef56'])).toMatchObject({ command: 'run', options: { streamId: 'Ab12Cd34Ef56' } });


### PR DESCRIPTION
## なぜこの変更が必要か

想定する最終構成「日本 → Cherry origin → Chicago 内 replica → 日本」の遅延を測るには、配信先（origin）と視聴先（replica）を別に指定する必要がある。`--node-host` は両方を同じノードにするため測れなかった。

## 変更内容

- `--read-host HOST[:PORT]`: 出口計測と VRChat 用 URL の視聴先だけを差し替える。allowlist は `--node-host` と同じ `web-screen.net` 配下 1 ラベル + ポート（1〜65535）。CLI と `validateRunOptions` の両方で検証
- `Makefile`: `READ_HOST=` を `LP_READ_HOST` 経由で渡す（既存の注入対策と同じ形）
- docs: verification.md I26 に run D（同一 DC 内 replica 経由 1.206 秒、+0.43 秒）を追記。latency-harness.md に `--read-host` と「ポート付きは自宅回線から届かないことがある」注意

## テスト

- [x] `bun test tests/scripts/latency-probe.test.ts` 38 pass、`tsc --noEmit` 成功
- [x] 実機: `--node-host chi1.web-screen.net --read-host chi1.web-screen.net`（Cherry 上で origin egress を 5554 に退避し replica を 554 で起動）で 8 分計測が完走
- [x] codex レビューゲート（sol high、通常 + セキュリティ）: ブロッキングなし。改善提案 2 件は defer（下記）

## レビュー指摘 対応表

| # | レーン | 指摘 | 決着 |
|---|---|---|---|
| 1 | 通常 | `--read-host` にポートを付けても `--server-snap` は 554 固定で、別ポート replica の計測を混同しうる | defer: 今回はポート入れ替えで運用回避。server-snap のポート指定は必要になった時に足す（latency-harness.md に注意書き） |
| 2 | 通常 | readHost → nodeHost → webscreen.tv の優先順位を純関数化してテストしたい | defer: 実機 run D で反映を確認済み。純関数化は次にハーネスを触る時に |

Refs noricha-vr/choicast#20

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
