### PR TITLE
feat(latency-probe): 配信 URL の通知コマンドを環境変数で注入し、個人スキルの固定パスを外す（#185）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ latency-probe: export LP_NOTIFY_DISCORD := $(value NOTIFY_DISCORD)
 latency-probe: export LP_SERVER_SNAP := $(value SERVER_SNAP)
 latency-probe: export LP_NODE_HOST := $(value NODE_HOST)
 latency-probe: export LP_READ_HOST := $(value READ_HOST)
+# NOTIFY_DISCORD を使う時は、実際に叩く通知コマンドを環境変数 WEBSCREEN_LATENCY_NOTIFY_COMMAND で
+# 渡す（make VAR= 経由では $ が Make に展開されるので、シェル側で export しておく）。
+# 値の書式と例: docs/streaming/latency-harness.md#配信-url-の通知コマンド
 latency-probe: ## 遅延測定を実行（MIN=5 SOURCE=URL、PLAYER=win2022、NOTIFY_DISCORD=ID、SERVER_SNAP=HOST、NODE_HOST=HOST、READ_HOST=HOST[:PORT]）
 	@script="$(WEB_DIR)/scripts/latency-probe.ts"; \
 	if [[ ! -f "$$script" ]]; then echo 'feat/latency-harness をマージしてください' >&2; exit 1; fi; \

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -64,11 +64,36 @@ bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 - `--server-snap HOST` は run 中にサーバーへ SSH し、ingress（8554）と egress（554）を**並列起動**で単発取得して `server-snap.md` に出す。ingress の値が「配信元 → ingress」、egress との差が relay の寄与
 - 実測（2026-09-02、計測ページ 1150x720 / 250 ms 更新）: ingress 約 0.55 秒、egress 約 0.80 秒（上限値）、Mac からの出口単発取得 約 0.78 秒。開始直後から安定し、出口に「数秒 → 1 秒未満」の収束は無い
 - `?tones=1` の左右確認用定常音（現行 220/330 Hz、旧 440/880 Hz）は 50 ms 検出窓では秒識別ビープの 8 帯域へ漏れず、検出数・`secondMod8`・onset（±15 ms）を乱さない（回帰: `web/tests/scripts/latency-probe.test.ts` の test.each「定常音 … に重ねても8個の秒識別ビープを取り違えず検出する」。ただし 600〜1300 Hz の各帯域近傍に定常音を足すとグローバル閾値が持ち上がって検出が消えるため（実測: 890 / 900 / 905+1210 Hz で検出 0 件）、確認音の周波数はこの範囲外に置く）
-- `--notify-discord CHANNEL_ID` で配信 URL を Discord に投稿する（VRChat を動かす別 PC で貼るため）。`--player win2022` の録画は Scheduled Task 経由で、MacType 導入機では互換性ダイアログが出るが録画は継続する
+- `--notify-discord CHANNEL_ID` で配信 URL を外部へ通知する（VRChat を動かす別 PC で貼るため）。叩くコマンドは環境変数で注入する（[配信 URL の通知コマンド](#配信-url-の通知コマンド)）。`--player win2022` の録画は Scheduled Task 経由で、MacType 導入機では互換性ダイアログが出るが録画は継続する
+
+## 配信 URL の通知コマンド
+
+`--notify-discord CHANNEL_ID`（`make` では `NOTIFY_DISCORD=`）を付けると、配信開始時に外部コマンドへ配信 URL を渡す。
+どのコマンドを叩くかはリポジトリに持たず、環境変数 `WEBSCREEN_LATENCY_NOTIFY_COMMAND` で注入する（個人環境のスクリプトを固定パスで参照しないため）。
+
+- 値は**空白区切りの argv**。空白を含む引数は `'…'` または `"…"` で囲む。引用符は語の途中でも開閉できる（`--message='a b'`）
+- **シェルを介さない**ので `~` / `$VAR` / パイプ / リダイレクトは展開されない。`~` は literal のパスになり必ず失敗するため、`export` する側で `$HOME` を展開させる（下の例は外側を `"` で囲っているので shell が展開する）
+- 各引数の `{url}` は配信 URL（`rtspt://.../live/{id}`）、`{channel}` は `--notify-discord` に渡した値へ置換される
+- 加えて **stdin に `{"url":"...","channel":"..."}` の JSON を 1 行**渡す。引数を組み立てにくい CLI はこちらを読む
+- 未設定なら「通知コマンド未設定のため通知をスキップ」と警告を出すだけで、計測はそのまま続行する。値の引用符が閉じていない場合は配信を始める前に失敗する
+- 失敗・10 秒のタイムアウトも警告のみで run は止めない
+
+例 1: 個人の discord-mention スキル（旧ハードコードと同じ引数）
+
+```bash
+export WEBSCREEN_LATENCY_NOTIFY_COMMAND="bun $HOME/.claude/skills/discord-mention/scripts/notify-discord.ts --message '遅延計測の配信を開始しました。VRChat に貼ってください: {url}' --target nori --channel-id {channel} --project-dir ."
+```
+
+例 2: 任意の webhook CLI（stdin の JSON をそのまま送る。`{url}` / `{channel}` は使わない）
+
+```bash
+export WEBSCREEN_LATENCY_NOTIFY_COMMAND="curl -fsS -X POST -H 'Content-Type: application/json' --data-binary @- https://example.com/webhook/xxxx"
+```
 
 ## 実測前の確認手順（2026-09-02 追記）
 
 1. `bun scripts/latency-probe.ts login`（初回のみ。ハーネスが開く Chrome でログイン）
 2. `bun scripts/latency-probe.ts player-check --seconds 8`（配信なしで Windows 録画・回収だけを試す。`--seconds` は 900 まで。録画長が指定の 80% 以上で OK。フレームに PowerShell コンソールや MacType 警告が写らないこと）
-3. `make latency-probe MIN=4 SOURCE=... PLAYER=win2022 NOTIFY_DISCORD=<channel> SERVER_SNAP=<host>`
-4. Discord の URL を VRChat に貼り、**プレイヤーを正面に近い視点で**映し続ける（斜めになると復号できない）
+3. 通知を使うなら `WEBSCREEN_LATENCY_NOTIFY_COMMAND` を export（[配信 URL の通知コマンド](#配信-url-の通知コマンド)）
+4. `make latency-probe MIN=4 SOURCE=... PLAYER=win2022 NOTIFY_DISCORD=<channel> SERVER_SNAP=<host>`
+5. 通知された URL を VRChat に貼り、**プレイヤーを正面に近い視点で**映し続ける（斜めになると復号できない）

--- a/docs/streaming/vrchat-ab-runbook.md
+++ b/docs/streaming/vrchat-ab-runbook.md
@@ -8,6 +8,7 @@
 |---|---|
 | 配信元（計測ページ） | `http://127.0.0.1:0/latency-source.html?tones=1`（ms 時刻のブロックコード + 毎秒ビープ。`?load=heavy` は帯域飢餓の最悪素材） |
 | 配信 URL の通知先 | Discord「通知」チャンネル `1380914078100488334`（skill `discord-mention` の既定） |
+| 通知コマンド | 環境変数 `WEBSCREEN_LATENCY_NOTIFY_COMMAND` で注入する（未 export だと `--notify-discord` を付けても警告のみで通知されない）。値の形と例: [latency-harness.md](latency-harness.md#配信-url-の通知コマンド) |
 | VRChat 側 | Windows `win2022`（SSH で gdigrab 録画）。プレイヤーのあるワールド（YamaStream）でプレイヤーを正面に映す |
 | 配信サーバー | `webscreen-indigo-poc`（`--server-snap` で ingress / egress を撮る） |
 | 出力 | `docs/tmp/latency/<UTC>/`（git 管理外）。`summary.md` の「VRChat プレイヤー」節と「プロファイル区間別」節を見る |

--- a/web/scripts/latency-probe-notify.ts
+++ b/web/scripts/latency-probe-notify.ts
@@ -1,16 +1,37 @@
-import { readPipeText, requirePipe } from './latency-probe-observe';
+import { requirePipe } from './latency-probe-observe';
 
 /** 通知コマンドを注入する環境変数。個人環境のスクリプトをリポジトリに固定パスで書かないための唯一の入口。 */
 export const NOTIFY_COMMAND_ENV = 'WEBSCREEN_LATENCY_NOTIFY_COMMAND';
 
+/** Discord のチャンネル ID の書式。CLI と run 境界の双方が同じ規則で弾けるよう正本をここに 1 つだけ置く。 */
+export const NOTIFY_CHANNEL_ID_PATTERN = /^\d{15,25}$/;
+
 /** 通知は計測の付帯処理なので、固まっても run を止めずに打ち切る。 */
 const NOTIFY_TIMEOUT_MS = 10_000;
+
+/** タイムアウト後、SIGTERM を無視する子を待つ猶予。過ぎたら SIGKILL へ上げる（30 秒の孤児を残さない）。 */
+const NOTIFY_KILL_GRACE_MS = 500;
+
+/** kill 後に stderr の EOF を待つ猶予。孫プロセスが fd を握ったままだと閉じないので無期限には待たない。 */
+const NOTIFY_STDERR_GRACE_MS = 500;
+
+/** stderr は警告に載せる診断用なので上限で切る（暴走した子の出力でメモリを食わない）。 */
+const NOTIFY_STDERR_LIMIT_BYTES = 4_096;
+
+/** 上限で切ったことを警告文から判別できるようにする印。 */
+export const NOTIFY_STDERR_TRUNCATED_SUFFIX = '…（stderr 切り捨て）';
+
+/** タイムアウトで打ち切った時に警告へ出す擬似 exit（実際の終了コードと区別する）。 */
+const NOTIFY_TIMEOUT_EXIT = -1;
+
+/** 期限切れを実際の終了コード・stderr 文字列と取り違えないための番兵。 */
+const NOTIFY_DEADLINE = Symbol('notify deadline');
 
 /** 起動した通知コマンドのうち、この module が使う最小の面だけを型にする（Bun.spawn の overload に縛られずテストで差し替えるため）。 */
 export interface NotifyChild {
   readonly exited: Promise<number>;
   readonly stderr: ReadableStream<Uint8Array>;
-  kill(): void;
+  kill(signal?: NodeJS.Signals | number): void;
 }
 
 /** argv と stdin（JSON 1 行）を受け取ってプロセスを起こす関数。既定は Bun.spawn。 */
@@ -59,6 +80,16 @@ export function notifyCommandTemplate(raw: string | undefined): string[] | null 
   return argv;
 }
 
+/** 通知先チャンネル ID を CLI と run 境界で同じ規則で検証する。 */
+export function validateNotifyChannelId(channelId: string): void {
+  if (!NOTIFY_CHANNEL_ID_PATTERN.test(channelId)) throw new Error('--notify-discord must be a Discord channel id');
+}
+
+/** 通知コマンドが未設定であることを、Chrome 起動・配信開始より前に知らせる（計測はそのまま続行する）。 */
+export function warnNotifyCommandMissing(): void {
+  console.warn(`通知コマンド未設定のため通知をスキップします（${NOTIFY_COMMAND_ENV} を設定すると配信 URL を投稿できます）`);
+}
+
 /** テンプレートの各引数の `{url}` / `{channel}` を実値へ置換する（シェルを通さないのでクォートは不要）。 */
 export function buildNotifyArgv(template: readonly string[], values: { url: string; channel: string }): string[] {
   return template.map((argument) => argument.replaceAll('{url}', values.url).replaceAll('{channel}', values.channel));
@@ -72,30 +103,79 @@ export function notifyStdinJson(values: { url: string; channel: string }): strin
 const spawnNotifyCommand: NotifySpawn = (argv, stdin) => {
   // stdout は使わないので捨てる（読まれない pipe が満杯になると子が write でブロックし、成功なのにタイムアウト扱いになる）
   const child = Bun.spawn([...argv], { stdin, stdout: 'ignore', stderr: 'pipe' });
-  return { exited: child.exited, stderr: requirePipe(child.stderr, 'notify stderr'), kill: () => child.kill() };
+  return { exited: child.exited, stderr: requirePipe(child.stderr, 'notify stderr'), kill: (signal) => child.kill(signal) };
 };
 
+function describeError(error: unknown): string { return error instanceof Error ? error.message : String(error); }
+
+/** promise と期限を競わせる。期限側は Symbol で返し、終了コード 0 や空文字と区別できるようにする。 */
+async function raceDeadline<T>(promise: Promise<T>, milliseconds: number): Promise<T | typeof NOTIFY_DEADLINE> {
+  return Promise.race([promise, Bun.sleep(milliseconds).then((): typeof NOTIFY_DEADLINE => NOTIFY_DEADLINE)]);
+}
+
 /**
- * VRChat を動かす別 PC で URL を拾えるよう、注入されたコマンドへ配信 URL を渡す（失敗は計測を止めない）。
- * stderr は await せずに読み始める（子が固まると pipe が閉じず、先に await するとタイムアウトが始まらない）。
+ * stderr を上限付きで読む。上限を超えた分は捨てながら EOF まで drain する
+ * （途中で cancel すると、まだ生きている子が stderr への write で EPIPE を受けて成功が失敗に化ける）。
+ */
+async function readStderrCapped(stream: ReadableStream<Uint8Array>, limitBytes = NOTIFY_STDERR_LIMIT_BYTES): Promise<string> {
+  const reader = stream.getReader();
+  const kept: Uint8Array[] = [];
+  let keptBytes = 0;
+  let truncated = false;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value === undefined || value.length === 0) continue;
+    const room = limitBytes - keptBytes;
+    if (room <= 0) { truncated = true; continue; }
+    kept.push(value.length > room ? value.subarray(0, room) : value);
+    keptBytes += Math.min(value.length, room);
+    if (value.length > room) truncated = true;
+  }
+  const joined = new Uint8Array(keptBytes);
+  let offset = 0;
+  for (const chunk of kept) { joined.set(chunk, offset); offset += chunk.length; }
+  // 上限で切ると多バイト文字が割れるが、診断用途なので U+FFFD のまま出す
+  const text = new TextDecoder().decode(joined);
+  return truncated ? `${text}${NOTIFY_STDERR_TRUNCATED_SUFFIX}` : text;
+}
+
+/** 期限を過ぎた子を SIGTERM → 猶予 → SIGKILL の順で落とす（SIGTERM を無視する子を孤児として残さない）。 */
+async function terminateNotifyChild(child: NotifyChild): Promise<void> {
+  child.kill();
+  if (await raceDeadline(child.exited, NOTIFY_KILL_GRACE_MS) === NOTIFY_DEADLINE) child.kill('SIGKILL');
+}
+
+/**
+ * VRChat を動かす別 PC で URL を拾えるよう、注入されたコマンドへ配信 URL を渡す。
+ * 起動失敗・異常終了・タイムアウトはすべて警告のみで、計測は止めない。
+ * stderr は await せずに読み始め（子が固まると pipe が閉じず、先に await するとタイムアウトが始まらない）、
+ * 回収にも期限を付けて関数全体が timeoutMs + 猶予 で必ず返るようにする。
  */
 export async function notifyStreamUrl(options: {
-  template: readonly string[] | null;
+  template: readonly string[];
   url: string;
   channel: string;
   timeoutMs?: number;
   spawn?: NotifySpawn;
 }): Promise<void> {
   const { template, url, channel, timeoutMs = NOTIFY_TIMEOUT_MS, spawn = spawnNotifyCommand } = options;
-  if (template === null) {
-    console.warn(`通知コマンド未設定のため通知をスキップします（${NOTIFY_COMMAND_ENV} を設定すると配信 URL を投稿できます）`);
+  const argv = buildNotifyArgv(template, { url, channel });
+  let child: NotifyChild;
+  try {
+    child = spawn(argv, new TextEncoder().encode(notifyStdinJson({ url, channel })));
+  } catch (error) {
+    // 実行ファイルが無い等、spawn が同期で投げるケース。通知の失敗で run を落とさない
+    console.warn(`配信 URL の通知コマンドを起動できませんでした（${argv[0] ?? ''}）: ${describeError(error)}`);
     return;
   }
-  const argv = buildNotifyArgv(template, { url, channel });
-  const child = spawn(argv, new TextEncoder().encode(notifyStdinJson({ url, channel })));
-  const stderr = readPipeText(child.stderr).catch((error: unknown) => (error instanceof Error ? error.message : String(error)));
-  const exit = await Promise.race([child.exited, Bun.sleep(timeoutMs).then(() => { child.kill(); return -1; })]);
-  const diagnostics = (await stderr).trim();
-  if (exit !== 0) console.warn(`配信 URL の通知に失敗またはタイムアウトしました（exit ${exit}）: ${diagnostics}`);
+  const stderr = readStderrCapped(child.stderr).catch(describeError);
+  // 期限判定は最初の race だけで決める（kill 後に exited が 137 等を返しても「タイムアウト」の事実は変わらない）
+  const exit = await raceDeadline(child.exited, timeoutMs);
+  if (exit === NOTIFY_DEADLINE) await terminateNotifyChild(child);
+  const collected = await raceDeadline(stderr, NOTIFY_STDERR_GRACE_MS);
+  const diagnostics = (collected === NOTIFY_DEADLINE ? '(stderr を回収できませんでした)' : collected).trim();
+  if (exit === NOTIFY_DEADLINE) console.warn(`配信 URL の通知がタイムアウトしました（exit ${NOTIFY_TIMEOUT_EXIT}、${timeoutMs} ms）: ${diagnostics}`);
+  else if (exit !== 0) console.warn(`配信 URL の通知に失敗しました（exit ${exit}）: ${diagnostics}`);
   else console.info(`配信 URL を通知しました（channel ${channel}）`);
 }

--- a/web/scripts/latency-probe-notify.ts
+++ b/web/scripts/latency-probe-notify.ts
@@ -1,0 +1,101 @@
+import { readPipeText, requirePipe } from './latency-probe-observe';
+
+/** 通知コマンドを注入する環境変数。個人環境のスクリプトをリポジトリに固定パスで書かないための唯一の入口。 */
+export const NOTIFY_COMMAND_ENV = 'WEBSCREEN_LATENCY_NOTIFY_COMMAND';
+
+/** 通知は計測の付帯処理なので、固まっても run を止めずに打ち切る。 */
+const NOTIFY_TIMEOUT_MS = 10_000;
+
+/** 起動した通知コマンドのうち、この module が使う最小の面だけを型にする（Bun.spawn の overload に縛られずテストで差し替えるため）。 */
+export interface NotifyChild {
+  readonly exited: Promise<number>;
+  readonly stderr: ReadableStream<Uint8Array>;
+  kill(): void;
+}
+
+/** argv と stdin（JSON 1 行）を受け取ってプロセスを起こす関数。既定は Bun.spawn。 */
+export type NotifySpawn = (argv: readonly string[], stdin: Uint8Array) => NotifyChild;
+
+/**
+ * シェルを介さず argv へ分解する簡易パーサ。
+ * 空白区切りで、`'…'` / `"…"` に囲めば空白を含む引数を書ける。引用符は語の途中でも開閉でき（`--m='a b'` → `--m=a b`）、
+ * エスケープ・変数展開・`~` 展開・glob は解釈しない（`~` を使うと literal のパスになり必ず失敗する。docs の例は `$HOME` を shell 側で展開させる）。
+ */
+export function parseCommandLine(raw: string): string[] {
+  const argv: string[] = [];
+  let current: string | null = null;
+  let quote: '"' | "'" | null = null;
+  for (const char of raw) {
+    if (quote !== null) {
+      if (char === quote) quote = null;
+      else current = (current ?? '') + char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current = current ?? '';
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current !== null) argv.push(current);
+      current = null;
+      continue;
+    }
+    current = (current ?? '') + char;
+  }
+  if (quote !== null) throw new Error(`${NOTIFY_COMMAND_ENV} の引用符が閉じていません`);
+  if (current !== null) argv.push(current);
+  return argv;
+}
+
+/**
+ * 環境変数の値を argv テンプレートへ変換する。未設定・空白のみなら null（通知を諦めて計測は続行する）。
+ * 不正な値は run の副作用が始まる前に投げたいので、呼び出しは配信開始前に置く。
+ */
+export function notifyCommandTemplate(raw: string | undefined): string[] | null {
+  if (raw === undefined || raw.trim() === '') return null;
+  const argv = parseCommandLine(raw);
+  if (argv.length === 0 || argv[0] === '') throw new Error(`${NOTIFY_COMMAND_ENV} にコマンド名がありません`);
+  return argv;
+}
+
+/** テンプレートの各引数の `{url}` / `{channel}` を実値へ置換する（シェルを通さないのでクォートは不要）。 */
+export function buildNotifyArgv(template: readonly string[], values: { url: string; channel: string }): string[] {
+  return template.map((argument) => argument.replaceAll('{url}', values.url).replaceAll('{channel}', values.channel));
+}
+
+/** コマンドが引数ではなく stdin から読みたい場合のための JSON 1 行。 */
+export function notifyStdinJson(values: { url: string; channel: string }): string {
+  return `${JSON.stringify({ url: values.url, channel: values.channel })}\n`;
+}
+
+const spawnNotifyCommand: NotifySpawn = (argv, stdin) => {
+  // stdout は使わないので捨てる（読まれない pipe が満杯になると子が write でブロックし、成功なのにタイムアウト扱いになる）
+  const child = Bun.spawn([...argv], { stdin, stdout: 'ignore', stderr: 'pipe' });
+  return { exited: child.exited, stderr: requirePipe(child.stderr, 'notify stderr'), kill: () => child.kill() };
+};
+
+/**
+ * VRChat を動かす別 PC で URL を拾えるよう、注入されたコマンドへ配信 URL を渡す（失敗は計測を止めない）。
+ * stderr は await せずに読み始める（子が固まると pipe が閉じず、先に await するとタイムアウトが始まらない）。
+ */
+export async function notifyStreamUrl(options: {
+  template: readonly string[] | null;
+  url: string;
+  channel: string;
+  timeoutMs?: number;
+  spawn?: NotifySpawn;
+}): Promise<void> {
+  const { template, url, channel, timeoutMs = NOTIFY_TIMEOUT_MS, spawn = spawnNotifyCommand } = options;
+  if (template === null) {
+    console.warn(`通知コマンド未設定のため通知をスキップします（${NOTIFY_COMMAND_ENV} を設定すると配信 URL を投稿できます）`);
+    return;
+  }
+  const argv = buildNotifyArgv(template, { url, channel });
+  const child = spawn(argv, new TextEncoder().encode(notifyStdinJson({ url, channel })));
+  const stderr = readPipeText(child.stderr).catch((error: unknown) => (error instanceof Error ? error.message : String(error)));
+  const exit = await Promise.race([child.exited, Bun.sleep(timeoutMs).then(() => { child.kill(); return -1; })]);
+  const diagnostics = (await stderr).trim();
+  if (exit !== 0) console.warn(`配信 URL の通知に失敗またはタイムアウトしました（exit ${exit}）: ${diagnostics}`);
+  else console.info(`配信 URL を通知しました（channel ${channel}）`);
+}

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -8,7 +8,7 @@ import {
   collectOutletGrabs, decodeDurationSummary, probeDimensionsFor, readPipeText, requirePipe, scaledProbeDimensions, startAudioProbe, type VideoDiagnostics,
 } from './latency-probe-observe';
 import { recordWindowsPlayer, type PlayerResult } from './latency-probe-player';
-import { NOTIFY_COMMAND_ENV, notifyCommandTemplate, notifyStreamUrl } from './latency-probe-notify';
+import { NOTIFY_COMMAND_ENV, notifyCommandTemplate, notifyStreamUrl, validateNotifyChannelId, warnNotifyCommandMissing } from './latency-probe-notify';
 import { captureSenderConfig, collectOutletQuality, collectSenderStats, parseSenderCsv, peerConnectionTrackerInitScript } from './latency-probe-quality';
 import { cycleVideoProfiles, startVideoProfileCycle, validateProfileCycleSeconds, validateVideoProfile, videoProfileEvaluator } from './latency-probe-profile';
 import type { ProfileSwitch } from './latency-probe-profile-analysis';
@@ -45,8 +45,7 @@ function browserLogTail(): string { return browserLog.length ? `\nbrowser consol
 /** 実Chromeの画面共有、出口プローブ、出力保存を同じcleanup境界で実行する。 */
 export async function runLatencyProbe(options: RunOptions): Promise<void> {
   validateRunOptions(options);
-  // 通知コマンドの構文エラーは配信を始める前に落とす（run 開始後に投げると計測ぶんの待機が無駄になる）
-  const notifyTemplate = options.notifyDiscordChannelId === null ? null : notifyCommandTemplate(process.env[NOTIFY_COMMAND_ENV]);
+  const notify = resolveNotifyTarget(options.notifyDiscordChannelId);
   rejectRepositoryProfile(options.profileDir);
   requireCommands(options.player);
   await mkdir(options.outDir, { recursive: true, mode: 0o700 });
@@ -95,7 +94,7 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
       pbcopy.stdin.end();
       await pbcopy.exited;
     }
-    if (options.notifyDiscordChannelId !== null) await notifyStreamUrl({ template: notifyTemplate, url: viewerUrl, channel: options.notifyDiscordChannelId });
+    if (notify !== null) await notifyStreamUrl({ ...notify, url: viewerUrl });
     const dimensions = scaledProbeDimensions(await probeDimensionsFor(rtspUrl));
     audio = startAudioProbe(rtspUrl);
     const videoLog = Promise.resolve('(映像は単発取得方式のため連続 ffmpeg なし)');
@@ -210,6 +209,7 @@ export async function clearPreviousRunArtifacts(outDir: string): Promise<void> {
 /** runの公開境界でプロファイル関連値を検証し、副作用の前に不正入力を拒否する。 */
 export function validateRunOptions(options: RunOptions): void {
   if (options.videoProfile !== 'quality' && options.videoProfile !== 'realtime') throw new Error('videoProfile must be quality or realtime');
+  if (options.notifyDiscordChannelId !== null) validateNotifyChannelId(options.notifyDiscordChannelId);
   if (options.nodeHost !== null) validateNodeHost(options.nodeHost);
   if (options.readHost !== null) validateReadHost(options.readHost);
   if (options.maxBitrate !== null) validateVideoProfile(options.videoProfile, options.maxBitrate);
@@ -390,4 +390,16 @@ function rejectRepositoryProfile(profileDir: string): void {
   const path = relative(repository, candidate);
   if (path === '' || (path !== '..' && !path.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) && !path.startsWith('..'))) throw new Error('--profile-dir must not be inside the repository');
 }
+
+/**
+ * 通知先とコマンドを配信開始前に確定させる。構文エラーはここで投げ、未設定はここで警告して null にする
+ * （Chrome 起動・配信開始より後に出すと、計測ぶんの待機が無駄になる／警告に気づけない）。
+ */
+function resolveNotifyTarget(channel: string | null): { template: readonly string[]; channel: string } | null {
+  if (channel === null) return null;
+  const template = notifyCommandTemplate(process.env[NOTIFY_COMMAND_ENV]);
+  if (template === null) { warnNotifyCommandMissing(); return null; }
+  return { template, channel };
+}
+
 function requireCommands(player: RunOptions['player']): void { const required = player ? ['ffmpeg', 'ffprobe', 'ssh'] : ['ffmpeg', 'ffprobe']; const missing = required.filter((command) => Bun.which(command) === null); if (missing.length) throw new Error(`必要なコマンドがありません: ${missing.join(', ')}。macOSでは brew install ffmpeg、sshはXcode Command Line Toolsを確認してください。`); }

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -1,4 +1,3 @@
-import { homedir } from 'node:os';
 import { captureServerSnapshots, snapshotScheduleSeconds } from './latency-probe-server-snap';
 import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
@@ -9,6 +8,7 @@ import {
   collectOutletGrabs, decodeDurationSummary, probeDimensionsFor, readPipeText, requirePipe, scaledProbeDimensions, startAudioProbe, type VideoDiagnostics,
 } from './latency-probe-observe';
 import { recordWindowsPlayer, type PlayerResult } from './latency-probe-player';
+import { NOTIFY_COMMAND_ENV, notifyCommandTemplate, notifyStreamUrl } from './latency-probe-notify';
 import { captureSenderConfig, collectOutletQuality, collectSenderStats, parseSenderCsv, peerConnectionTrackerInitScript } from './latency-probe-quality';
 import { cycleVideoProfiles, startVideoProfileCycle, validateProfileCycleSeconds, validateVideoProfile, videoProfileEvaluator } from './latency-probe-profile';
 import type { ProfileSwitch } from './latency-probe-profile-analysis';
@@ -45,6 +45,8 @@ function browserLogTail(): string { return browserLog.length ? `\nbrowser consol
 /** 実Chromeの画面共有、出口プローブ、出力保存を同じcleanup境界で実行する。 */
 export async function runLatencyProbe(options: RunOptions): Promise<void> {
   validateRunOptions(options);
+  // 通知コマンドの構文エラーは配信を始める前に落とす（run 開始後に投げると計測ぶんの待機が無駄になる）
+  const notifyTemplate = options.notifyDiscordChannelId === null ? null : notifyCommandTemplate(process.env[NOTIFY_COMMAND_ENV]);
   rejectRepositoryProfile(options.profileDir);
   requireCommands(options.player);
   await mkdir(options.outDir, { recursive: true, mode: 0o700 });
@@ -93,7 +95,7 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
       pbcopy.stdin.end();
       await pbcopy.exited;
     }
-    if (options.notifyDiscordChannelId) await notifyDiscord(options.notifyDiscordChannelId, viewerUrl, options.minutes);
+    if (options.notifyDiscordChannelId !== null) await notifyStreamUrl({ template: notifyTemplate, url: viewerUrl, channel: options.notifyDiscordChannelId });
     const dimensions = scaledProbeDimensions(await probeDimensionsFor(rtspUrl));
     audio = startAudioProbe(rtspUrl);
     const videoLog = Promise.resolve('(映像は単発取得方式のため連続 ffmpeg なし)');
@@ -389,15 +391,3 @@ function rejectRepositoryProfile(profileDir: string): void {
   if (path === '' || (path !== '..' && !path.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) && !path.startsWith('..'))) throw new Error('--profile-dir must not be inside the repository');
 }
 function requireCommands(player: RunOptions['player']): void { const required = player ? ['ffmpeg', 'ffprobe', 'ssh'] : ['ffmpeg', 'ffprobe']; const missing = required.filter((command) => Bun.which(command) === null); if (missing.length) throw new Error(`必要なコマンドがありません: ${missing.join(', ')}。macOSでは brew install ffmpeg、sshはXcode Command Line Toolsを確認してください。`); }
-
-const DISCORD_NOTIFY_SCRIPT = `${homedir()}/.claude/skills/discord-mention/scripts/notify-discord.ts`;
-
-/** VRChat を動かす別 PC で URL を拾えるよう、Discord のチャンネルへ配信 URL を投稿する（失敗は計測を止めない）。 */
-async function notifyDiscord(channelId: string, viewerUrl: string, minutes: number): Promise<void> {
-  const message = `遅延計測の配信を開始しました（${minutes} 分）。VRChat に貼ってください:\n${viewerUrl}`;
-  const child = Bun.spawn(['bun', DISCORD_NOTIFY_SCRIPT, '--message', message, '--target', 'nori', '--channel-id', channelId, '--project-dir', process.cwd()], { stdout: 'pipe', stderr: 'pipe' });
-  const stderr = await readPipeText(requirePipe(child.stderr, 'discord notify stderr'));
-  const exit = await Promise.race([child.exited, Bun.sleep(10_000).then(() => { child.kill(); return -1; })]);
-  if (exit !== 0) console.warn(`Discord 通知に失敗またはタイムアウトしました: ${stderr.trim()}`);
-  else console.info(`Discord へ配信 URL を投稿しました（channel ${channelId}）`);
-}

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { analyzeDirectory, loginProfile, runLatencyProbe, switchSource, validateNodeHost, validateReadHost, type RunOptions } from './latency-probe-run';
+import { validateNotifyChannelId } from './latency-probe-notify';
 import { checkWindowsRecording } from './latency-probe-player';
 
 const HELP = `Usage: bun scripts/latency-probe.ts <subcommand> [options]
@@ -82,7 +83,7 @@ export function parseLatencyProbeArgs(argv: readonly string[]):
   if (values['server-snap'] !== undefined && !isValidSshHost(values['server-snap'])) throw new Error('--server-snap must be an ssh host name');
   if (values['node-host'] !== undefined) validateNodeHost(values['node-host']);
   if (values['read-host'] !== undefined) validateReadHost(values['read-host']);
-  if (values['notify-discord'] !== undefined && !/^\d{15,25}$/.test(values['notify-discord'])) throw new Error('--notify-discord must be a Discord channel id');
+  if (values['notify-discord'] !== undefined) validateNotifyChannelId(values['notify-discord']);
   if (values['stream-id'] !== undefined && !/^[A-Za-z0-9]{12}$/.test(values['stream-id'])) throw new Error('--stream-id must be a 12-character alphanumeric ID');
   const minutes = Number(values.minutes);
   if (!Number.isInteger(minutes) || minutes < 1 || minutes > 120) throw new Error('--minutes must be an integer between 1 and 120');

--- a/web/scripts/latency-probe.ts
+++ b/web/scripts/latency-probe.ts
@@ -33,7 +33,11 @@ run options:
   --outlet-quality-seconds N
                      出口画質の連続ffmpeg測定窓（5〜120秒、既定20）。遅延用の単発取得とは別系統
   --notify-discord CHANNEL_ID
-                     配信 URL を Discord の指定チャンネルへ投稿する（VRChat 側の PC で貼るため）
+                     配信 URL を外部へ通知する（VRChat 側の PC で貼るため）。実際に叩くコマンドは環境変数
+                     WEBSCREEN_LATENCY_NOTIFY_COMMAND で注入する（空白区切りの argv。'…' / "…" で空白を含む引数を囲める。
+                     シェルは介さないので ~ や $VAR は展開されない）。各引数の {url} は配信 URL、{channel} はこの
+                     CHANNEL_ID に置換し、stdin へ {"url":"...","channel":"..."} の JSON を 1 行渡す。
+                     未設定なら警告だけ出して計測は続行する。例と注入方法は docs/streaming/latency-harness.md
   --node-host HOST   配信先ノードを差し替える（web-screen.net 配下の 1 ラベルのみ、例 chi1.web-screen.net）。配信開始 API 応答の whipUrl のホストを HOST にして WHIP を
                      そのノードへ送り、出口計測と VRChat へ渡す URL も rtsp(t)://HOST/live/{id} にする
                      （本番の STREAM_WHIP_ORIGIN と DNS は変えずに別ノードを origin として測る用途）

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -30,6 +30,7 @@ import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
 import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, syntheticHealthBody, validateReadHost, validateRunOptions } from '../../scripts/latency-probe-run';
+import { NOTIFY_COMMAND_ENV, buildNotifyArgv, notifyCommandTemplate, notifyStdinJson, notifyStreamUrl, parseCommandLine, type NotifyChild } from '../../scripts/latency-probe-notify';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 import { recordingDeadlineSeconds } from '../../scripts/latency-probe-player';
 
@@ -492,5 +493,111 @@ describe('latency probe windows recording deadline', () => {
     expect(recordingDeadlineSeconds(10)).toBe(45);
     expect(recordingDeadlineSeconds(480)).toBe(750);
     expect(recordingDeadlineSeconds(8)).toBe(42);
+  });
+});
+
+/** 通知コマンドを起こさずに argv と stdin だけを記録する差し替え先。 */
+function recordingSpawn(exitCode: number): { calls: { argv: string[]; stdin: string }[]; spawn: (argv: readonly string[], stdin: Uint8Array) => NotifyChild } {
+  const calls: { argv: string[]; stdin: string }[] = [];
+  return {
+    calls,
+    spawn: (argv, stdin) => {
+      calls.push({ argv: [...argv], stdin: new TextDecoder().decode(stdin) });
+      return {
+        exited: Promise.resolve(exitCode),
+        stderr: new ReadableStream<Uint8Array>({ start(controller) { controller.enqueue(new TextEncoder().encode('boom')); controller.close(); } }),
+        kill: () => undefined,
+      };
+    },
+  };
+}
+
+describe('latency probe notify command', () => {
+  test('空白区切りの argv を引用符つきで分解する', () => {
+    expect(parseCommandLine('bun notify.ts --target nori')).toEqual(['bun', 'notify.ts', '--target', 'nori']);
+    expect(parseCommandLine('  bun   notify.ts  ')).toEqual(['bun', 'notify.ts']);
+    expect(parseCommandLine(`cmd --message '配信を開始しました: {url}'`)).toEqual(['cmd', '--message', '配信を開始しました: {url}']);
+    expect(parseCommandLine('cmd --message "a b" --flag')).toEqual(['cmd', '--message', 'a b', '--flag']);
+    // 語の途中の引用符（--message='a b' 形式）と、引用符内の別種の引用符
+    expect(parseCommandLine(`cmd --message='a b' -x`)).toEqual(['cmd', '--message=a b', '-x']);
+    expect(parseCommandLine(`cmd "it's here"`)).toEqual(['cmd', "it's here"]);
+    // 空文字の引数は明示的に残す
+    expect(parseCommandLine(`cmd "" tail`)).toEqual(['cmd', '', 'tail']);
+  });
+
+  test('閉じていない引用符とコマンド名なしは env の読み込み時点で失敗する', () => {
+    expect(() => parseCommandLine(`cmd --message 'unterminated`)).toThrow(NOTIFY_COMMAND_ENV);
+    expect(() => notifyCommandTemplate(`cmd "unterminated`)).toThrow(NOTIFY_COMMAND_ENV);
+    expect(() => notifyCommandTemplate('"" --flag')).toThrow(NOTIFY_COMMAND_ENV);
+  });
+
+  test('未設定・空白のみの環境変数は null を返す', () => {
+    expect(notifyCommandTemplate(undefined)).toBeNull();
+    expect(notifyCommandTemplate('   ')).toBeNull();
+  });
+
+  test('{url} と {channel} を引数配列と stdin JSON へ反映する', async () => {
+    const template = notifyCommandTemplate(`bun /opt/notify.ts --message '配信: {url}' --channel-id {channel} --url={url}`);
+    expect(template).not.toBeNull();
+    expect(buildNotifyArgv(template ?? [], { url: 'rtspt://chi1.web-screen.net/live/AbCdEf123456', channel: '123456789012345678' })).toEqual([
+      'bun', '/opt/notify.ts', '--message', '配信: rtspt://chi1.web-screen.net/live/AbCdEf123456',
+      '--channel-id', '123456789012345678', '--url=rtspt://chi1.web-screen.net/live/AbCdEf123456',
+    ]);
+    const recorder = recordingSpawn(0);
+    const info = spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      await notifyStreamUrl({ template, url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200, spawn: recorder.spawn });
+    } finally { info.mockRestore(); }
+    expect(recorder.calls).toHaveLength(1);
+    expect(recorder.calls[0]?.argv).toContain('配信: rtspt://host/live/AbCdEf123456');
+    expect(recorder.calls[0]?.argv).toContain('123456789012345678');
+    expect(JSON.parse(recorder.calls[0]?.stdin ?? '{}')).toEqual({ url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678' });
+    expect(notifyStdinJson({ url: 'u', channel: 'c' }).endsWith('\n')).toBe(true);
+  });
+
+  test('未設定なら警告だけ出して例外にせず計測を続行する', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await notifyStreamUrl({ template: null, url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200 });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain(NOTIFY_COMMAND_ENV);
+    } finally { warn.mockRestore(); }
+  });
+
+  test('非ゼロ終了は警告に落として run を止めない', async () => {
+    const recorder = recordingSpawn(3);
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await notifyStreamUrl({ template: ['notify'], url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200, spawn: recorder.spawn });
+      expect(String(warn.mock.calls[0]?.[0])).toContain('boom');
+    } finally { warn.mockRestore(); }
+  });
+
+  test('既定の spawn で実プロセスを起こし、成功を info で報告する', async () => {
+    const info = spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      await notifyStreamUrl({ template: ['echo', '{channel}', '{url}'], url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 5_000 });
+      expect(String(info.mock.calls[0]?.[0])).toContain('123456789012345678');
+    } finally { info.mockRestore(); }
+  });
+
+  // docs の注入例と同じ形（$HOME 展開後の絶対パス + 引用符つきメッセージ）が argv へ落ちることを確認する。
+  // 実パスは書かない（リポジトリに個人環境の固定パスを残さないのが本変更の目的）。
+  test('固まったコマンドはタイムアウトで kill して警告に落とす', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    const startedAt = Date.now();
+    try {
+      // stderr を先に await していると pipe が閉じずタイムアウトが始まらない（実プロセスでの回帰確認）
+      await notifyStreamUrl({ template: ['sleep', '30'], url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200 });
+      expect(String(warn.mock.calls[0]?.[0])).toContain('exit -1');
+    } finally { warn.mockRestore(); }
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  test('docs の通知コマンド例が argv へ分解できる', () => {
+    const template = notifyCommandTemplate(`bun /Users/example/notify-discord.ts --message '遅延計測の配信を開始しました。VRChat に貼ってください: {url}' --target nori --channel-id {channel} --project-dir .`);
+    expect(template?.[0]).toBe('bun');
+    expect(template).toContain('遅延計測の配信を開始しました。VRChat に貼ってください: {url}');
+    expect(template?.slice(-4)).toEqual(['--channel-id', '{channel}', '--project-dir', '.']);
   });
 });

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -27,10 +27,10 @@ import {
   encodeMonoWav,
 } from '../../scripts/latency-probe-codec';
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
-import { resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
+import { requirePipe, resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
 import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, syntheticHealthBody, validateReadHost, validateRunOptions } from '../../scripts/latency-probe-run';
-import { NOTIFY_COMMAND_ENV, buildNotifyArgv, notifyCommandTemplate, notifyStdinJson, notifyStreamUrl, parseCommandLine, type NotifyChild } from '../../scripts/latency-probe-notify';
+import { NOTIFY_COMMAND_ENV, NOTIFY_STDERR_TRUNCATED_SUFFIX, buildNotifyArgv, notifyCommandTemplate, notifyStdinJson, notifyStreamUrl, parseCommandLine, warnNotifyCommandMissing, type NotifyChild, type NotifySpawn } from '../../scripts/latency-probe-notify';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 import { recordingDeadlineSeconds } from '../../scripts/latency-probe-player';
 
@@ -160,6 +160,8 @@ describe('latency probe video profiles', () => {
     await expect(applyVideoProfile(evaluator, 'other' as 'quality', 1_500_000, 1_000)).rejects.toThrow('video profile');
     expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 999_999, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null, readHost: null })).toThrow('maxBitrate');
     expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: 1_500_000, abCycleSeconds: 59, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: null, serverSnapHost: null, streamId: null, nodeHost: null, readHost: null })).toThrow('cycleSeconds');
+    // CLI を通さず runLatencyProbe を直接呼ぶ経路でも、通知先 ID を CLI と同じ規則で弾く
+    expect(() => validateRunOptions({ minutes: 1, source: 'https://example.test', player: null, profileDir: '/tmp/profile', outDir: '/tmp/out', videoProfile: 'quality', maxBitrate: null, abCycleSeconds: null, scrollPixelsPerSecond: 0, outletQualitySeconds: 20, notifyDiscordChannelId: '12345', serverSnapHost: null, streamId: null, nodeHost: null, readHost: null })).toThrow('notify-discord');
   });
 
   test('sender差し替え時は5秒ポーリングで同じプロファイルを再適用する', async () => {
@@ -546,7 +548,7 @@ describe('latency probe notify command', () => {
     const recorder = recordingSpawn(0);
     const info = spyOn(console, 'info').mockImplementation(() => undefined);
     try {
-      await notifyStreamUrl({ template, url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200, spawn: recorder.spawn });
+      await notifyStreamUrl({ template: template ?? [], url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200, spawn: recorder.spawn });
     } finally { info.mockRestore(); }
     expect(recorder.calls).toHaveLength(1);
     expect(recorder.calls[0]?.argv).toContain('配信: rtspt://host/live/AbCdEf123456');
@@ -555,10 +557,10 @@ describe('latency probe notify command', () => {
     expect(notifyStdinJson({ url: 'u', channel: 'c' }).endsWith('\n')).toBe(true);
   });
 
-  test('未設定なら警告だけ出して例外にせず計測を続行する', async () => {
+  test('未設定なら警告だけ出して例外にせず計測を続行する', () => {
     const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
     try {
-      await notifyStreamUrl({ template: null, url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200 });
+      warnNotifyCommandMissing();
       expect(warn).toHaveBeenCalledTimes(1);
       expect(String(warn.mock.calls[0]?.[0])).toContain(NOTIFY_COMMAND_ENV);
     } finally { warn.mockRestore(); }
@@ -581,8 +583,6 @@ describe('latency probe notify command', () => {
     } finally { info.mockRestore(); }
   });
 
-  // docs の注入例と同じ形（$HOME 展開後の絶対パス + 引用符つきメッセージ）が argv へ落ちることを確認する。
-  // 実パスは書かない（リポジトリに個人環境の固定パスを残さないのが本変更の目的）。
   test('固まったコマンドはタイムアウトで kill して警告に落とす', async () => {
     const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
     const startedAt = Date.now();
@@ -594,6 +594,56 @@ describe('latency probe notify command', () => {
     expect(Date.now() - startedAt).toBeLessThan(5_000);
   });
 
+  test('存在しないコマンドでも spawn の同期例外を警告に落として run を止めない', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      // Bun.spawn は実行ファイルが無いと同期で ENOENT を投げる（実プロセスでの回帰確認）
+      await notifyStreamUrl({ template: ['/nonexistent/webscreen-notify-xyz', '{channel}'], url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200 });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain('/nonexistent/webscreen-notify-xyz');
+      expect(String(warn.mock.calls[0]?.[0])).toContain('起動できませんでした');
+    } finally { warn.mockRestore(); }
+  });
+
+  test('SIGTERM を無視する子も期限内に打ち切り、SIGKILL まで上げて残さない', async () => {
+    const exits: Promise<number>[] = [];
+    const spawn: NotifySpawn = (argv, stdin) => {
+      const child = Bun.spawn([...argv], { stdin, stdout: 'ignore', stderr: 'pipe' });
+      exits.push(child.exited);
+      return { exited: child.exited, stderr: requirePipe(child.stderr, 'test notify stderr'), kill: (signal) => child.kill(signal) };
+    };
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    const startedAt = Date.now();
+    try {
+      await notifyStreamUrl({
+        template: [process.execPath, '-e', "process.on('SIGTERM', () => {}); setTimeout(() => {}, 30_000)"],
+        url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 300, spawn,
+      });
+      expect(String(warn.mock.calls[0]?.[0])).toContain('exit -1');
+    } finally { warn.mockRestore(); }
+    // 期限 + kill 猶予 + stderr 猶予の合計で返ること（stderr の EOF 待ちで 30 秒引きずらない）
+    expect(Date.now() - startedAt).toBeLessThan(3_000);
+    // 30 秒の孤児を残さない（SIGTERM だけでは死なないので SIGKILL まで上げられているか）
+    expect(await Promise.race([exits[0] ?? Promise.resolve(0), Bun.sleep(1_000).then(() => 'alive')])).not.toBe('alive');
+  });
+
+  test('stderr は上限で切り詰めて警告に載せる', async () => {
+    const noisy: NotifySpawn = () => ({
+      exited: Promise.resolve(1),
+      stderr: new ReadableStream<Uint8Array>({ start(controller) { controller.enqueue(new TextEncoder().encode('e'.repeat(10_000))); controller.close(); } }),
+      kill: () => undefined,
+    });
+    const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await notifyStreamUrl({ template: ['notify'], url: 'rtspt://host/live/AbCdEf123456', channel: '123456789012345678', timeoutMs: 200, spawn: noisy });
+      const message = String(warn.mock.calls[0]?.[0]);
+      expect(message.match(/e{2,}/)?.[0]).toHaveLength(4_096);
+      expect(message).toContain(NOTIFY_STDERR_TRUNCATED_SUFFIX);
+    } finally { warn.mockRestore(); }
+  });
+
+  // docs の注入例と同じ形（$HOME 展開後の絶対パス + 引用符つきメッセージ）が argv へ落ちることを確認する。
+  // 実パスは書かない（リポジトリに個人環境の固定パスを残さないのが本変更の目的）。
   test('docs の通知コマンド例が argv へ分解できる', () => {
     const template = notifyCommandTemplate(`bun /Users/example/notify-discord.ts --message '遅延計測の配信を開始しました。VRChat に貼ってください: {url}' --target nori --channel-id {channel} --project-dir .`);
     expect(template?.[0]).toBe('bun');


### PR DESCRIPTION
## なぜこの変更が必要か

`--notify-discord` がリポジトリに無い個人スキルのパスを固定で起動しており、そのスキルを持たない端末では通知が必ず失敗した（#185、PR #181 の Codex 指摘）。

## 変更内容

- `web/scripts/latency-probe-notify.ts`（新規）: 環境変数 `WEBSCREEN_LATENCY_NOTIFY_COMMAND` を argv に分解（引用符対応の簡易パーサ、シェル非経由）し、`{url}` / `{channel}` を置換、stdin に JSON 1 行を渡して 10 秒で打ち切る
- `latency-probe-run.ts`: 固定パス `DISCORD_NOTIFY_SCRIPT` を削除。未設定なら警告して計測続行、不正値は配信開始前に落とす。旧実装で stderr を先に await していてタイムアウトが効かなかった順序を修正
- `--help`、`docs/streaming/latency-harness.md`（注入例: discord-mention / webhook CLI）、`vrchat-ab-runbook.md`、`Makefile` の注記

## 意思決定

- 環境変数 1 本に寄せ、`--notify-discord CHANNEL_ID` は互換のため残す（`{channel}` へ渡すだけ）
- パーサはエスケープ・`~`・`$` 展開を持たない（`$HOME` は shell 側で展開させる）。過剰設計を避けるため

## テスト

- [x] `bun test tests/scripts/latency-probe.test.ts` 47 pass（パーサ・置換・未設定時の警告・タイムアウトの実プロセス確認）、`bun run typecheck`
- [x] `rg "\.claude/skills" web/scripts web/tests Makefile` ヒット 0
- [ ] 実 run での Discord 投稿は次回の計測で確認する（外部投稿のため PR 内では未実施）

Closes #185

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KjQWSGJDJsk6mmyehKPVK
