### PR TITLE
feat(latency-probe): 計測ページに秒針つき時計とミリ秒表示を足し、ビープを穏やかにし、Windows 全画面録画を 8 分で完走させる

### DIFF
--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -19,7 +19,8 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 ```
 
 - 初回だけ既定プロファイル `~/.webscreen-harness/chrome-profile` で `bun scripts/latency-probe.ts login` を実行し、開いたChromeでWebScreenへ手動ログインする。未ログイン時は開始せず終了する。
-- `--source` の `127.0.0.1:0` は起動時の空きポートへ置換される。`?tones=1` はステレオ定常トーンも加える。
+- `--source` の `127.0.0.1:0` は起動時の空きポートへ置換される。`?tones=1` は左右チャンネル確認用の小さな持続音（220 / 330 Hz、ゆっくり揺らぐ）も加える。
+- 計測ページは復号用の格子の左に秒針つきアナログ時計、右に `HH:MM:SS.mmm`（配信元 PC のローカル時刻）を描く。VRChat 実機で隣にブラウザの同じページ（または任意の時計）を並べれば、Windows 全画面録画のフレームから目視でも遅延を読める。どちらも格子の隔離矩形の外に描くので復号には影響しない（plain / heavy / 800x600 で確認済み）
 - 結果は `outlet.csv` と `summary.md`。送出側の生counterは `sender.csv`、共有ページで実際に使われたsender/track設定は `sender-config.json` に保存する。設定取得に失敗してもJSONに理由を残す。
 - 出口画質は遅延用の単発取得と別の連続ffmpegで測り、`outlet-quality.csv`（fps・解像度・freeze・実効ビットレートの窓別値）と `outlet-quality.md`（窓数・freeze・解像度変化の要約）を出す。既定の窓は20秒で、`--outlet-quality-seconds 5..120`で変えられる。失敗時は `outlet-quality.log` に理由を残しrunを失敗にする。
 - `--video-profile quality`（既定）は通常の共有ページを開く。`--video-profile realtime --max-bitrate 1200000|1500000|2000000` はproduction共有ページへ設定queryを渡す（省略時は1500000）。`--ab-cycle`なしで`--max-bitrate`をqualityと併用したり許可外の値を指定すると開始前に失敗する。
@@ -50,7 +51,7 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 - 出口が止まっても指定時間まで待機し、`outlet-ffmpeg.log` と `outlet-decode.log` にffmpeg・復号状態を残す。
 - `frames/` の最初/最後の復号フレームと直近の失敗フレームで、配信映像を目視確認できる。
 - `outlet-audio.wav` と `outlet-audio.json` は `analyze` 時に再検出され、`outlet-audio.csv` と既存の映像行を結合して `summary.md` を再生成する。毎秒ビープは `600 + 100 * (UTC秒 mod 8)` Hz の8種類で、絶対遅延を映像近接標本から復元できない時は `audio_latency_phase_ms`（1秒位相）のみを残す。
-- Windows録画は対話セッションのScheduled Taskを使う。失敗時は `player-error.md`、成功時の時刻・`w32tm`補正は `player-recording.md` を見る。
+- Windows録画は対話セッションのScheduled Taskを使う。ssh はタスクの起動と、20 秒間隔の短い done マーカー読みだけに使う（1 本の ssh で録画時間ぶんブロックする方式は 8 分 run で出力なしの exit 1 になり録画を失った。2026-09-04）。失敗時は `player-error.md`、成功時の時刻・`w32tm`補正は `player-recording.md` を見る。
 - run 終了時は共有ページの停止ボタンを押してから Chrome を閉じる。`browser.close()` だけでは停止ビーコンが届かず配信がサーバーに残り、次の run が「既存の配信を終了」経路に入って不安定になる（2026-09-02 に連続 8 run 中 3 run が失敗）。Playwright がクラッシュして Chrome が残った時も同じ状態になるので、`pgrep -f webscreen-harness/chrome-profile` で残留を確認してから始める
 - `page.evaluate` に渡す関数はシリアライズされるため module scope の helper を参照できない（`ReferenceError` になり 1 秒標本が 0 件になる）。閉包内に定義する
 - ffmpeg の `-t` は直後の出力にしか効かない。出力を 2 本持つ画質計測では両方に付けないと終わらず run 全体が固まる
@@ -67,6 +68,6 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 ## 実測前の確認手順（2026-09-02 追記）
 
 1. `bun scripts/latency-probe.ts login`（初回のみ。ハーネスが開く Chrome でログイン）
-2. `bun scripts/latency-probe.ts player-check --seconds 8`（配信なしで Windows 録画・回収だけを試す。録画長が指定の 80% 以上で OK。フレームに PowerShell コンソールや MacType 警告が写らないこと）
+2. `bun scripts/latency-probe.ts player-check --seconds 8`（配信なしで Windows 録画・回収だけを試す。`--seconds` は 900 まで。録画長が指定の 80% 以上で OK。フレームに PowerShell コンソールや MacType 警告が写らないこと）
 3. `make latency-probe MIN=4 SOURCE=... PLAYER=win2022 NOTIFY_DISCORD=<channel> SERVER_SNAP=<host>`
 4. Discord の URL を VRChat に貼り、**プレイヤーを正面に近い視点で**映し続ける（斜めになると復号できない）

--- a/web/scripts/latency-probe-observe.ts
+++ b/web/scripts/latency-probe-observe.ts
@@ -239,7 +239,9 @@ export async function collectOutletGrabs(rtspUrl: string, until: number, output:
         await copyFile(pngPath, join(framesDir, 'last-decoded.png'));
       } else {
         logDecodeFailure(diagnostics, decoded.reason === 'checksum-mismatch' ? 'チェックサム不一致' : '同期パターン未検出', false);
-        await copyFile(pngPath, join(framesDir, 'last-failure.png'));
+        // ffmpeg が exit 0 でも PNG を書かないことがある（2026-09-04 に 8 分 run が 60 枚目でここの ENOENT で落ちた）。
+        // 失敗フレームの保存は診断用なので、無ければ run を止めずに続ける。
+        if (await Bun.file(pngPath).exists()) await copyFile(pngPath, join(framesDir, 'last-failure.png'));
       }
     }
     index += 1;

--- a/web/scripts/latency-probe-player.ts
+++ b/web/scripts/latency-probe-player.ts
@@ -62,7 +62,8 @@ export async function recordWindowsPlayer(outDir: string, until: number): Promis
     try { return { samples: await decodePlayerRecording(local, startedAt, offset.valueMs), warning: durationWarning, diagnostics }; }
     catch (error) { return { samples: [], warning: `Windows録画の復号に失敗しました: ${String(error)}`, diagnostics }; }
   } finally {
-    const cleanup = await runTextProcess(sshPowerShell(`Remove-Item -LiteralPath ${remoteDir} -Recurse -Force -ErrorAction Stop`), 30_000).catch((error) => ({ stdout: '', stderr: String(error), exitCode: -1 }));
+    // 起動 ssh が切れた後にタスクだけ残ると次回の Register -Force と衝突するので、成否に関わらず必ず止めて消す
+    const cleanup = await runTextProcess(sshPowerShell(`$ErrorActionPreference='Continue'; Stop-ScheduledTask -TaskName 'WebScreenLatencyHarness' -ErrorAction SilentlyContinue; Unregister-ScheduledTask -TaskName 'WebScreenLatencyHarness' -Confirm:$false -ErrorAction SilentlyContinue; Remove-Item -LiteralPath ${remoteDir} -Recurse -Force -ErrorAction Stop`), 30_000).catch((error) => ({ stdout: '', stderr: String(error), exitCode: -1 }));
     if (cleanup.exitCode !== 0) console.warn(`Windows一時ディレクトリcleanupに失敗しました: ${cleanup.stderr}`);
   }
 }
@@ -78,6 +79,7 @@ async function waitForDoneMarker(donePath: string, deadlineSeconds: number, poll
   const deadline = Date.now() + deadlineSeconds * 1_000;
   let polls = 0;
   let sshFailures = 0;
+  let invalidMarkers = 0;
   while (Date.now() < deadline) {
     polls += 1;
     const result = await runTextProcess(sshPowerShell(`if(Test-Path -LiteralPath ${donePath}){ Get-Content -Raw -LiteralPath ${donePath} } else { Write-Output 'pending' }`), 45_000);
@@ -85,14 +87,14 @@ async function waitForDoneMarker(donePath: string, deadlineSeconds: number, poll
     else {
       const text = result.stdout.trim();
       const match = /^(-?\d+)\s+(\S+)$/.exec(text);
-      if (match) {
-        const endedAtMs = Date.parse(match[2]!);
-        return { exitCode: Number(match[1]), endedAtMs: Number.isFinite(endedAtMs) ? endedAtMs : null, diagnostics: `- polls: ${polls}\n- ssh failures: ${sshFailures}\n- marker: ${text}` };
-      }
+      const endedAtMs = match ? Date.parse(match[2]!) : Number.NaN;
+      // 形式は "<exit code> <ended UTC ISO>"。時刻が読めないマーカーは書きかけ・破損とみなし、次のポーリングで読み直す
+      if (match && Number.isFinite(endedAtMs)) return { exitCode: Number(match[1]), endedAtMs, diagnostics: `- polls: ${polls}\n- ssh failures: ${sshFailures}\n- marker: ${text}` };
+      if (text !== 'pending') invalidMarkers += 1;
     }
     await Bun.sleep(Math.min(pollMs, Math.max(0, deadline - Date.now())));
   }
-  return { exitCode: -1, endedAtMs: null, diagnostics: `- polls: ${polls}\n- ssh failures: ${sshFailures}\n- marker: (timed out after ${deadlineSeconds} s)` };
+  return { exitCode: -1, endedAtMs: null, diagnostics: `- polls: ${polls}\n- ssh failures: ${sshFailures}\n- invalid markers: ${invalidMarkers}\n- marker: (timed out after ${deadlineSeconds} s)` };
 }
 
 async function remoteFileSize(path: string): Promise<number> {

--- a/web/scripts/latency-probe-player.ts
+++ b/web/scripts/latency-probe-player.ts
@@ -21,6 +21,8 @@ export async function recordWindowsPlayer(outDir: string, until: number): Promis
   const log = `"$env:TEMP\\webscreen-latency-${runId}\\ffmpeg.log"`;
   const started = `"$env:TEMP\\webscreen-latency-${runId}\\started.txt"`;
   const done = `"$env:TEMP\\webscreen-latency-${runId}\\done.txt"`;
+  // run ごとに一意な名前にして、前回の残骸や並行実行と衝突しないようにする（finally で必ず止めて消す）
+  const taskName = `WebScreenLatencyHarness-${runId}`;
   const ffmpeg = 'C:\\Users\\win\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe\\ffmpeg-7.1.1-full_build\\bin\\ffmpeg.exe';
   let diagnostics = '';
   try {
@@ -29,14 +31,14 @@ export async function recordWindowsPlayer(outDir: string, until: number): Promis
     // 300 秒までは通る）、長い無出力セッションが途中で切れると録画が丸ごと失われるため。
     // 一時ディレクトリは Windows 側で $env:TEMP を展開してから __ROOT__ に差し込む（単一引用符リテラル内では展開されない）
     const taskScript = `$recorded=[DateTime]::UtcNow; Set-Content -LiteralPath '__ROOT__\\started.txt' -Value $recorded.ToString('o') -NoNewline; & '${ffmpeg}' -y -f gdigrab -framerate 30 -i desktop -t ${seconds} -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p '__ROOT__\\recording.mp4' 2>&1 | Set-Content -LiteralPath '__ROOT__\\ffmpeg.log'; $code=$LASTEXITCODE; Set-Content -LiteralPath '__ROOT__\\done.txt' -Value ($code.ToString() + ' ' + [DateTime]::UtcNow.ToString('o')) -NoNewline; exit $code`;
-    const startCommand = `$ErrorActionPreference='Stop'; $root=${remoteDir}; $task='WebScreenLatencyHarness'; Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path $root -Force | Out-Null; $taskScript=${powerShellLiteral(taskScript)}.Replace('__ROOT__', $root); $encoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($taskScript)); $action=New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -EncodedCommand $encoded"; $principal=New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited; Register-ScheduledTask -TaskName $task -Action $action -Principal $principal -Force | Out-Null; Start-ScheduledTask -TaskName $task; Write-Output 'task_started'`;
+    const startCommand = `$ErrorActionPreference='Stop'; $root=${remoteDir}; $task=${powerShellLiteral(taskName)}; Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path $root -Force | Out-Null; $taskScript=${powerShellLiteral(taskScript)}.Replace('__ROOT__', $root.Replace("'", "''")); $encoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($taskScript)); $action=New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -EncodedCommand $encoded"; $principal=New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited; Register-ScheduledTask -TaskName $task -Action $action -Principal $principal -Force | Out-Null; Start-ScheduledTask -TaskName $task; Write-Output 'task_started'`;
     console.info(`[player] 録画タスク起動（${seconds} 秒、done 待ち期限 ${recordingDeadlineSeconds(seconds)} 秒）`);
     const startResult = await runTextProcess(sshPowerShell(startCommand), 60_000);
     diagnostics = formatProcessDiagnostics('Windows Scheduled Task 起動', startResult);
     if (startResult.exitCode !== 0 || !startResult.stdout.includes('task_started')) return { samples: [], warning: 'Windows録画タスクを起動できませんでした。player-error.mdのSSH出力を確認してください。', diagnostics };
     const doneMarker = await waitForDoneMarker(done, recordingDeadlineSeconds(seconds));
     diagnostics += `\n## done マーカー待ち\n\n${doneMarker.diagnostics}\n`;
-    const finish = await runTextProcess(sshPowerShell(`$ErrorActionPreference='Continue'; Stop-ScheduledTask -TaskName 'WebScreenLatencyHarness' -ErrorAction SilentlyContinue; Unregister-ScheduledTask -TaskName 'WebScreenLatencyHarness' -Confirm:$false -ErrorAction SilentlyContinue; if(Test-Path -LiteralPath ${started}){ Write-Output ('recording_started_utc=' + (Get-Content -Raw -LiteralPath ${started}).Trim()) }; Write-Output 'ffmpeg_log_begin'; if(Test-Path -LiteralPath ${log}){ Get-Content -Raw -LiteralPath ${log} }; Write-Output 'ffmpeg_log_end'`), 60_000);
+    const finish = await runTextProcess(sshPowerShell(`$ErrorActionPreference='Continue'; Stop-ScheduledTask -TaskName ${powerShellLiteral(taskName)} -ErrorAction SilentlyContinue; Unregister-ScheduledTask -TaskName ${powerShellLiteral(taskName)} -Confirm:$false -ErrorAction SilentlyContinue; if(Test-Path -LiteralPath ${started}){ Write-Output ('recording_started_utc=' + (Get-Content -Raw -LiteralPath ${started}).Trim()) }; Write-Output 'ffmpeg_log_begin'; if(Test-Path -LiteralPath ${log}){ Get-Content -Raw -LiteralPath ${log} }; Write-Output 'ffmpeg_log_end'`), 60_000);
     const recording = { stdout: finish.stdout, stderr: finish.stderr, exitCode: doneMarker.exitCode };
     console.info(`[player] 録画完了 exit=${recording.exitCode} started=${parseUtcMarker(recording.stdout, 'recording_started_utc')}`);
     diagnostics += formatProcessDiagnostics('Windows Scheduled Task 録画', recording);
@@ -63,7 +65,7 @@ export async function recordWindowsPlayer(outDir: string, until: number): Promis
     catch (error) { return { samples: [], warning: `Windows録画の復号に失敗しました: ${String(error)}`, diagnostics }; }
   } finally {
     // 起動 ssh が切れた後にタスクだけ残ると次回の Register -Force と衝突するので、成否に関わらず必ず止めて消す
-    const cleanup = await runTextProcess(sshPowerShell(`$ErrorActionPreference='Continue'; Stop-ScheduledTask -TaskName 'WebScreenLatencyHarness' -ErrorAction SilentlyContinue; Unregister-ScheduledTask -TaskName 'WebScreenLatencyHarness' -Confirm:$false -ErrorAction SilentlyContinue; Remove-Item -LiteralPath ${remoteDir} -Recurse -Force -ErrorAction Stop`), 30_000).catch((error) => ({ stdout: '', stderr: String(error), exitCode: -1 }));
+    const cleanup = await runTextProcess(sshPowerShell(`$ErrorActionPreference='Continue'; Stop-ScheduledTask -TaskName ${powerShellLiteral(taskName)} -ErrorAction SilentlyContinue; Unregister-ScheduledTask -TaskName ${powerShellLiteral(taskName)} -Confirm:$false -ErrorAction SilentlyContinue; Remove-Item -LiteralPath ${remoteDir} -Recurse -Force -ErrorAction Stop`), 30_000).catch((error) => ({ stdout: '', stderr: String(error), exitCode: -1 }));
     if (cleanup.exitCode !== 0) console.warn(`Windows一時ディレクトリcleanupに失敗しました: ${cleanup.stderr}`);
   }
 }

--- a/web/scripts/latency-probe-player.ts
+++ b/web/scripts/latency-probe-player.ts
@@ -24,15 +24,26 @@ export async function recordWindowsPlayer(outDir: string, until: number): Promis
   const ffmpeg = 'C:\\Users\\win\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe\\ffmpeg-7.1.1-full_build\\bin\\ffmpeg.exe';
   let diagnostics = '';
   try {
-    const command = `$ErrorActionPreference='Stop'; $ff='${ffmpeg}'; $root=${remoteDir}; $out=${remote}; $log=${log}; $startedPath=${started}; $donePath=${done}; $task='WebScreenLatencyHarness'; Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path $root -Force | Out-Null; $taskScript="\`$recorded=[DateTime]::UtcNow; Set-Content -LiteralPath '$startedPath' -Value \`$recorded.ToString('o') -NoNewline; & '$ff' -y -f gdigrab -framerate 30 -i desktop -t ${seconds} -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p '$out' 2>&1 | Set-Content -LiteralPath '$log'; \`$code=\`$LASTEXITCODE; Set-Content -LiteralPath '$donePath' -Value \`$code -NoNewline; exit \`$code"; $encoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($taskScript)); $action=New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -EncodedCommand $encoded"; $principal=New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited; Register-ScheduledTask -TaskName $task -Action $action -Principal $principal -Force | Out-Null; try { Start-ScheduledTask -TaskName $task; $deadline=[DateTime]::UtcNow.AddSeconds(${recordingDeadlineSeconds(seconds)}); do { Start-Sleep -Seconds 1 } while(-not (Test-Path -LiteralPath $donePath) -and [DateTime]::UtcNow -lt $deadline); $ended=[DateTime]::UtcNow; if(-not (Test-Path -LiteralPath $donePath)){ Stop-ScheduledTask -TaskName $task -ErrorAction SilentlyContinue; Start-Sleep -Seconds 2; throw 'Scheduled Task recording timed out (done marker not written; task stopped)' }; if(-not(Test-Path -LiteralPath $startedPath)){ throw 'Scheduled Task did not write recording start time' }; $exitCode=(Get-Content -Raw -LiteralPath $donePath).Trim(); if($exitCode -notmatch '^-?\\d+$' -or [int]$exitCode -ne 0){ throw ('ffmpeg exited with code ' + $exitCode) }; $recorded=(Get-Content -Raw -LiteralPath $startedPath).Trim(); Write-Output ('recording_started_utc=' + $recorded); Write-Output ('recording_ended_utc=' + $ended.ToString('o')); Write-Output 'ffmpeg_log_begin'; if(Test-Path -LiteralPath $log){ Get-Content -Raw -LiteralPath $log }; Write-Output 'ffmpeg_log_end' } finally { Unregister-ScheduledTask -TaskName $task -Confirm:$false -ErrorAction SilentlyContinue }`;
-    console.info(`[player] 録画コマンド送信（${seconds} 秒、期限 ${recordingDeadlineSeconds(seconds) + 45} 秒）`);
-    const recording = await runTextProcess(sshPowerShell(command), (recordingDeadlineSeconds(seconds) + 45) * 1_000);
-    console.info(`[player] 録画コマンド完了 exit=${recording.exitCode} stdout=${recording.stdout.trim().slice(0, 200)}`);
-    diagnostics = formatProcessDiagnostics('Windows Scheduled Task 録画', recording);
+    // Scheduled Task を起動する ssh と、done マーカーを待つ ssh を分ける。1 本の ssh セッションで
+    // 録画時間ぶん待つ方式は 8 分 run で stdout / stderr が空のまま exit 1 になり（2026-09-04、
+    // 300 秒までは通る）、長い無出力セッションが途中で切れると録画が丸ごと失われるため。
+    // 一時ディレクトリは Windows 側で $env:TEMP を展開してから __ROOT__ に差し込む（単一引用符リテラル内では展開されない）
+    const taskScript = `$recorded=[DateTime]::UtcNow; Set-Content -LiteralPath '__ROOT__\\started.txt' -Value $recorded.ToString('o') -NoNewline; & '${ffmpeg}' -y -f gdigrab -framerate 30 -i desktop -t ${seconds} -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p '__ROOT__\\recording.mp4' 2>&1 | Set-Content -LiteralPath '__ROOT__\\ffmpeg.log'; $code=$LASTEXITCODE; Set-Content -LiteralPath '__ROOT__\\done.txt' -Value ($code.ToString() + ' ' + [DateTime]::UtcNow.ToString('o')) -NoNewline; exit $code`;
+    const startCommand = `$ErrorActionPreference='Stop'; $root=${remoteDir}; $task='WebScreenLatencyHarness'; Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path $root -Force | Out-Null; $taskScript=${powerShellLiteral(taskScript)}.Replace('__ROOT__', $root); $encoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($taskScript)); $action=New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -EncodedCommand $encoded"; $principal=New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited; Register-ScheduledTask -TaskName $task -Action $action -Principal $principal -Force | Out-Null; Start-ScheduledTask -TaskName $task; Write-Output 'task_started'`;
+    console.info(`[player] 録画タスク起動（${seconds} 秒、done 待ち期限 ${recordingDeadlineSeconds(seconds)} 秒）`);
+    const startResult = await runTextProcess(sshPowerShell(startCommand), 60_000);
+    diagnostics = formatProcessDiagnostics('Windows Scheduled Task 起動', startResult);
+    if (startResult.exitCode !== 0 || !startResult.stdout.includes('task_started')) return { samples: [], warning: 'Windows録画タスクを起動できませんでした。player-error.mdのSSH出力を確認してください。', diagnostics };
+    const doneMarker = await waitForDoneMarker(done, recordingDeadlineSeconds(seconds));
+    diagnostics += `\n## done マーカー待ち\n\n${doneMarker.diagnostics}\n`;
+    const finish = await runTextProcess(sshPowerShell(`$ErrorActionPreference='Continue'; Stop-ScheduledTask -TaskName 'WebScreenLatencyHarness' -ErrorAction SilentlyContinue; Unregister-ScheduledTask -TaskName 'WebScreenLatencyHarness' -Confirm:$false -ErrorAction SilentlyContinue; if(Test-Path -LiteralPath ${started}){ Write-Output ('recording_started_utc=' + (Get-Content -Raw -LiteralPath ${started}).Trim()) }; Write-Output 'ffmpeg_log_begin'; if(Test-Path -LiteralPath ${log}){ Get-Content -Raw -LiteralPath ${log} }; Write-Output 'ffmpeg_log_end'`), 60_000);
+    const recording = { stdout: finish.stdout, stderr: finish.stderr, exitCode: doneMarker.exitCode };
+    console.info(`[player] 録画完了 exit=${recording.exitCode} started=${parseUtcMarker(recording.stdout, 'recording_started_utc')}`);
+    diagnostics += formatProcessDiagnostics('Windows Scheduled Task 録画', recording);
     if (recording.exitCode !== 0) return { samples: [], warning: 'Windows録画は失敗しました。Scheduled TaskのSSH/ffmpeg出力をplayer-error.mdで確認してください。', diagnostics };
     const startedAt = parseUtcMarker(recording.stdout, 'recording_started_utc');
     if (startedAt === null) return { samples: [], warning: 'Windows録画の実開始UTC時刻を取得できませんでした。', diagnostics };
-    const endedAt = parseUtcMarker(recording.stdout, 'recording_ended_utc') ?? Date.now();
+    const endedAt = doneMarker.endedAtMs ?? Date.now();
     const local = join(outDir, 'recording.mp4');
     const size = await remoteFileSize(remote);
     console.info(`[player] リモートサイズ ${size} bytes。回収開始`);
@@ -54,6 +65,34 @@ export async function recordWindowsPlayer(outDir: string, until: number): Promis
     const cleanup = await runTextProcess(sshPowerShell(`Remove-Item -LiteralPath ${remoteDir} -Recurse -Force -ErrorAction Stop`), 30_000).catch((error) => ({ stdout: '', stderr: String(error), exitCode: -1 }));
     if (cleanup.exitCode !== 0) console.warn(`Windows一時ディレクトリcleanupに失敗しました: ${cleanup.stderr}`);
   }
+}
+
+/** PowerShell の単一引用符リテラル（' を '' に二重化）。 */
+function powerShellLiteral(value: string): string { return `'${value.replace(/'/g, "''")}'`; }
+
+/**
+ * done マーカー（"<exit code> <ended UTC ISO>"）を短い ssh で定期的に読む。ssh の一時失敗は数えるだけで
+ * 待ちを続け、期限までにマーカーが出なければ exit -1 で返す。
+ */
+async function waitForDoneMarker(donePath: string, deadlineSeconds: number, pollMs = 20_000): Promise<{ exitCode: number; endedAtMs: number | null; diagnostics: string }> {
+  const deadline = Date.now() + deadlineSeconds * 1_000;
+  let polls = 0;
+  let sshFailures = 0;
+  while (Date.now() < deadline) {
+    polls += 1;
+    const result = await runTextProcess(sshPowerShell(`if(Test-Path -LiteralPath ${donePath}){ Get-Content -Raw -LiteralPath ${donePath} } else { Write-Output 'pending' }`), 45_000);
+    if (result.exitCode !== 0) sshFailures += 1;
+    else {
+      const text = result.stdout.trim();
+      const match = /^(-?\d+)\s+(\S+)$/.exec(text);
+      if (match) {
+        const endedAtMs = Date.parse(match[2]!);
+        return { exitCode: Number(match[1]), endedAtMs: Number.isFinite(endedAtMs) ? endedAtMs : null, diagnostics: `- polls: ${polls}\n- ssh failures: ${sshFailures}\n- marker: ${text}` };
+      }
+    }
+    await Bun.sleep(Math.min(pollMs, Math.max(0, deadline - Date.now())));
+  }
+  return { exitCode: -1, endedAtMs: null, diagnostics: `- polls: ${polls}\n- ssh failures: ${sshFailures}\n- marker: (timed out after ${deadlineSeconds} s)` };
 }
 
 async function remoteFileSize(path: string): Promise<number> {

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -61,7 +61,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
   if (command === 'player-check') {
     rejectUnknown(values, ['seconds', 'out']);
     const seconds = values.seconds === undefined ? 15 : Number(values.seconds);
-    if (!Number.isInteger(seconds) || seconds < 5 || seconds > 300) throw new Error('--seconds must be an integer between 5 and 300');
+    if (!Number.isInteger(seconds) || seconds < 5 || seconds > 900) throw new Error('--seconds must be an integer between 5 and 900');
     const stamp = new Date().toISOString().replace(/[:.]/g, '-');
     return { command, seconds, outDir: values.out ?? resolve('..', 'docs', 'tmp', 'latency', `player-check-${stamp}`) };
   }

--- a/web/scripts/latency-source.html
+++ b/web/scripts/latency-source.html
@@ -62,7 +62,49 @@
       context.fillStyle = cells[row][column] ? '#fff' : '#000';
       context.fillRect(x + column * cell, y + row * cell, cell, cell);
     }
+    drawWallClock(now, x, y, size, cell);
     if (heavy) drawSyntheticCursor(now, x, y, size, cell);
+  }
+  // 人が目で読む時計。格子の左に秒針つきアナログ、右にミリ秒つきデジタル。復号用の格子（同期枠）とは
+  // 隔離矩形の外側に置き、heavy 素材でも同じ暗色の下地を敷く。
+  function pad(value, length) { return String(value).padStart(length, '0'); }
+  function drawWallClock(now, codeX, codeY, codeSize, cell) {
+    const date = new Date(now), centerY = codeY + codeSize / 2;
+    const side = Math.min((codeX - cell * 1.2) / 2, cell * 4.4);
+    if (side < cell * 2) return;
+    const backing = '#101827';
+    // 左: アナログ時計（秒針はミリ秒でなめらかに回す）
+    const radius = side - cell * 0.5, leftX = (codeX - cell * 1.2) / 2;
+    context.fillStyle = backing; context.fillRect(leftX - side, centerY - side, side * 2, side * 2);
+    context.strokeStyle = '#e5e7eb'; context.lineWidth = Math.max(2, cell * 0.08);
+    context.beginPath(); context.arc(leftX, centerY, radius, 0, Math.PI * 2); context.stroke();
+    for (let tick = 0; tick < 60; tick += 1) {
+      const angle = (tick / 60) * Math.PI * 2, major = tick % 5 === 0;
+      const inner = radius * (major ? 0.86 : 0.93);
+      context.lineWidth = major ? Math.max(2, cell * 0.1) : Math.max(1, cell * 0.04);
+      context.beginPath(); context.moveTo(leftX + Math.sin(angle) * inner, centerY - Math.cos(angle) * inner);
+      context.lineTo(leftX + Math.sin(angle) * radius, centerY - Math.cos(angle) * radius); context.stroke();
+    }
+    const seconds = date.getSeconds() + date.getMilliseconds() / 1000;
+    const minutes = date.getMinutes() + seconds / 60, hours = (date.getHours() % 12) + minutes / 60;
+    const hand = (value, unit, length, width, color) => {
+      const angle = (value / unit) * Math.PI * 2;
+      context.strokeStyle = color; context.lineWidth = width; context.lineCap = 'round';
+      context.beginPath(); context.moveTo(leftX, centerY); context.lineTo(leftX + Math.sin(angle) * radius * length, centerY - Math.cos(angle) * radius * length); context.stroke();
+    };
+    hand(hours, 12, 0.5, Math.max(4, cell * 0.22), '#e5e7eb');
+    hand(minutes, 60, 0.72, Math.max(3, cell * 0.15), '#e5e7eb');
+    hand(seconds, 60, 0.9, Math.max(2, cell * 0.07), '#f87171');
+    context.fillStyle = '#f87171'; context.beginPath(); context.arc(leftX, centerY, Math.max(3, cell * 0.12), 0, Math.PI * 2); context.fill();
+    // 右: ローカル時刻 HH:MM:SS.mmm
+    const rightStart = codeX + codeSize + cell * 1.2, rightRoom = innerWidth - rightStart, rightX = rightStart + rightRoom / 2;
+    const text = `${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(date.getSeconds(), 2)}.${pad(date.getMilliseconds(), 3)}`;
+    // 12 文字の等幅で右側の余白に収まる大きさ（等幅 1 文字 ≒ 0.62 em）
+    context.font = `700 ${Math.max(20, Math.floor(Math.min(side * 0.42, (rightRoom - cell) / (text.length * 0.62))))}px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    const width = context.measureText(text).width + cell;
+    context.fillStyle = backing; context.fillRect(rightX - width / 2, centerY - side * 0.5, width, side);
+    context.fillStyle = '#ffffff'; context.textAlign = 'center'; context.textBaseline = 'middle'; context.fillText(text, rightX, centerY);
+    context.textBaseline = 'alphabetic';
   }
   function drawHeavyBackground(now) {
     const width = innerWidth, height = innerHeight;
@@ -98,15 +140,24 @@
       setTimeout(() => {
         if (audioContext.currentTime >= startAt) { scheduleBeep(); return; }
         // 秒の 8 秒剰余を周波数に符号化する。受信側は 8 帯域を照合し、映像近接標本と組み合わせて絶対遅延を復元する。
+        // 立ち上がり・立ち下がりを傾斜させてクリック音を消す。受信側の検出窓は 50 ms なので
+        // 定常部 40 ms を残し、周波数（帯域）は変えない。
         const oscillator = audioContext.createOscillator(); oscillator.frequency.value = 600 + 100 * ((nextBoundaryMs / 1000) % 8);
-        oscillator.connect(gain); oscillator.start(startAt); oscillator.stop(startAt + 0.05);
+        const envelope = audioContext.createGain(); envelope.gain.setValueAtTime(0, startAt);
+        envelope.gain.linearRampToValueAtTime(0.55, startAt + 0.008); envelope.gain.setValueAtTime(0.55, startAt + 0.048);
+        envelope.gain.linearRampToValueAtTime(0, startAt + 0.075);
+        oscillator.connect(envelope).connect(gain); oscillator.start(startAt); oscillator.stop(startAt + 0.08);
         scheduleBeep();
       }, Math.max(0, (startAt - audioContext.currentTime) * 1000 - leadMs));
     };
     if (new URLSearchParams(location.search).get('tones') === '1') {
-      for (const [frequency, pan] of [[440, -1], [880, 1]]) {
-        const oscillator = audioContext.createOscillator(), stereo = audioContext.createStereoPanner();
-        oscillator.frequency.value = frequency; stereo.pan.value = pan; oscillator.connect(stereo).connect(gain); oscillator.start();
+      // 左右チャンネルの存在確認用。高い持続音は耳障りなので、低い 2 音を小さく、ゆっくり揺らして鳴らす。
+      const tremolo = audioContext.createOscillator(), depth = audioContext.createGain();
+      tremolo.frequency.value = 0.4; depth.gain.value = 0.08; tremolo.connect(depth); tremolo.start();
+      for (const [frequency, pan] of [[220, -1], [330, 1]]) {
+        const oscillator = audioContext.createOscillator(), stereo = audioContext.createStereoPanner(), level = audioContext.createGain();
+        oscillator.frequency.value = frequency; stereo.pan.value = pan; level.gain.value = 0.16; depth.connect(level.gain);
+        oscillator.connect(level).connect(stereo).connect(gain); oscillator.start();
       }
     }
     scheduleBeep();


### PR DESCRIPTION
## なぜこの変更が必要か

VRChat 実機で遅延計測の配信を映した時、(1) 毎秒のビープと `tones=1` の持続音が耳障り、(2) 画面に epoch ミリ秒の数字しか無く目視で遅延を読めない、(3) `--player win2022` の Windows 全画面録画が 8 分 run で完走せず（stdout / stderr が空の exit 1）実機側の標本が取れない、という 3 つの問題があった。VRChat の隣にブラウザの時計を並べ、Windows 全画面録画のフレームから目視でも遅延を読める状態にする。

## 変更内容

- 計測ページ: 復号用の格子の左に秒針つきアナログ時計（ミリ秒で滑らかに回る）、右に `HH:MM:SS.mmm` を描く。どちらも格子の隔離矩形の外で、plain / heavy / 800x600 の描画を `decodePngFrame` で復号できることを確認
- 音: 秒識別ビープに 8 ms / 27 ms の傾斜（クリック除去、周波数帯と 50 ms の検出窓に対する定常部 40 ms は維持）。`tones=1` の持続音を 440/880 Hz から 220/330 Hz の小さくゆっくり揺らぐ音に変更
- Windows 録画: 1 本の ssh で録画時間ぶんブロックする方式をやめ、Scheduled Task の起動と 20 秒間隔の短い ssh による done マーカー読みに分ける。タスクは finally で必ず停止・削除。`player-check --seconds` の上限を 900 に
- 出口の単発取得: ffmpeg が exit 0 でも PNG を書かない時に `copyFile` の ENOENT で run 全体が落ちるのを修正（2026-09-04 の 8 分 run が 60 枚目で落ち標本を全て失った）

## 意思決定

- 時計はページ内に描く（配信元 PC の時刻）: VRChat 側の別ブラウザで同じページを開けば、録画フレーム内で「配信元の時刻」と「視聴側の時刻」を並べて読める
- ビープの周波数は変えない: 受信側の 8 帯域検出（`detectIdentifiedBeeps`）を触らずに済む。改修後の 8 分 run で `outlet-audio.csv` 478 標本が取れ検出は変わらず動いた
- Windows 録画は detach + poll: 長い無出力 ssh セッションの切断が原因と断定はできていないが、300 秒までは通り 8 分で落ちる再現があり、セッション長に依存しない構造にした

## テスト

- [x] `bun test tests/scripts/latency-probe.test.ts` 38 pass、`bun run typecheck`
- [x] ページ描画 3 条件（plain / heavy / 800x600）を Playwright で撮影し復号成功
- [x] `player-check --seconds 10 / 20 / 480`（VRChat 起動中の Windows 機）: すべて OK、480 秒は録画長 480 秒・回収 20 MB
- [x] 改修ページで 8 分 run（Indigo → Cherry replica → Mac）: summary.md 生成、出口中央値 0.95 秒、音声標本 478 件

## Screenshot

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/8a24c071-6bc1-481e-8dbe-0aa965a8fca8) | ![After](https://github.com/user-attachments/assets/cfdeb002-621f-49aa-ae5d-ac72babdbae3) |

Windows 全画面録画のフレーム（VRChat + Discord が写る）: ![Windows desktop](https://github.com/user-attachments/assets/88b43853-1349-4d1c-880c-86a9fb5d1434)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KjQWSGJDJsk6mmyehKPVK
