### PR TITLE
test(latency-probe): 定常音を重ねた合成 PCM で秒識別ビープの検出を固定する（#184）

### DIFF
--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -63,6 +63,7 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 - 連続 ffmpeg（`-vf fps=5` や `-use_wallclock_as_timestamps`）は起動時の PTS ギャップと内部バッファで古さを引きずり、実遅延 0.8 秒が 2〜6 秒に見えた。映像の連続取得は使わない（音声は連続取得で WAV に保存し `analyze` で検出）
 - `--server-snap HOST` は run 中にサーバーへ SSH し、ingress（8554）と egress（554）を**並列起動**で単発取得して `server-snap.md` に出す。ingress の値が「配信元 → ingress」、egress との差が relay の寄与
 - 実測（2026-09-02、計測ページ 1150x720 / 250 ms 更新）: ingress 約 0.55 秒、egress 約 0.80 秒（上限値）、Mac からの出口単発取得 約 0.78 秒。開始直後から安定し、出口に「数秒 → 1 秒未満」の収束は無い
+- `?tones=1` の左右確認用定常音（現行 220/330 Hz、旧 440/880 Hz）は 50 ms 検出窓では秒識別ビープの 8 帯域へ漏れず、検出数・`secondMod8`・onset（±15 ms）を乱さない（回帰: `web/tests/scripts/latency-probe.test.ts` の test.each「定常音 … に重ねても8個の秒識別ビープを取り違えず検出する」。ただし 600〜1300 Hz の各帯域近傍に定常音を足すとグローバル閾値が持ち上がって検出が消えるため（実測: 890 / 900 / 905+1210 Hz で検出 0 件）、確認音の周波数はこの範囲外に置く）
 - `--notify-discord CHANNEL_ID` で配信 URL を Discord に投稿する（VRChat を動かす別 PC で貼るため）。`--player win2022` の録画は Scheduled Task 経由で、MacType 導入機では互換性ダイアログが出るが録画は継続する
 
 ## 実測前の確認手順（2026-09-02 追記）

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -72,6 +72,33 @@ function scaleNearest(frame: { rgb: Uint8Array; width: number; height: number },
   return { rgb, width, height };
 }
 
+/** latency-source.html と同じ傾斜エンベロープ（8 ms 立ち上がり / 48 ms まで保持 / 75 ms で 0）。 */
+function beepEnvelope(elapsedSeconds: number): number {
+  if (elapsedSeconds < 0.008) return elapsedSeconds / 0.008;
+  if (elapsedSeconds <= 0.048) return 1;
+  return Math.max(0, (0.075 - elapsedSeconds) / 0.027);
+}
+
+/** 定常音（各 -20 dBFS）へ毎秒 1 回の秒識別ビープ（-20 dBFS）を重ねた 8 秒の 48 kHz モノラル PCM。 */
+function synthesizeBeepsOverSteadyTones(steadyHz: readonly number[]): { samples: Float32Array; onsets: number[] } {
+  const sampleRate = 48_000;
+  const amplitude = 0.1;
+  const samples = new Float32Array(sampleRate * 8);
+  for (const frequency of steadyHz) {
+    for (let index = 0; index < samples.length; index += 1) samples[index] += Math.sin(2 * Math.PI * frequency * index / sampleRate) * amplitude;
+  }
+  const onsets: number[] = [];
+  for (let secondMod8 = 0; secondMod8 < 8; secondMod8 += 1) {
+    // 検出の hop（10 ms）に揃えた位置へ置き、窓中心を onset とする既知のバイアスを 15 ms に固定する。
+    const onset = sampleRate / 2 + secondMod8 * sampleRate;
+    onsets.push(onset);
+    for (let index = 0; index < Math.round(sampleRate * 0.075); index += 1) {
+      samples[onset + index] += Math.sin(2 * Math.PI * (600 + 100 * secondMod8) * index / sampleRate) * amplitude * beepEnvelope(index / sampleRate);
+    }
+  }
+  return { samples, onsets };
+}
+
 function withLiveVideoSender(trackId = 'sender-a'): { evaluator: VideoProfileEvaluator; parameters: RTCRtpSendParameters; setReadbackMismatch(value: boolean): void; replaceSender(track: string): void; restore(): void } {
   let parameters = { encodings: [{ scaleResolutionDownBy: 2 }] } as RTCRtpSendParameters;
   let mismatch = false;
@@ -210,6 +237,17 @@ describe('latency block code', () => {
     expect(detected.secondMod8).toBe(5);
     expect(detected.onset).toBeGreaterThanOrEqual(11_040);
     expect(detected.onset).toBeLessThanOrEqual(12_480);
+  });
+
+  test.each([
+    ['現行の 220/330 Hz', [220, 330]],
+    ['旧 440/880 Hz（倍音がビープ帯域に近い最悪ケース）', [440, 880]],
+  ] as const)('定常音 %s に重ねても8個の秒識別ビープを取り違えず検出する', (_label, steadyHz) => {
+    const { samples, onsets } = synthesizeBeepsOverSteadyTones(steadyHz);
+    const detected = detectIdentifiedBeeps(samples, 48_000);
+
+    expect(detected.map((beep) => beep.secondMod8)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    for (const [index, beep] of detected.entries()) expect(Math.abs(beep.onset - onsets[index]!)).toBeLessThanOrEqual(720);
   });
 
   test('映像近接標本で8秒内の音声送出秒を絶対遅延へ対応付ける', () => {


### PR DESCRIPTION
## なぜこの変更が必要か

`?tones=1` の左右確認用定常音が秒識別ビープ（600〜1300 Hz）の検出を妨げる懸念（#184）が、PR #181 以来「未検証のまま」だった。定常音自体は PR #255 で 440/880 Hz から 220/330 Hz へ移したので、実際のページ条件と旧条件の両方で検出が崩れないことを回帰テストで固定する。

## 変更内容

- `web/tests/scripts/latency-probe.test.ts`: ページと同じ傾斜エンベロープのビープ 8 種を、定常音 220/330 Hz と 440/880 Hz（各 −20 dBFS）に重ねた合成 PCM で `detectIdentifiedBeeps` を検証（検出数 8・`secondMod8` 一致・onset ±15 ms・誤検出 0）
- `docs/streaming/latency-harness.md`: 定常音が検出に影響しないこと、および帯域近傍（890〜905 Hz）の定常音では検出が落ちる既知の限界を 1 行

## 意思決定

- codec 本体は変えない: 新テストは修正前から通り、現行実装がページの定常音に耐性を持つことが確認できた。帯域近傍の定常音（計測ページは鳴らさない）に対する帯域別ノイズフロア化は、必要になった時に別 Issue で扱う

## テスト

- [x] `bun test tests/scripts/latency-probe.test.ts` 40 pass、`bun run typecheck`
- [x] 実 E2E: 改修後ページ（tones=1）の 8 分 run で `outlet-audio.csv` 478 標本・A/V 差が算出済み（PR #255 の run C'、verification.md I27）

Closes #184

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KjQWSGJDJsk6mmyehKPVK
