### PR TITLE
fix(latency-probe): ローカル controller（/source）に Bearer トークン認証と入力制限を付ける（#205）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ web/playwright-report/
 
 # ローカル worktree のタスク説明
 .wt-task
+
+# 遅延計測ハーネスの実行状態（controller token を含む）
+docs/tmp/

--- a/docs/streaming/latency-harness.md
+++ b/docs/streaming/latency-harness.md
@@ -18,6 +18,8 @@ bun scripts/latency-probe.ts source --url https://example.com/ --scroll 240
 bun scripts/latency-probe.ts analyze docs/tmp/latency/<UTC timestamp>
 ```
 
+`source` は `run` と同じマシン・同じユーザーから実行する。切替には `docs/tmp/latency/.active.json`（mode `0600`）に保存された実行中トークンが必要。
+
 - 初回だけ既定プロファイル `~/.webscreen-harness/chrome-profile` で `bun scripts/latency-probe.ts login` を実行し、開いたChromeでWebScreenへ手動ログインする。未ログイン時は開始せず終了する。
 - `--source` の `127.0.0.1:0` は起動時の空きポートへ置換される。`?tones=1` は左右チャンネル確認用の小さな持続音（220 / 330 Hz、ゆっくり揺らぐ）も加える。
 - 計測ページは復号用の格子の左に秒針つきアナログ時計、右に `HH:MM:SS.mmm`（配信元 PC のローカル時刻）を描く。VRChat 実機で隣にブラウザの同じページ（または任意の時計）を並べれば、Windows 全画面録画のフレームから目視でも遅延を読める。どちらも格子の隔離矩形の外に描くので復号には影響しない（plain / heavy / 800x600 で確認済み）

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -1,4 +1,5 @@
 import { captureServerSnapshots, snapshotScheduleSeconds } from './latency-probe-server-snap';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 
@@ -35,8 +36,12 @@ export interface RunOptions {
   /** 視聴先だけを差し替える `host` または `host:port`。null なら nodeHost、それも null なら webscreen.tv。 */
   readHost: string | null;
 }
-interface ActiveController { endpoint: string; sourceUrl: string }
-interface ControllerState { sourcePage: import('@playwright/test').Page | null; sourceUrl: string; sourceServerUrl: string }
+interface ActiveController { endpoint: string; sourceUrl: string; token: string }
+/** controller が参照・更新する実行中ハーネスの状態。 */
+export interface ControllerState { sourcePage: import('@playwright/test').Page | null; sourceUrl: string; sourceServerUrl: string }
+interface ControllerRequestBody { url?: unknown; scrollPixelsPerSecond?: unknown }
+
+const CONTROLLER_BODY_LIMIT_BYTES = 4 * 1024;
 
 const browserLog: string[] = [];
 function pushBrowserLog(line: string): void { browserLog.push(`${new Date().toISOString()} ${line}`); if (browserLog.length > 80) browserLog.shift(); }
@@ -53,9 +58,11 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
   await clearPreviousRunArtifacts(options.outDir);
   const sourceServer = startSourceServer();
   const state: ControllerState = { sourcePage: null, sourceUrl: sourceServer.url.href, sourceServerUrl: sourceServer.url.href };
-  const controllerServer = startControllerServer(state);
+  const controllerToken = randomBytes(32).toString('hex');
+  const controllerServer = startControllerServer(state, controllerToken);
   await mkdir(resolve('..', 'docs', 'tmp', 'latency'), { recursive: true });
-  await writeFile(ACTIVE_FILE, JSON.stringify({ endpoint: controllerServer.url.href, sourceUrl: sourceServer.url.href }));
+  await writeFile(ACTIVE_FILE, JSON.stringify({ endpoint: controllerServer.url.href, sourceUrl: sourceServer.url.href, token: controllerToken }), { mode: 0o600 });
+  await chmod(ACTIVE_FILE, 0o600);
   let startedAtMs = 0;
   const outlet: LatencySample[] = [];
   let browser: import('@playwright/test').BrowserContext | null = null;
@@ -175,7 +182,7 @@ export async function loginProfile(profileDir: string, timeoutMs = 8 * 60_000): 
 /** 動作中ハーネスの共有済みタブを指定URLへ遷移する。 */
 export async function switchSource(url: string, scrollPixelsPerSecond = 0): Promise<void> {
   const active = JSON.parse(await readFile(ACTIVE_FILE, 'utf8')) as ActiveController;
-  const response = await fetch(new URL('/source', active.endpoint), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url, scrollPixelsPerSecond }) });
+  const response = await fetch(new URL('/source', active.endpoint), { method: 'POST', headers: { Authorization: `Bearer ${active.token}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ url, scrollPixelsPerSecond }) });
   if (!response.ok) throw new Error(`source switch failed: ${await response.text()}`);
 }
 
@@ -304,11 +311,17 @@ function startSourceServer(): ReturnType<typeof Bun.serve> {
   } });
 }
 
-function startControllerServer(state: ControllerState): ReturnType<typeof Bun.serve> {
+/** 認証済みの source 切替要求だけを受け付けるローカル controller を起動する。 */
+export function startControllerServer(state: ControllerState, token: string): ReturnType<typeof Bun.serve> {
   return Bun.serve({ hostname: '127.0.0.1', port: 0, async fetch(request) {
     const url = new URL(request.url);
     if (request.method !== 'POST' || url.pathname !== '/source') return new Response('Not found', { status: 404 });
-    const body = await request.json().catch(() => null) as { url?: unknown; scrollPixelsPerSecond?: unknown } | null;
+    if (!hasValidControllerToken(request.headers.get('authorization'), token)) return new Response('Unauthorized', { status: 401 });
+    if (request.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase() !== 'application/json') return new Response('Content-Type must be application/json', { status: 400 });
+    const bodyText = await readControllerBody(request);
+    if (bodyText === null) return new Response('request body must not exceed 4 KB', { status: 400 });
+    let body: ControllerRequestBody | null = null;
+    try { body = JSON.parse(bodyText) as ControllerRequestBody; } catch { /* invalid JSON is handled as a bad request below */ }
     if (!body || typeof body.url !== 'string') return new Response('url is required', { status: 400 });
     const target = resolveSourceUrl(body.url, new URL(state.sourceServerUrl));
     if (!state.sourcePage) return new Response('run is not ready', { status: 409 });
@@ -317,6 +330,36 @@ function startControllerServer(state: ControllerState): ReturnType<typeof Bun.se
     await applyAutoScroll(state.sourcePage, target, state.sourceServerUrl, body.scrollPixelsPerSecond); state.sourceUrl = target;
     return Response.json({ ok: true, sourceUrl: target });
   } });
+}
+
+function hasValidControllerToken(authorization: string | null, token: string): boolean {
+  const match = /^Bearer (.+)$/.exec(authorization ?? '');
+  if (!match) return false;
+  const supplied = new TextEncoder().encode(match[1]);
+  const expected = new TextEncoder().encode(token);
+  return supplied.byteLength === expected.byteLength && timingSafeEqual(supplied, expected);
+}
+
+async function readControllerBody(request: Request): Promise<string | null> {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null && (!/^\d+$/.test(contentLength) || Number(contentLength) > CONTROLLER_BODY_LIMIT_BYTES)) return null;
+  if (!request.body) return '';
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > CONTROLLER_BODY_LIMIT_BYTES) { await reader.cancel(); return null; }
+      chunks.push(value);
+    }
+  } finally { reader.releaseLock(); }
+  const body = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) { body.set(chunk, offset); offset += chunk.byteLength; }
+  return new TextDecoder().decode(body);
 }
 
 async function startChrome(profileDir: string): Promise<import('@playwright/test').BrowserContext> {

--- a/web/scripts/latency-probe-run.ts
+++ b/web/scripts/latency-probe-run.ts
@@ -1,6 +1,6 @@
 import { captureServerSnapshots, snapshotScheduleSeconds } from './latency-probe-server-snap';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
-import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 
 import { formatLatencyCsv, formatSummary, type LatencySample } from './latency-probe-analysis';
@@ -61,8 +61,7 @@ export async function runLatencyProbe(options: RunOptions): Promise<void> {
   const controllerToken = randomBytes(32).toString('hex');
   const controllerServer = startControllerServer(state, controllerToken);
   await mkdir(resolve('..', 'docs', 'tmp', 'latency'), { recursive: true });
-  await writeFile(ACTIVE_FILE, JSON.stringify({ endpoint: controllerServer.url.href, sourceUrl: sourceServer.url.href, token: controllerToken }), { mode: 0o600 });
-  await chmod(ACTIVE_FILE, 0o600);
+  await writeActiveController({ endpoint: controllerServer.url.href, sourceUrl: sourceServer.url.href, token: controllerToken });
   let startedAtMs = 0;
   const outlet: LatencySample[] = [];
   let browser: import('@playwright/test').BrowserContext | null = null;
@@ -333,11 +332,20 @@ export function startControllerServer(state: ControllerState, token: string): Re
 }
 
 function hasValidControllerToken(authorization: string | null, token: string): boolean {
-  const match = /^Bearer (.+)$/.exec(authorization ?? '');
+  const match = /^bearer\s+(\S+)$/i.exec(authorization ?? '');
   if (!match) return false;
   const supplied = new TextEncoder().encode(match[1]);
   const expected = new TextEncoder().encode(token);
   return supplied.byteLength === expected.byteLength && timingSafeEqual(supplied, expected);
+}
+
+async function writeActiveController(active: ActiveController): Promise<void> {
+  const temporaryFile = `${ACTIVE_FILE}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`;
+  try {
+    await writeFile(temporaryFile, JSON.stringify(active), { flag: 'wx', mode: 0o600 });
+    await chmod(temporaryFile, 0o600);
+    await rename(temporaryFile, ACTIVE_FILE);
+  } finally { await rm(temporaryFile, { force: true }); }
 }
 
 async function readControllerBody(request: Request): Promise<string | null> {

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createConnection } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -40,10 +41,22 @@ function controllerState(sourcePage: import('@playwright/test').Page | null = nu
   return { sourcePage, sourceUrl: 'http://127.0.0.1:4321/', sourceServerUrl: 'http://127.0.0.1:4321/' };
 }
 
+function rawHttpRequest(port: number, request: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let response = '';
+    const socket = createConnection({ host: '127.0.0.1', port }, () => socket.write(request));
+    socket.setEncoding('utf8');
+    socket.setTimeout(2_000, () => socket.destroy(new Error('raw controller request timed out')));
+    socket.on('data', (chunk) => { response += chunk; });
+    socket.on('close', () => resolve(response));
+    socket.on('error', reject);
+  });
+}
+
 describe('latency probe controller', () => {
   test.each([
-    ['トークンなし', { 'Content-Type': 'application/json' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 401],
-    ['不一致トークン', { Authorization: 'Bearer wrong', 'Content-Type': 'application/json' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 401],
+    ['単純POSTでトークンなし', { 'Content-Type': 'application/x-www-form-urlencoded' }, 'url=http%3A%2F%2F127.0.0.1%3A4321%2Fnext', 401],
+    ['同じ長さの不一致トークン', { Authorization: `Bearer ${'b'.repeat(64)}`, 'Content-Type': 'application/json' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 401],
     ['text/plain', { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'text/plain' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 400],
     ['4 KB超', { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'application/json' }, 'x'.repeat(4 * 1024 + 1), 400],
   ])('%sの要求を拒否する', async (_caseName, headers, body, expectedStatus) => {
@@ -51,6 +64,39 @@ describe('latency probe controller', () => {
     try {
       const response = await fetch(new URL('/source', server.url), { method: 'POST', headers, body });
       expect(response.status).toBe(expectedStatus);
+      expect(await response.text()).not.toContain(CONTROLLER_TOKEN);
+    } finally { server.stop(true); }
+  });
+
+  test('Content-Lengthなしのchunked本文が4 KBを超えたら拒否する', async () => {
+    const server = startControllerServer(controllerState(), CONTROLLER_TOKEN);
+    const encoder = new TextEncoder();
+    try {
+      const body = new ReadableStream<Uint8Array>({ start(controller) {
+        controller.enqueue(encoder.encode('x'.repeat(4 * 1024)));
+        controller.enqueue(encoder.encode('x'));
+        controller.close();
+      } });
+      const response = await fetch(new URL('/source', server.url), { method: 'POST', headers: { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'application/json' }, body });
+      expect(response.status).toBe(400);
+      expect(await response.text()).not.toContain(CONTROLLER_TOKEN);
+    } finally { server.stop(true); }
+  });
+
+  test.each([
+    ['実本文より短い値', '1', '1x'],
+    ['数値でない値', 'invalid', '1'],
+  ])('偽装Content-Length（%s）を拒否する', async (_caseName, contentLength, body) => {
+    const server = startControllerServer(controllerState(), CONTROLLER_TOKEN);
+    try {
+      if (server.port === undefined) throw new Error('controller TCP port is unavailable');
+      const request = [
+        'POST /source HTTP/1.1', `Host: 127.0.0.1:${server.port}`, `Authorization: Bearer ${CONTROLLER_TOKEN}`,
+        'Content-Type: application/json', `Content-Length: ${contentLength}`, 'Connection: close', '', body,
+      ].join('\r\n');
+      const response = await rawHttpRequest(server.port, request);
+      expect(response).toMatch(/^HTTP\/1\.1 400 /);
+      expect(response).not.toContain(CONTROLLER_TOKEN);
     } finally { server.stop(true); }
   });
 
@@ -61,7 +107,7 @@ describe('latency probe controller', () => {
     try {
       const response = await fetch(new URL('/source', server.url), {
         method: 'POST',
-        headers: { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'application/json; charset=utf-8' },
+        headers: { Authorization: `bEaReR   ${CONTROLLER_TOKEN}`, 'Content-Type': 'application/json; charset=utf-8' },
         body: JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }),
       });
       expect(response.status).toBe(200);

--- a/web/tests/scripts/latency-probe.test.ts
+++ b/web/tests/scripts/latency-probe.test.ts
@@ -29,10 +29,46 @@ import {
 import { parseLatencyProbeArgs } from '../../scripts/latency-probe';
 import { requirePipe, resolveAbsoluteAudioLatency, shouldLogDecodeFailure } from '../../scripts/latency-probe-observe';
 import { applyVideoProfile, cycleVideoProfiles, type VideoProfileEvaluator } from '../../scripts/latency-probe-profile';
-import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, syntheticHealthBody, validateReadHost, validateRunOptions } from '../../scripts/latency-probe-run';
+import { analyzeDirectory, clearPreviousRunArtifacts, headersForRewrittenBody, rewriteWhipUrlHost, screenShareUrl, startControllerServer, syntheticHealthBody, validateReadHost, validateRunOptions } from '../../scripts/latency-probe-run';
 import { NOTIFY_COMMAND_ENV, NOTIFY_STDERR_TRUNCATED_SUFFIX, buildNotifyArgv, notifyCommandTemplate, notifyStdinJson, notifyStreamUrl, parseCommandLine, warnNotifyCommandMissing, type NotifyChild, type NotifySpawn } from '../../scripts/latency-probe-notify';
 import { parseFreezeLog, type SenderSample } from '../../scripts/latency-probe-quality';
 import { recordingDeadlineSeconds } from '../../scripts/latency-probe-player';
+
+const CONTROLLER_TOKEN = 'a'.repeat(64);
+
+function controllerState(sourcePage: import('@playwright/test').Page | null = null) {
+  return { sourcePage, sourceUrl: 'http://127.0.0.1:4321/', sourceServerUrl: 'http://127.0.0.1:4321/' };
+}
+
+describe('latency probe controller', () => {
+  test.each([
+    ['トークンなし', { 'Content-Type': 'application/json' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 401],
+    ['不一致トークン', { Authorization: 'Bearer wrong', 'Content-Type': 'application/json' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 401],
+    ['text/plain', { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'text/plain' }, JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }), 400],
+    ['4 KB超', { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'application/json' }, 'x'.repeat(4 * 1024 + 1), 400],
+  ])('%sの要求を拒否する', async (_caseName, headers, body, expectedStatus) => {
+    const server = startControllerServer(controllerState(), CONTROLLER_TOKEN);
+    try {
+      const response = await fetch(new URL('/source', server.url), { method: 'POST', headers, body });
+      expect(response.status).toBe(expectedStatus);
+    } finally { server.stop(true); }
+  });
+
+  test('正しいトークンとJSONなら共有タブを切り替える', async () => {
+    const navigations: string[] = [];
+    const sourcePage = { goto: async (url: string) => { navigations.push(url); return null; } } as unknown as import('@playwright/test').Page;
+    const server = startControllerServer(controllerState(sourcePage), CONTROLLER_TOKEN);
+    try {
+      const response = await fetch(new URL('/source', server.url), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${CONTROLLER_TOKEN}`, 'Content-Type': 'application/json; charset=utf-8' },
+        body: JSON.stringify({ url: 'http://127.0.0.1:4321/next', scrollPixelsPerSecond: 0 }),
+      });
+      expect(response.status).toBe(200);
+      expect(navigations).toEqual(['http://127.0.0.1:4321/next']);
+    } finally { server.stop(true); }
+  });
+});
 
 function rasterize(timestampMs: number, cell = 20): { rgb: Uint8Array; width: number; height: number } {
   const width = BLOCK_GRID_SIZE * cell + 40;


### PR DESCRIPTION
## なぜこの変更が必要か

遅延計測ハーネスが run 中に立てるローカル controller（`POST /source`）に認証が無く、同一マシンの任意プロセスやブラウザで開いた任意ページの単純 POST（`text/plain`）で、配信中の共有タブを別 URL へ遷移させられた（#205、codex セキュリティレビュー指摘）。

## 変更内容

- run 起動時に 32 byte のランダムトークンを生成し、`.active.json`（mode 0600）に endpoint と一緒に書く
- `source` サブコマンドは `Authorization: Bearer` で送る。controller はトークン無し・不一致を 401、`application/json` 以外と本文 4 KB 超を 400 で拒否（timing-safe 比較、Content-Length 事前判定 + 読みながら上限）
- テスト 5 件（実ポートで 401 / 401 / 400 / 400 / 200）、docs に `source` の実行条件を追記

## 意思決定

- 開発者ローカル専用ツールなので、トークンファイル + Bearer の最小構成にし、TLS や CSRF トークンのローテーションは持たない

## テスト

- [x] `bun test tests/scripts/latency-probe.test.ts` 57 pass、`bun run typecheck`、`bun test` 全体 1017 pass
- [x] 実 run 中に `bun scripts/latency-probe.ts source --url ...` が従来どおり動くこと（下記コメントに結果）

Closes #205

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KjQWSGJDJsk6mmyehKPVK
